### PR TITLE
[FEAT] 정산 도메인 구현 (#14)

### DIFF
--- a/settlement/build.gradle
+++ b/settlement/build.gradle
@@ -1,40 +1,4 @@
-plugins {
-    id 'java'
-    id 'org.springframework.boot' version '4.0.1'
-    id 'io.spring.dependency-management' version '1.1.7'
-}
-
-group = 'com.back'
-version = '0.0.1-SNAPSHOT'
-description = 'settlement'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-h2console'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-    compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.h2database:h2'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation project(path: ':common')
 }

--- a/settlement/src/main/java/com/back/settlement/domain/Settlement.java
+++ b/settlement/src/main/java/com/back/settlement/domain/Settlement.java
@@ -1,0 +1,65 @@
+package com.back.settlement.domain;
+
+import com.back.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "settlement")
+public class Settlement extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(name = "seller_id")
+    private Long sellerId;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(nullable = false, length = 20)
+    private SettlementStatus status;
+
+    @Column(name = "settlement_expected_at")
+    private LocalDateTime expectedAt; // 정산 예정일
+
+    @NotNull
+    @Column(name = "settlement_start_at")
+    private LocalDateTime startAt; // 정산 시작일
+
+    @NotNull
+    @Column(name = "settlement_end_at")
+    private LocalDateTime endAt; // 정산 종료일
+
+    @Column(name = "settlement_completed_at")
+    private LocalDateTime completedAt; // 정산 완료일
+
+    @NotNull
+    @Column(name = "total_sales_amount", precision = 15, scale = 2)
+    private BigDecimal totalSalesAmount;
+
+    @NotNull
+    @Column(name = "total_fee_amount", precision = 15, scale = 2)
+    private BigDecimal totalFeeAmount;
+
+    @NotNull
+    @Column(name = "total_net_amount", precision = 15, scale = 2)
+    private BigDecimal totalNetAmount;
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementItem.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementItem.java
@@ -1,0 +1,74 @@
+package com.back.settlement.domain;
+
+import com.back.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "settlement_item")
+public class SettlementItem extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settlement_id")
+    @NotNull
+    private Settlement settlement;
+
+    @NotNull
+    @Column(name = "order_id")
+    private Long orderId;
+
+    @NotNull
+    @Column(name = "product_id")
+    private Long productId;
+
+    @NotNull
+    @Column(name = "buyer_id")
+    private Long buyerId;
+
+    @NotNull
+    @Column(name = "seller_id")
+    private Long sellerId;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private SettlementItemStatus status;
+
+    @NotNull
+    @Column(name = "sales_amount", precision = 15, scale = 2)
+    private BigDecimal salesAmount;
+
+    @NotNull
+    @Column(name = "fee_amount", precision = 15, scale = 2)
+    private BigDecimal feeAmount;
+
+    @NotNull
+    @Column(name = "net_amount", precision = 15, scale = 2)
+    private BigDecimal netAmount;
+
+    @NotNull
+    @Column(name = "transaction_at")
+    private LocalDateTime transactionAt; // 결제 시간
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementItemLog.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementItemLog.java
@@ -1,0 +1,48 @@
+package com.back.settlement.domain;
+
+import com.back.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "settlement_item_log")
+public class SettlementItemLog extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id")
+    @NotNull
+    private Long orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settlement_item_id")
+    @NotNull
+    private SettlementItem settlementItem;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "status", length = 20)
+    private SettlementItemStatus status;
+
+    @NotNull
+    @Column(name = "amount", precision = 15, scale = 2)
+    private BigDecimal amount;
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementItemStatus.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementItemStatus.java
@@ -1,0 +1,11 @@
+package com.back.settlement.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SettlementItemStatus {
+    INCLUDED,  // 포함됨: 정산에 포함된 정상 거래
+    CANCELED,  // 취소됨: 주문 취소로 정산 제외
+    REFUNDED,  // 환불됨: 환불 처리되어 정산 제외
+    NEGATIVE   // 마이너스: 환불로 인한 차감 항목
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementLog.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementLog.java
@@ -1,0 +1,43 @@
+package com.back.settlement.domain;
+
+import com.back.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "settlement_log")
+public class SettlementLog extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settlement_id")
+    @NotNull
+    private Settlement settlement;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_status", length = 20)
+    private SettlementStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "new_status", length = 20)
+    private SettlementStatus newStatus;
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementPolicy.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementPolicy.java
@@ -1,0 +1,8 @@
+package com.back.settlement.domain;
+
+import java.math.BigDecimal;
+
+public final class SettlementPolicy {
+
+    public static final BigDecimal FEE_RATE = new BigDecimal("0.03");
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementStatus.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementStatus.java
@@ -1,0 +1,12 @@
+package com.back.settlement.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SettlementStatus {
+    PENDING,      // 정산 대기: 정산 집계 전, 아직 처리 시작 안 함
+    IN_PROGRESS,  // 정산 진행 중: 정산 집계/계산 진행 중
+    HOLD,         // 보류: 관리자가 일시 중단 (문제 발생 등)
+    COMPLETED,    // 정산 완료: 정산 완료, 지급됨
+    FAILED        // 정산 실패: 정산 처리 실패
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #14 

## 🔎 작업 내용
- 정산(Settlement), 정산 아이템(SettlementItem) 엔티티 구현
- 정산 상태 관리를 위한 SettlementStatus, SettlementItemStatus enum 구현
- 정산 수수료 정책(SettlementPolicy) 구현
- 정산 상태 변경 로그(SettlementLog, SettlementItemLog) 엔티티 구현

<br>

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
