### PR TITLE
[FEAT] 회원 알림 설정 도메인 추가 (#19)

### DIFF
--- a/user/build.gradle
+++ b/user/build.gradle
@@ -25,6 +25,8 @@ repositories {
 }
 
 dependencies {
+    implementation project(path: ':common')
+
     implementation 'org.springframework.boot:spring-boot-h2console'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     compileOnly 'org.projectlombok:lombok'

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -25,8 +25,6 @@ repositories {
 }
 
 dependencies {
-    implementation project(path: ':common')
-
     implementation 'org.springframework.boot:spring-boot-h2console'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     compileOnly 'org.projectlombok:lombok'

--- a/user/src/main/java/com/back/user/adapter/out/UserNotificationSettingRepository.java
+++ b/user/src/main/java/com/back/user/adapter/out/UserNotificationSettingRepository.java
@@ -1,0 +1,7 @@
+package com.back.user.adapter.out;
+
+import com.back.user.domain.UserNotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserNotificationSettingRepository extends JpaRepository<UserNotificationSetting, Long> {
+}

--- a/user/src/main/java/com/back/user/domain/UserNotificationSetting.java
+++ b/user/src/main/java/com/back/user/domain/UserNotificationSetting.java
@@ -1,0 +1,34 @@
+package com.back.user.domain;
+
+import com.back.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "user_notification_setting")
+public class UserNotificationSetting extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder.Default
+    private boolean bdStatusEnabled = true;
+
+    @Builder.Default
+    private boolean productStatusEnabled = true;
+
+    @Builder.Default
+    private boolean priceEnabled = true;
+
+    @Builder.Default
+    private boolean settlementEnabled = true;
+
+}

--- a/user/src/main/java/com/back/user/domain/UserNotificationSetting.java
+++ b/user/src/main/java/com/back/user/domain/UserNotificationSetting.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Table(name = "user_notification_setting")
+@Table(name = "user_notification_settings")
 public class UserNotificationSetting extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #19 

## 🔎 작업 내용

- 회원 알림 설정 엔티티, 레포지터리 추가

<br>


## 📌 참고 사항

user 모듈 안의 build.gradle에 `implementation project(path: ':common')` 추가했습니다

<br>

## 📷 테스트 결과
- x

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
