### PR TITLE
[FEAT] Swagger (springdoc-openapi) 적용 및 공통 설정 (#41)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-h2console'
         implementation 'org.springframework.boot:spring-boot-starter-webmvc'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
         compileOnly 'org.projectlombok:lombok'
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         runtimeOnly 'com.h2database:h2'

--- a/common/src/main/java/com/back/common/config/SwaggerConfig.java
+++ b/common/src/main/java/com/back/common/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.back.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Resello 프로젝트 API")
+                .version("1.0.0")
+                .description("Resello 멀티모듈 프로젝트의 API 명세서입니다.");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #41 

## 🔎 작업 내용

- common 모듈의 config 디렉토리에 SwaggerConfig 구성
- 스웨거를 위한 springdoc-openapi 종속성 추가

<br>


## 📌 참고 사항

- 기타 안내 사항
    - 스웨거 접속 시, 아래와 같은 URL을 통해 접속
      - `{ip}:{port}/swagger-ui.html`

<br>

## 📷 테스트 결과
- 스웨거 메인 페이지
<img width="1258" height="438" alt="image" src="https://github.com/user-attachments/assets/3d8712ed-8113-45d6-8626-2548185dddb4" />

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
