### PR TITLE
[FEAT] 채팅 메시지 수신 처리 기능 구현 (#18)

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -4,5 +4,6 @@ dependencies {
     implementation project(":common")
     implementation project(":security")
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 }
 

--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -3,5 +3,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation project(":common")
     implementation project(":security")
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 

--- a/chat/src/main/java/com/back/chat/adapter/in/ChatMessagePublishListener.java
+++ b/chat/src/main/java/com/back/chat/adapter/in/ChatMessagePublishListener.java
@@ -1,0 +1,30 @@
+package com.back.chat.adapter.in;
+
+import com.back.chat.adapter.out.RedisChatMessagePublisher;
+import com.back.chat.event.ChatMessageSavedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessagePublishListener {
+
+    private final RedisChatMessagePublisher redisChatMessagePublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAfterCommit(ChatMessageSavedEvent event) {
+        try {
+            redisChatMessagePublisher.publish(event.roomId(), event.payload());
+        } catch (Exception e) {
+            log.error("Redis publish failed after commit. roomId={}, messageId={}",
+                    event.roomId(),
+                    event.payload().messageId(),
+                    e
+            );
+        }
+    }
+}

--- a/chat/src/main/java/com/back/chat/adapter/in/ChatWsController.java
+++ b/chat/src/main/java/com/back/chat/adapter/in/ChatWsController.java
@@ -2,8 +2,6 @@ package com.back.chat.adapter.in;
 
 import com.back.chat.app.ChatFacade;
 import com.back.chat.dto.request.ChatMessageSendRequestDto;
-import com.back.chat.dto.response.ChatMessageSendResponseDto;
-import com.back.common.response.CommonResponse;
 import com.back.security.principal.AuthPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/chat/src/main/java/com/back/chat/adapter/in/ChatWsController.java
+++ b/chat/src/main/java/com/back/chat/adapter/in/ChatWsController.java
@@ -1,0 +1,40 @@
+package com.back.chat.adapter.in;
+
+import com.back.chat.app.ChatFacade;
+import com.back.chat.dto.request.ChatMessageSendRequestDto;
+import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.back.common.response.CommonResponse;
+import com.back.security.principal.AuthPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chat-ws")
+@RequiredArgsConstructor
+public class ChatWsController {
+
+    private final ChatFacade chatFacade;
+
+    private static final String ATTR_PRINCIPAL = "AUTH_PRINCIPAL";
+
+    @MessageMapping("/message")
+    public void sendMessage(
+            @Payload ChatMessageSendRequestDto requestDto,
+            SimpMessageHeaderAccessor headerAccessor
+    ) {
+        Object principalObj = headerAccessor.getSessionAttributes().get(ATTR_PRINCIPAL);
+
+        if (!(principalObj instanceof AuthPrincipal)) {
+            throw new IllegalStateException("WebSocket 인증 정보(AuthPrincipal)가 없습니다.");
+        }
+
+        AuthPrincipal authPrincipal = (AuthPrincipal) principalObj;
+        Long userId = authPrincipal.getUserId();
+
+        chatFacade.sendMessage(requestDto, userId);
+    }
+}

--- a/chat/src/main/java/com/back/chat/adapter/in/ChatWsController.java
+++ b/chat/src/main/java/com/back/chat/adapter/in/ChatWsController.java
@@ -5,6 +5,7 @@ import com.back.chat.dto.request.ChatMessageSendRequestDto;
 import com.back.chat.dto.response.ChatMessageSendResponseDto;
 import com.back.common.response.CommonResponse;
 import com.back.security.principal.AuthPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -23,7 +24,7 @@ public class ChatWsController {
 
     @MessageMapping("/message")
     public void sendMessage(
-            @Payload ChatMessageSendRequestDto requestDto,
+            @Valid @Payload ChatMessageSendRequestDto requestDto,
             SimpMessageHeaderAccessor headerAccessor
     ) {
         Object principalObj = headerAccessor.getSessionAttributes().get(ATTR_PRINCIPAL);

--- a/chat/src/main/java/com/back/chat/adapter/out/RedisChatMessagePublisher.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/RedisChatMessagePublisher.java
@@ -1,6 +1,6 @@
 package com.back.chat.adapter.out;
 
-import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.back.chat.event.payload.ChatMessagePayload;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ public class RedisChatMessagePublisher {
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
 
-    public void publish(Long roomId, ChatMessageSendResponseDto payload) {
+    public void publish(Long roomId, ChatMessagePayload payload) {
         String channel = CHANNEL_PREFIX + roomId;
 
         try {

--- a/chat/src/main/java/com/back/chat/adapter/out/RedisChatMessagePublisher.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/RedisChatMessagePublisher.java
@@ -1,0 +1,29 @@
+package com.back.chat.adapter.out;
+
+import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisChatMessagePublisher {
+
+    private static final String CHANNEL_PREFIX = "chatroom:";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void publish(Long roomId, ChatMessageSendResponseDto payload) {
+        String channel = CHANNEL_PREFIX + roomId;
+
+        try {
+            String message = objectMapper.writeValueAsString(payload);
+            stringRedisTemplate.convertAndSend(channel, message);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Redis 채팅 메시지 발행 실패", e);
+        }
+    }
+}

--- a/chat/src/main/java/com/back/chat/app/ChatFacade.java
+++ b/chat/src/main/java/com/back/chat/app/ChatFacade.java
@@ -1,6 +1,7 @@
 package com.back.chat.app;
 
 
+import com.back.chat.dto.request.ChatMessageSendRequestDto;
 import com.back.chat.dto.response.ChatRoomEnterResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,12 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatFacade {
 
     private final ChatEnterChatRoomUseCase chatEnterChatRoomUseCase;
+    private final ChatSendMessageUseCase chatSendMessageUseCase;
 
     @Transactional
     public ChatRoomEnterResponseDto enterChatRoom(Long brandId){
         return chatEnterChatRoomUseCase.enterChatRoom(brandId);
     }
 
-
-
+    @Transactional
+    public void sendMessage(ChatMessageSendRequestDto requestDto, Long userId) {
+        chatSendMessageUseCase.sendMessage(requestDto, userId);
+    }
 }

--- a/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
@@ -1,0 +1,48 @@
+package com.back.chat.app;
+
+import com.back.chat.domain.ChatMessage;
+import com.back.chat.domain.ChatRoom;
+import com.back.chat.dto.request.ChatMessageSendRequestDto;
+import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatSendMessageUseCase {
+
+    private final ChatSupport chatSupport;
+
+    // Redis pub/sub 발행.
+    // private final ChatMessagePublisher chatMessagePublisher;
+
+    @Transactional
+    public void sendMessage(ChatMessageSendRequestDto requestDto, Long userId) {
+
+        ChatRoom chatRoom = chatSupport.findRoomById(requestDto.roomId())
+                .orElseThrow(() -> new BadRequestException(FailureCode.CHAT_ROOM_NOT_FOUND));
+
+        // (User 모듈 ApiClient 필요)
+        // 사용자 메시지 전송 제한 여부 검증
+
+        ChatMessage savedMessage = chatSupport.saveMessage(
+                ChatMessage.create(chatRoom,userId,requestDto.content())
+        );
+
+        ChatMessageSendResponseDto payload = new ChatMessageSendResponseDto(
+                savedMessage.getId(),
+                chatRoom.getId(),
+                userId,
+                savedMessage.getContent(),
+                savedMessage.isBlinded(),
+                savedMessage.getCreatedAt()
+        );
+
+        // 모든 인스턴스에 메시지 전파
+        // chatMessagePublisher.publish(room.getId(), payload);
+    }
+
+}

--- a/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
@@ -2,7 +2,7 @@ package com.back.chat.app;
 
 import com.back.chat.domain.ChatMessage;
 import com.back.chat.dto.request.ChatMessageSendRequestDto;
-import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.back.chat.event.payload.ChatMessagePayload;
 import com.back.chat.event.ChatMessageSavedEvent;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
@@ -33,7 +33,7 @@ public class ChatSendMessageUseCase {
                 ChatMessage.create(roomId,userId,requestDto.content())
         );
 
-        ChatMessageSendResponseDto payload = new ChatMessageSendResponseDto(
+        ChatMessagePayload payload = new ChatMessagePayload(
                 savedMessage.getId(),
                 roomId,
                 userId,

--- a/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
@@ -1,5 +1,6 @@
 package com.back.chat.app;
 
+import com.back.chat.adapter.out.RedisChatMessagePublisher;
 import com.back.chat.domain.ChatMessage;
 import com.back.chat.domain.ChatRoom;
 import com.back.chat.dto.request.ChatMessageSendRequestDto;
@@ -15,9 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatSendMessageUseCase {
 
     private final ChatSupport chatSupport;
-
-    // Redis pub/sub 발행.
-    // private final ChatMessagePublisher chatMessagePublisher;
+    private final RedisChatMessagePublisher redisChatMessagePublisher;
 
     @Transactional
     public void sendMessage(ChatMessageSendRequestDto requestDto, Long userId) {
@@ -42,7 +41,7 @@ public class ChatSendMessageUseCase {
         );
 
         // 모든 인스턴스에 메시지 전파
-        // chatMessagePublisher.publish(room.getId(), payload);
+        redisChatMessagePublisher.publish(chatRoom.getId(), payload);
     }
 
 }

--- a/chat/src/main/java/com/back/chat/app/ChatSupport.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSupport.java
@@ -21,9 +21,7 @@ public class ChatSupport {
         return chatRoomRepository.findByBrandId(brandId);
     }
 
-    public Optional<ChatRoom> findRoomById(Long roomId) {
-        return chatRoomRepository.findById(roomId);
-    }
+    public boolean existsRoomById(Long roomId) { return chatRoomRepository.existsById(roomId); }
 
     public ChatMessage saveMessage(ChatMessage chatMessage) {
         return chatMessageRepository.save(chatMessage);

--- a/chat/src/main/java/com/back/chat/app/ChatSupport.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSupport.java
@@ -3,6 +3,7 @@ package com.back.chat.app;
 import com.back.chat.adapter.out.ChatMessageRepository;
 import com.back.chat.adapter.out.ChatReportRepository;
 import com.back.chat.adapter.out.ChatRoomRepository;
+import com.back.chat.domain.ChatMessage;
 import com.back.chat.domain.ChatRoom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,14 @@ public class ChatSupport {
 
     public Optional<ChatRoom> findRoomByBrandId(Long brandId){
         return chatRoomRepository.findByBrandId(brandId);
+    }
+
+    public Optional<ChatRoom> findRoomById(Long roomId) {
+        return chatRoomRepository.findById(roomId);
+    }
+
+    public ChatMessage saveMessage(ChatMessage chatMessage) {
+        return chatMessageRepository.save(chatMessage);
     }
 
 

--- a/chat/src/main/java/com/back/chat/config/JacksonConfig.java
+++ b/chat/src/main/java/com/back/chat/config/JacksonConfig.java
@@ -1,6 +1,8 @@
 package com.back.chat.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,6 +11,10 @@ public class JacksonConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        // ISO-8601 문자열로 나가게 (timestamp 배열 방지)
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return om;
     }
 }

--- a/chat/src/main/java/com/back/chat/config/JacksonConfig.java
+++ b/chat/src/main/java/com/back/chat/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.back.chat.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/chat/src/main/java/com/back/chat/domain/ChatMessage.java
+++ b/chat/src/main/java/com/back/chat/domain/ChatMessage.java
@@ -16,9 +16,8 @@ public class ChatMessage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id", nullable = false)
-    private ChatRoom chatRoom;
+    @Column(name = "room_id", nullable = false, unique = true)
+    private Long roomId;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -30,22 +29,22 @@ public class ChatMessage extends BaseTimeEntity {
     private boolean isBlinded = false;
 
     private ChatMessage(
-            ChatRoom chatRoom,
+            Long roomId,
             Long userId,
             String content
     ) {
-        this.chatRoom = chatRoom;
+        this.roomId = roomId;
         this.userId = userId;
         this.content = content;
         this.isBlinded = false;
     }
 
     public static ChatMessage create(
-            ChatRoom chatRoom,
+            Long roomId,
             Long userId,
             String content
     ) {
-        return new ChatMessage(chatRoom, userId, content);
+        return new ChatMessage(roomId, userId, content);
     }
 
 }

--- a/chat/src/main/java/com/back/chat/domain/ChatMessage.java
+++ b/chat/src/main/java/com/back/chat/domain/ChatMessage.java
@@ -2,10 +2,14 @@ package com.back.chat.domain;
 
 import com.back.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage extends BaseTimeEntity {
 
     @Id
@@ -19,10 +23,29 @@ public class ChatMessage extends BaseTimeEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "content", nullable = false, length = 500)
+    @Column(name = "content", nullable = false, length = 1000)
     private String content;
 
     @Column(name = "is_blinded", nullable = false)
     private boolean isBlinded = false;
+
+    private ChatMessage(
+            ChatRoom chatRoom,
+            Long userId,
+            String content
+    ) {
+        this.chatRoom = chatRoom;
+        this.userId = userId;
+        this.content = content;
+        this.isBlinded = false;
+    }
+
+    public static ChatMessage create(
+            ChatRoom chatRoom,
+            Long userId,
+            String content
+    ) {
+        return new ChatMessage(chatRoom, userId, content);
+    }
 
 }

--- a/chat/src/main/java/com/back/chat/dto/request/ChatMessageSendRequestDto.java
+++ b/chat/src/main/java/com/back/chat/dto/request/ChatMessageSendRequestDto.java
@@ -1,7 +1,17 @@
 package com.back.chat.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
 public record ChatMessageSendRequestDto (
+        @NotNull
+        @Positive
         Long roomId,
+
+        @NotBlank
+        @Size(max = 1000)
         String content
 ){
 }

--- a/chat/src/main/java/com/back/chat/dto/request/ChatMessageSendRequestDto.java
+++ b/chat/src/main/java/com/back/chat/dto/request/ChatMessageSendRequestDto.java
@@ -1,0 +1,7 @@
+package com.back.chat.dto.request;
+
+public record ChatMessageSendRequestDto (
+        Long roomId,
+        String content
+){
+}

--- a/chat/src/main/java/com/back/chat/dto/response/ChatMessageSendResponseDto.java
+++ b/chat/src/main/java/com/back/chat/dto/response/ChatMessageSendResponseDto.java
@@ -1,0 +1,13 @@
+package com.back.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageSendResponseDto (
+        Long messageId,
+        Long userId,
+        Long roomId,
+        String content,
+        boolean isBlinded,
+        LocalDateTime createdAt
+){
+}

--- a/chat/src/main/java/com/back/chat/event/ChatMessageSavedEvent.java
+++ b/chat/src/main/java/com/back/chat/event/ChatMessageSavedEvent.java
@@ -1,0 +1,9 @@
+package com.back.chat.event;
+
+
+import com.back.chat.dto.response.ChatMessageSendResponseDto;
+
+public record ChatMessageSavedEvent(
+        Long roomId,
+        ChatMessageSendResponseDto payload
+) {}

--- a/chat/src/main/java/com/back/chat/event/ChatMessageSavedEvent.java
+++ b/chat/src/main/java/com/back/chat/event/ChatMessageSavedEvent.java
@@ -1,9 +1,9 @@
 package com.back.chat.event;
 
 
-import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.back.chat.event.payload.ChatMessagePayload;
 
 public record ChatMessageSavedEvent(
         Long roomId,
-        ChatMessageSendResponseDto payload
+        ChatMessagePayload payload
 ) {}

--- a/chat/src/main/java/com/back/chat/event/payload/ChatMessagePayload.java
+++ b/chat/src/main/java/com/back/chat/event/payload/ChatMessagePayload.java
@@ -1,8 +1,8 @@
-package com.back.chat.dto.response;
+package com.back.chat.event.payload;
 
 import java.time.LocalDateTime;
 
-public record ChatMessageSendResponseDto (
+public record ChatMessagePayload(
         Long messageId,
         Long userId,
         Long roomId,

--- a/chat/src/test/java/com/back/chat/ChatWsControllerTest.java
+++ b/chat/src/test/java/com/back/chat/ChatWsControllerTest.java
@@ -1,0 +1,34 @@
+package com.back.chat;
+
+import com.back.chat.adapter.in.ChatWsController;
+import com.back.chat.app.ChatFacade;
+import com.back.chat.dto.request.ChatMessageSendRequestDto;
+import com.back.security.principal.AuthPrincipal;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+class ChatWsControllerTest {
+
+    @Test
+    void sendMessage_shouldCallFacade_withUserIdFromSession() {
+        ChatFacade chatFacade = mock(ChatFacade.class);
+        ChatWsController controller = new ChatWsController(chatFacade);
+
+        ChatMessageSendRequestDto dto = new ChatMessageSendRequestDto(1L, "hello"); // record면 이렇게
+        // class DTO면 new로 맞게 생성/세팅
+
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("AUTH_PRINCIPAL", new AuthPrincipal(10L, "USER"));
+        accessor.setSessionAttributes(attrs);
+
+        controller.sendMessage(dto, accessor);
+
+        verify(chatFacade, times(1)).sendMessage(dto, 10L);
+    }
+}

--- a/chat/src/test/java/com/back/chat/RedisPublishIntegrationTest.java
+++ b/chat/src/test/java/com/back/chat/RedisPublishIntegrationTest.java
@@ -1,0 +1,69 @@
+package com.back.chat;
+
+import com.back.chat.adapter.out.RedisChatMessagePublisher;
+import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RedisPublishIntegrationTest {
+
+    @Autowired
+    private RedisChatMessagePublisher redisChatMessagePublisher;
+
+    @Autowired
+    private RedisMessageListenerContainer redisMessageListenerContainer;
+
+    @Test
+    void redis_publish_should_send_message_to_channel() throws Exception {
+        // given
+        Long roomId = 1L;
+        String channel = "chatroom:" + roomId;
+
+        ChatMessageSendResponseDto payload = new ChatMessageSendResponseDto(
+                100L,
+                roomId,
+                1L,
+                "redis publish test",
+                false,
+                LocalDateTime.now()
+        );
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> receivedMessage = new AtomicReference<>();
+
+        MessageListener listener = new MessageListener() {
+            @Override
+            public void onMessage(Message message, byte[] pattern) {
+                receivedMessage.set(new String(message.getBody()));
+                latch.countDown();
+            }
+        };
+
+        redisMessageListenerContainer.addMessageListener(listener, new ChannelTopic(channel));
+
+        // when
+        redisChatMessagePublisher.publish(roomId, payload);
+
+        // then
+        boolean messageReceived = latch.await(2, TimeUnit.SECONDS);
+
+        assertThat(messageReceived).isTrue();
+        assertThat(receivedMessage.get()).contains("redis publish test");
+
+        // cleanup
+        redisMessageListenerContainer.removeMessageListener(listener);
+    }
+}

--- a/chat/src/test/java/com/back/chat/RedisPublishIntegrationTest.java
+++ b/chat/src/test/java/com/back/chat/RedisPublishIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.back.chat;
 
 import com.back.chat.adapter.out.RedisChatMessagePublisher;
-import com.back.chat.dto.response.ChatMessageSendResponseDto;
+import com.back.chat.event.payload.ChatMessagePayload;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,7 +32,7 @@ class RedisPublishIntegrationTest {
         Long roomId = 1L;
         String channel = "chatroom:" + roomId;
 
-        ChatMessageSendResponseDto payload = new ChatMessageSendResponseDto(
+        ChatMessagePayload payload = new ChatMessagePayload(
                 100L,
                 roomId,
                 1L,

--- a/chat/src/test/java/com/back/chat/RedisTestConfig.java
+++ b/chat/src/test/java/com/back/chat/RedisTestConfig.java
@@ -1,0 +1,20 @@
+package com.back.chat;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisTestConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+}
+


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #18 

## 🔎 작업 내용

- 채팅 메시지 수신 처리 기능 구현





## 📷 테스트 결과
- 웹소켓 세션 인증 테스트 
  <br>
  <img width="408" height="164" alt="image" src="https://github.com/user-attachments/assets/b4ac10eb-89ce-402e-92bf-e1a76e6b0af8" />
- 레디스 발행 테스트

  <img width="403" height="158" alt="image" src="https://github.com/user-attachments/assets/97e80ab0-7d45-405b-a23f-63aaef8a078d" />


<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
