### PR TITLE
[FEAT] 즉시 구매/판매 기능 구현 #39

### DIFF
--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -21,6 +21,7 @@ public enum FailureCode {
     // Market 모듈에서 사용
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "PRODUCT_NOT_FOUND","존재하지 않는 상품입니다."),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND","존재하지 않는 사용자입니다."),
+    BIDDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "BIDDING_NOT_FOUND","존재하지 않는 입찰입니다."),
     INVALID_PRICE_UNIT(HttpStatus.BAD_REQUEST, "INVALID_PRICE_UNIT","입찰 가격은 1,000원 단위여야 합니다."),
     INVALID_BID_PRICE_BUY(HttpStatus.BAD_REQUEST, "INVALID_BID_PRICE_BUY","구매 입찰가는 즉시 구매가보다 낮아야 합니다."),
     INVALID_BID_PRICE_SELL(HttpStatus.BAD_REQUEST, "INVALID_BID_PRICE_SELL","판매 입찰가는 즉시 판매가보다 높아야 합니다."),

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -4,6 +4,7 @@ import com.back.common.response.CommonResponse;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,29 +14,35 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Market API", description = "상품 구매 및 주문 관련 API")
 public interface ApiV1Market {
+    @Operation(summary = "구매 입찰 등록", description = "구매자가 원하는 가격으로 새로운 구매 입찰을 등록한다.")
     @PostMapping("/bids/buy")
     CommonResponse<Long> registerBuyBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
+    @Operation(summary = "판매 입찰 등록", description = "판매자가 원하는 가격으로 새로운 판매 입찰을 등록한다.")
     @PostMapping("/bids/sell")
     CommonResponse<Long> registerSellBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
+    @Operation(summary = "즉시 구매가 조회", description = "특정 상품에 대해 즉시 구매 가능한(판매 입찰 중 가장 낮은) 가격을 조회한다.")
     @GetMapping("/products/{productId}/buy-now-price")
     CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(@PathVariable Long productId);
 
+    @Operation(summary = "즉시 판매가 조회", description = "특정 상품에 대해 즉시 판매 가능한(구매 입찰 중 가장 높은) 가격을 조회한다.")
     @GetMapping("/products/{productId}/sell-now-price")
     CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(@PathVariable Long productId);
 
+    @Operation(summary = "즉시 구매 실행", description = "판매 대기 중인 최저가 매물과 매칭하여 즉시 주문을 생성하고 결제를 진행한다.")
     @PostMapping("/buy-now")
     CommonResponse<Long> buyNow(
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
+    @Operation(summary = "즉시 판매 실행", description = "구매 대기 중인 최고가 입찰과 매칭하여 즉시 주문을 생성하고 결제를 진행한다.")
     @PostMapping("/sell-now")
     CommonResponse<Long> sellNow(
             // @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -4,29 +4,39 @@ import com.back.common.response.CommonResponse;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "Market API", description = "상품 구매 및 주문 관련 API")
 public interface ApiV1Market {
+    @PostMapping("/bids/buy")
     CommonResponse<Long> registerBuyBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
+    @PostMapping("/bids/sell")
     CommonResponse<Long> registerSellBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
+    @GetMapping("/products/{productId}/buy-now-price")
     CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(@PathVariable Long productId);
 
+    @GetMapping("/products/{productId}/sell-now-price")
     CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(@PathVariable Long productId);
 
+    @PostMapping("/buy-now")
     CommonResponse<Long> buyNow(
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
+    @PostMapping("/sell-now")
     CommonResponse<Long> sellNow(
             // @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid BiddingRequestDto requestDto);

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -1,0 +1,34 @@
+package com.back.market.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.dto.response.InstantBuyPriceResponseDto;
+import com.back.market.dto.response.InstantSellPriceResponseDto;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface ApiV1Market {
+    CommonResponse<Long> registerBuyBid(
+            // TODO: 인증 로직 구현 완료시 수정 필요
+            // @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid BiddingRequestDto requestDto);
+
+    CommonResponse<Long> registerSellBid(
+            // TODO: 인증 로직 구현 완료시 수정 필요
+            // @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid BiddingRequestDto requestDto);
+
+    CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(@PathVariable Long productId);
+
+    CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(@PathVariable Long productId);
+
+    CommonResponse<Long> buyNow(
+            // @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid BiddingRequestDto requestDto);
+
+    CommonResponse<Long> sellNow(
+            // @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid BiddingRequestDto requestDto);
+
+}

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -3,13 +3,12 @@ package com.back.market.adapter.in;
 import com.back.common.response.CommonResponse;
 import com.back.market.app.MarketFacade;
 import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.dto.response.InstantBuyPriceResponseDto;
+import com.back.market.dto.response.InstantSellPriceResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -48,6 +47,18 @@ public class ApiV1MarketController {
         Long biddingId = marketFacade.registerSellBid(userId, requestDto);
 
         return CommonResponse.successWithData(HttpStatus.CREATED, biddingId);
+    }
+
+    @GetMapping("/product/{productId}/buy-now-price")
+    public CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(@PathVariable Long productId) {
+        InstantBuyPriceResponseDto response = marketFacade.getBuyNowPrice(productId);
+        return CommonResponse.successWithData(HttpStatus.OK, response);
+    }
+
+    @GetMapping("/product/{productId}/sell-now-price")
+    public CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(@PathVariable Long productId) {
+        InstantSellPriceResponseDto response = marketFacade.getSellNowPrice(productId);
+        return CommonResponse.successWithData(HttpStatus.OK, response);
     }
 
 }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -5,7 +5,6 @@ import com.back.market.app.MarketFacade;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +17,6 @@ public class ApiV1MarketController implements ApiV1Market{
     private final MarketFacade marketFacade;
 
     @Override
-    @PostMapping("/bids/buy")
     public CommonResponse<Long> registerBuyBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
             // CustomUserDetails userDetails,
@@ -35,7 +33,6 @@ public class ApiV1MarketController implements ApiV1Market{
     }
 
     @Override
-    @PostMapping("/bids/sell")
     public CommonResponse<Long> registerSellBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
             // CustomUserDetails userDetails,
@@ -52,21 +49,18 @@ public class ApiV1MarketController implements ApiV1Market{
     }
 
     @Override
-    @GetMapping("/products/{productId}/buy-now-price")
     public CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(Long productId) {
         InstantBuyPriceResponseDto response = marketFacade.getBuyNowPrice(productId);
         return CommonResponse.successWithData(HttpStatus.OK, response);
     }
 
     @Override
-    @GetMapping("/products/{productId}/sell-now-price")
     public CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(Long productId) {
         InstantSellPriceResponseDto response = marketFacade.getSellNowPrice(productId);
         return CommonResponse.successWithData(HttpStatus.OK, response);
     }
 
     @Override
-    @PostMapping("/buy-now")
     public CommonResponse<Long> buyNow(BiddingRequestDto requestDto) {
         Long userId = 1L; //TODO: 인증 적용 시 수정
         Long orderId = marketFacade.purchaseNow(userId, requestDto);
@@ -74,11 +68,10 @@ public class ApiV1MarketController implements ApiV1Market{
     }
 
     @Override
-    @PostMapping("/sell-now")
     public CommonResponse<Long> sellNow(BiddingRequestDto requestDto) {
         Long userId = 2L; //TODO: 인증 적용 시 수정
         Long orderId = marketFacade.sellNow(userId, requestDto);
         return CommonResponse.successWithData(HttpStatus.CREATED, orderId);
     }
-    
+
 }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -13,15 +13,16 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/market")
-public class ApiV1MarketController {
+public class ApiV1MarketController implements ApiV1Market{
 
     private final MarketFacade marketFacade;
 
+    @Override
     @PostMapping("/bids/buy")
     public CommonResponse<Long> registerBuyBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
-            // @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid BiddingRequestDto requestDto
+            // CustomUserDetails userDetails,
+            BiddingRequestDto requestDto
     ) {
         // TODO: 인증 적용 시 하드코딩해둔 값 삭제 필요
         // Long userId = userDetails.getId();
@@ -33,11 +34,12 @@ public class ApiV1MarketController {
         return CommonResponse.successWithData(HttpStatus.CREATED, biddingId);
     }
 
+    @Override
     @PostMapping("/bids/sell")
     public CommonResponse<Long> registerSellBid(
             // TODO: 인증 로직 구현 완료시 수정 필요
-            // @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid BiddingRequestDto requestDto
+            // CustomUserDetails userDetails,
+            BiddingRequestDto requestDto
     ) {
         // TODO: 인증 적용 시 하드코딩해둔 값 삭제 필요
         // Long userId = userDetails.getId();
@@ -49,16 +51,34 @@ public class ApiV1MarketController {
         return CommonResponse.successWithData(HttpStatus.CREATED, biddingId);
     }
 
-    @GetMapping("/product/{productId}/buy-now-price")
-    public CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(@PathVariable Long productId) {
+    @Override
+    @GetMapping("/products/{productId}/buy-now-price")
+    public CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(Long productId) {
         InstantBuyPriceResponseDto response = marketFacade.getBuyNowPrice(productId);
         return CommonResponse.successWithData(HttpStatus.OK, response);
     }
 
-    @GetMapping("/product/{productId}/sell-now-price")
-    public CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(@PathVariable Long productId) {
+    @Override
+    @GetMapping("/products/{productId}/sell-now-price")
+    public CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(Long productId) {
         InstantSellPriceResponseDto response = marketFacade.getSellNowPrice(productId);
         return CommonResponse.successWithData(HttpStatus.OK, response);
     }
 
+    @Override
+    @PostMapping("/buy-now")
+    public CommonResponse<Long> buyNow(BiddingRequestDto requestDto) {
+        Long userId = 1L; //TODO: 인증 적용 시 수정
+        Long orderId = marketFacade.purchaseNow(userId, requestDto);
+        return CommonResponse.successWithData(HttpStatus.CREATED, orderId);
+    }
+
+    @Override
+    @PostMapping("/sell-now")
+    public CommonResponse<Long> sellNow(BiddingRequestDto requestDto) {
+        Long userId = 2L; //TODO: 인증 적용 시 수정
+        Long orderId = marketFacade.sellNow(userId, requestDto);
+        return CommonResponse.successWithData(HttpStatus.CREATED, orderId);
+    }
+    
 }

--- a/market/src/main/java/com/back/market/adapter/out/BiddingRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/BiddingRepository.java
@@ -9,7 +9,30 @@ import java.util.Optional;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
-    Optional<Bidding> findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(Long productId, BiddingPosition sell, BiddingStatus process);
+    /**
+     * 즉시 구매가 조회(최저가 판매 입찰 조회)
+     * <p>
+     * 특정 상품에 대해 '판매(SELL)' 포지션으로 등록된 입찰 중,
+     * 가장 낮은 가격(오름차순, ASC)의 입찰 건을 1개 조회한다.
+     * </p>
+     * @param productId 조회할 상품의 ID
+     * @param biddingPosition 입찰 포지션 (반드시 BiddingPosition.SELL 이어야 함)
+     * @param biddingStatus 입찰 상태 (반드시 BiddingStatus.PROCESS 이어야 함)
+     * @return 특정 상품의 즉시 구매가
+     */
+    Optional<Bidding> findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(Long productId, BiddingPosition biddingPosition, BiddingStatus biddingStatus);
 
+    /**
+     * 즉시 판매가 조회(최고가 구매 입찰 조회)
+     * <p>
+     * 특정 상품에 대해 '구매(BUY)' 포지션으로 등록된 입찰 중,
+     * 가장 높은 가격(내림차순, DESC)의 입찰 건을 1개 조회한다.
+     * </p>
+     *
+     * @param productId 조회할 상품의 ID
+     * @param biddingPosition 입찰 포지션 (반드시 BiddingPosition.BUY 이어야 함)
+     * @param biddingStatus 입찰 상태 (반드시 BiddingStatus.PROCESS 이어야 함)
+     * @return 특정 상품의 즉시 판매가
+     */
     Optional<Bidding> findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(Long productId, BiddingPosition biddingPosition, BiddingStatus biddingStatus);
 }

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.back.market.adapter.out;
+
+import com.back.market.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/market/src/main/java/com/back/market/adapter/out/client/FakeCashClient.java
+++ b/market/src/main/java/com/back/market/adapter/out/client/FakeCashClient.java
@@ -9,7 +9,6 @@ import com.back.market.dto.response.CashHoldResponseDto;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
-import java.util.Random;
 
 @Component
 public class FakeCashClient implements CashClient {
@@ -30,10 +29,7 @@ public class FakeCashClient implements CashClient {
                     .build();
         }
 
-        CashHoldResponseDto fakeData = CashHoldResponseDto.builder()
-                .userId(userId)
-                .holdAmount(amount)
-                .build();
+        CashHoldResponseDto fakeData = new CashHoldResponseDto(userId, amount);
 
         System.out.println("[FakeCashClient] User " + userId + "의 " + amount + "원 홀딩 성공 (Ref: " + requestDto.relType() + " / " + requestDto.relId() + ")");
 

--- a/market/src/main/java/com/back/market/adapter/out/client/FakeCashClient.java
+++ b/market/src/main/java/com/back/market/adapter/out/client/FakeCashClient.java
@@ -29,7 +29,7 @@ public class FakeCashClient implements CashClient {
                     .build();
         }
 
-        CashHoldResponseDto fakeData = new CashHoldResponseDto(userId, amount);
+        CashHoldResponseDto fakeData = CashHoldResponseDto.of(userId, amount);
 
         System.out.println("[FakeCashClient] User " + userId + "의 " + amount + "원 홀딩 성공 (Ref: " + requestDto.relType() + " / " + requestDto.relId() + ")");
 

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -1,7 +1,10 @@
 package com.back.market.app;
 
+import com.back.market.app.usecase.GetInstantPriceUseCase;
 import com.back.market.app.usecase.RegisterBidUseCase;
 import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.dto.response.InstantBuyPriceResponseDto;
+import com.back.market.dto.response.InstantSellPriceResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MarketFacade {
     private final RegisterBidUseCase registerBidUseCase;
+    private final GetInstantPriceUseCase getInstantPriceUseCase;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -32,4 +36,25 @@ public class MarketFacade {
     public Long registerSellBid(Long userId, BiddingRequestDto requestDto) {
         return registerBidUseCase.registerSellBid(userId, requestDto);
     }
+
+    /**
+     * 즉시 구매가 조회
+     * @param productId 조회할 상품 ID
+     * @return InstantBuyPriceResponseDto
+     */
+    @Transactional(readOnly = true)
+    public InstantBuyPriceResponseDto getBuyNowPrice(Long productId) {
+        return getInstantPriceUseCase.getBuyNowPrice(productId);
+    }
+
+    /**
+     * 즉시 판매가 조회
+     * @param productId 조회할 상품 ID
+     * @return InstantSellPriceResponseDto
+     */
+    @Transactional(readOnly = true)
+    public InstantSellPriceResponseDto getSellNowPrice(Long productId) {
+        return getInstantPriceUseCase.getSellNowPrice(productId);
+    }
+
 }

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -1,6 +1,7 @@
 package com.back.market.app;
 
 import com.back.market.app.usecase.GetInstantPriceUseCase;
+import com.back.market.app.usecase.MatchInstantTradeUseCase;
 import com.back.market.app.usecase.RegisterBidUseCase;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MarketFacade {
     private final RegisterBidUseCase registerBidUseCase;
     private final GetInstantPriceUseCase getInstantPriceUseCase;
+    private final MatchInstantTradeUseCase matchInstantTradeUseCase;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -38,7 +40,7 @@ public class MarketFacade {
     }
 
     /**
-     * 즉시 구매가 조회
+     * MARKET-004: 즉시 구매가 조회
      * @param productId 조회할 상품 ID
      * @return InstantBuyPriceResponseDto
      */
@@ -48,13 +50,33 @@ public class MarketFacade {
     }
 
     /**
-     * 즉시 판매가 조회
+     * MARKET-005: 즉시 판매가 조회
      * @param productId 조회할 상품 ID
      * @return InstantSellPriceResponseDto
      */
     @Transactional(readOnly = true)
     public InstantSellPriceResponseDto getSellNowPrice(Long productId) {
         return getInstantPriceUseCase.getSellNowPrice(productId);
+    }
+
+    /**
+     * MARKET-009: 즉시 구매
+     * @param buyerId 구매자 ID
+     * @param requestDto BiddingRequestDto
+     * @return 생성된 주문(Order)의 ID
+     */
+    public Long purchaseNow(Long buyerId, BiddingRequestDto requestDto) {
+        return matchInstantTradeUseCase.buyNow(buyerId, requestDto);
+    }
+
+    /**
+     * MARKET-011: 즉시 판매
+     * @param sellerId 판매자 ID
+     * @param requestDto BiddingRequestDto
+     * @return 생성된 주문(Order)의 ID
+     */
+    public Long sellNow(Long sellerId, BiddingRequestDto requestDto) {
+        return matchInstantTradeUseCase.sellNow(sellerId, requestDto);
     }
 
 }

--- a/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
@@ -1,0 +1,56 @@
+package com.back.market.app.usecase;
+
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.dto.response.InstantBuyPriceResponseDto;
+import com.back.market.dto.response.InstantSellPriceResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+/**
+ * 즉시구매가, 즉시판매가 조회
+ */
+@Service
+@RequiredArgsConstructor
+public class GetInstantPriceUseCase {
+
+    private final BiddingRepository biddingRepository;
+
+    /**
+     * 즉시 구매가 조회
+     * @param productId 조회할 상품 ID
+     * @return InstantBuyPriceResponseDto
+     */
+    @Transactional(readOnly = true)
+    public InstantBuyPriceResponseDto getBuyNowPrice(Long productId) {
+        BigDecimal price = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(
+                productId,
+                BiddingPosition.SELL,
+                BiddingStatus.PROCESS
+        ).map(Bidding::getPrice).orElse(null);
+
+        return InstantBuyPriceResponseDto.of(productId, price);
+    }
+
+    /**
+     * 즉시 판매가 조회
+     * @param productId 조회할 상품 ID
+     * @return InstantSellPriceResponseDto
+     */
+    @Transactional(readOnly = true)
+    public InstantSellPriceResponseDto getSellNowPrice(Long productId) {
+        BigDecimal price = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
+                productId,
+                BiddingPosition.BUY,
+                BiddingStatus.PROCESS
+        ).map(Bidding::getPrice).orElse(null);
+
+        return InstantSellPriceResponseDto.of(productId, price);
+    }
+
+}

--- a/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
@@ -1,6 +1,9 @@
 package com.back.market.app.usecase;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
@@ -20,6 +23,7 @@ import java.math.BigDecimal;
 public class GetInstantPriceUseCase {
 
     private final BiddingRepository biddingRepository;
+    private final MarketProductRepository marketProductRepository;
 
     /**
      * 즉시 구매가 조회
@@ -28,6 +32,9 @@ public class GetInstantPriceUseCase {
      */
     @Transactional(readOnly = true)
     public InstantBuyPriceResponseDto getBuyNowPrice(Long productId) {
+        // 상품 존재 여부 검증
+        validateProductExists(productId);
+        
         BigDecimal price = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(
                 productId,
                 BiddingPosition.SELL,
@@ -44,6 +51,8 @@ public class GetInstantPriceUseCase {
      */
     @Transactional(readOnly = true)
     public InstantSellPriceResponseDto getSellNowPrice(Long productId) {
+        //상품 존재 여부 검증
+        validateProductExists(productId);
         BigDecimal price = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
                 productId,
                 BiddingPosition.BUY,
@@ -53,4 +62,9 @@ public class GetInstantPriceUseCase {
         return InstantSellPriceResponseDto.of(productId, price);
     }
 
+    private void validateProductExists(Long productId) {
+        if(!marketProductRepository.existsById(productId)) {
+            throw new BadRequestException(FailureCode.PRODUCT_NOT_FOUND);
+        }
+    }
 }

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -34,7 +34,7 @@ public class MatchInstantTradeUseCase {
      * @throws BadRequestException 해당 상품의 판매 입찰(매물)이 존재하지 않을 경우 (BIDDING_NOT_FOUND)
      */
     @Transactional
-    public Long purchaseNow(Long buyerId, BiddingRequestDto requestDto) {
+    public Long buyNow(Long buyerId, BiddingRequestDto requestDto) {
         Bidding targetSellBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
         return executeTrade(buyerId, requestDto, targetSellBid, BiddingPosition.BUY);

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -1,16 +1,22 @@
 package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
+import com.back.common.code.SuccessCode;
 import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.adapter.out.OrderRepository;
+import com.back.market.adapter.out.client.FakeCashClient;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.dto.enums.RelType;
 import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.dto.request.PayAndHoldRequestDto;
+import com.back.market.dto.response.CashApiResponse;
+import com.back.market.dto.response.CashHoldResponseDto;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.OrderMapper;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +31,7 @@ public class MatchInstantTradeUseCase {
     private final OrderMapper orderMapper;
     private final MarketUserRepository marketUserRepository;
     private final BiddingMapper biddingMapper;
+    private final FakeCashClient fakeCashClient;
 
     /**
      * MARKET-009 즉시 구매 실행
@@ -89,7 +96,25 @@ public class MatchInstantTradeUseCase {
         } else {
             order = orderMapper.toEntity(targetBid, myBid, targetBid.getMarketUser().getAddress());
         }
+        orderRepository.save(order);
 
-        return orderRepository.save(order).getId();
+        // 5. 실제 결제 요청(fakecashclient 사용)
+        PayAndHoldRequestDto paymentReq = PayAndHoldRequestDto.of(
+                order.getBuyBidding().getMarketUser().getId(),
+                order.getPrice(),
+                order.getBuyBidding().getMarketProduct().getName(),
+                RelType.ORDER,
+                order.getId()
+        );
+
+        CashApiResponse<CashHoldResponseDto> response = fakeCashClient.requestBidHold(paymentReq);
+        if(!response.isSuccess()) {
+            if (response.isChargeFailed()) {
+                throw new BadRequestException(FailureCode.WALLET_CHARGE_FAILED);
+            }
+            throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+        }
+
+        return order.getId();
     }
 }

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -1,0 +1,95 @@
+package com.back.market.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.mapper.BiddingMapper;
+import com.back.market.mapper.OrderMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchInstantTradeUseCase {
+    private final BiddingRepository biddingRepository;
+    private final OrderRepository orderRepository;
+    private final OrderMapper orderMapper;
+    private final MarketUserRepository marketUserRepository;
+    private final BiddingMapper biddingMapper;
+
+    /**
+     * MARKET-009 즉시 구매 실행
+     * @param buyerId 구매자 ID
+     * @param requestDto BiddingRequestDto
+     * @return 생성된 주문(Order)의 ID
+     * @throws BadRequestException 해당 상품의 판매 입찰(매물)이 존재하지 않을 경우 (BIDDING_NOT_FOUND)
+     */
+    @Transactional
+    public Long purchaseNow(Long buyerId, BiddingRequestDto requestDto) {
+        Bidding targetSellBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+
+        return executeTrade(buyerId, requestDto, targetSellBid, BiddingPosition.BUY);
+    }
+
+    /**
+     * MARKET-011 즉시 판매 실행
+     * @param sellerId 판매자 ID
+     * @param requestDto BiddingRequestDto
+     * @return 생성된 주문(Order)의 ID
+     * @throws BadRequestException 해당 상품의 판매 입찰(매물)이 존재하지 않을 경우 (BIDDING_NOT_FOUND)
+     */
+    @Transactional
+    public Long sellNow(Long sellerId, BiddingRequestDto requestDto) {
+        Bidding targetBuyBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
+                        requestDto.productId(), BiddingPosition.BUY, BiddingStatus.PROCESS)
+                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+
+        return executeTrade(sellerId, requestDto, targetBuyBid, BiddingPosition.SELL);
+    }
+
+    /**
+     * 실제 체결 및 주문 생성 공통 로직
+     * <p>
+     * 1. 자전거래 여부 검증 (본인의 입찰과 체결되는지 확인)
+     * 2. 요청자의 신규 입찰 생성 및 상태 변경 (MATCHED)
+     * 3. 매칭된 상대방 입찰의 상태 변경 (MATCHED)
+     * 4. 배송지 정보를 포함한 최종 주문(Order) 생성
+     * </p>
+     */
+    private Long executeTrade(Long userId, BiddingRequestDto requestDto, Bidding targetBid, BiddingPosition myPosition) {
+        // 1. 자전거래 검증
+        if(targetBid.getMarketUser().getId().equals(userId)){
+            throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
+        }
+
+        // 2. 입찰 생성 및 상태 변경
+        MarketUser me = marketUserRepository.findById(userId).orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
+
+        Bidding myBid = biddingMapper.toEntity(requestDto, me, targetBid.getMarketProduct(), myPosition);
+        myBid.changeStatus(BiddingStatus.MATCHED);
+        biddingRepository.save(myBid);
+
+        // 3. 상대방 입찰 상태 변경
+        targetBid.changeStatus(BiddingStatus.MATCHED);
+
+        // 4. 주문 생성
+        Order order;
+
+        if(myPosition == BiddingPosition.BUY) {
+            order = orderMapper.toEntity(myBid, targetBid, me.getAddress());
+        } else {
+            order = orderMapper.toEntity(targetBid, myBid, targetBid.getMarketUser().getAddress());
+        }
+
+        return orderRepository.save(order).getId();
+    }
+}

--- a/market/src/main/java/com/back/market/domain/Bidding.java
+++ b/market/src/main/java/com/back/market/domain/Bidding.java
@@ -49,4 +49,11 @@ public class Bidding extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private BiddingStatus status;           // 입찰 상태
 
+    /**
+     * 상태 변경을 위한 메서드(setter 역할)
+     * @param status 입찰상태
+     */
+    public void changeStatus(BiddingStatus status) {
+        this.status = status;
+    }
 }

--- a/market/src/main/java/com/back/market/domain/Order.java
+++ b/market/src/main/java/com/back/market/domain/Order.java
@@ -11,6 +11,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -36,7 +37,7 @@ public class Order extends BaseTimeEntity {
     private Bidding sellBidding;                // 판매 입찰 내역(1:1)
 
     @Column(name = "price", nullable = false)
-    private Long price;                          // 체결 가격(입찰가 변동과 무관)
+    private BigDecimal price;                          // 체결 가격(입찰가 변동과 무관)
 
     @Column(name = "address", nullable = false, length = 500)
     private String address;                      // 배송지 주소(사용자 주소 변경과 무관)

--- a/market/src/main/java/com/back/market/dto/request/BiddingRequestDto.java
+++ b/market/src/main/java/com/back/market/dto/request/BiddingRequestDto.java
@@ -1,19 +1,13 @@
 package com.back.market.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.math.BigDecimal;
 
 /**
  * Controller에서 Facade로, Facade에서 UseCase로 데이터를 넘길 때 사용
  */
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class BiddingRequestDto {
-    private Long productId;
-    private BigDecimal price;
-    private String size;
+public record BiddingRequestDto(
+        Long productId,
+        BigDecimal price,
+        String size
+) {
 }

--- a/market/src/main/java/com/back/market/dto/request/BiddingRequestDto.java
+++ b/market/src/main/java/com/back/market/dto/request/BiddingRequestDto.java
@@ -10,4 +10,7 @@ public record BiddingRequestDto(
         BigDecimal price,
         String size
 ) {
+    public static BiddingRequestDto of(Long productId, BigDecimal price, String size) {
+        return new BiddingRequestDto(productId, price, size);
+    }
 }

--- a/market/src/main/java/com/back/market/dto/request/PayAndHoldRequestDto.java
+++ b/market/src/main/java/com/back/market/dto/request/PayAndHoldRequestDto.java
@@ -11,4 +11,7 @@ public record PayAndHoldRequestDto (
         RelType relType,
         Long relId
 ) {
+    public static PayAndHoldRequestDto of(Long buyerId, BigDecimal totalAmount, String orderName, RelType relType, Long relId) {
+        return new PayAndHoldRequestDto(buyerId, totalAmount, orderName, relType, relId);
+    }
 }

--- a/market/src/main/java/com/back/market/dto/response/CashApiResponse.java
+++ b/market/src/main/java/com/back/market/dto/response/CashApiResponse.java
@@ -2,24 +2,21 @@ package com.back.market.dto.response;
 
 import com.back.common.code.FailureCode;
 import com.back.common.code.SuccessCode;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
+import lombok.Builder;
+
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class CashApiResponse<T> {
-    private String code;
-    private String message;
-    private T data;
+public record CashApiResponse<T> (
+        String code,
+        String message,
+        T data
+) {
 
     // ... 편의 메서드(isSuccess) 그대로 ...
     public boolean isSuccess() {
         return SuccessCode.OK.getCode().equals(this.code);
     }
+    
     public boolean isChargeFailed() {
         return FailureCode.WALLET_CHARGE_FAILED.getCode().equals(this.code);
     }

--- a/market/src/main/java/com/back/market/dto/response/CashHoldResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/CashHoldResponseDto.java
@@ -1,17 +1,9 @@
 package com.back.market.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.math.BigDecimal;
 
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class CashHoldResponseDto {
-    private Long userId;
-    private BigDecimal holdAmount;   // 묶인 금액
+public record CashHoldResponseDto(
+        Long userId,
+        BigDecimal holdAmount
+) {
 }

--- a/market/src/main/java/com/back/market/dto/response/CashHoldResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/CashHoldResponseDto.java
@@ -6,4 +6,7 @@ public record CashHoldResponseDto(
         Long userId,
         BigDecimal holdAmount
 ) {
+    public static CashHoldResponseDto of(Long userId, BigDecimal holdAmount) {
+        return new CashHoldResponseDto(userId, holdAmount);
+    }
 }

--- a/market/src/main/java/com/back/market/dto/response/InstantBuyPriceResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/InstantBuyPriceResponseDto.java
@@ -1,0 +1,18 @@
+package com.back.market.dto.response;
+
+import java.math.BigDecimal;
+
+/**
+ * 특정 상품의 즉시 구매가를 조회하기 위한 DTO
+ * @param productId 상품ID(PK)
+ * @param buyNowPrice 즉시 구매가
+ */
+public record InstantBuyPriceResponseDto(
+        Long productId,          // 상품ID
+        BigDecimal buyNowPrice  // 즉시 구매가(=판매 입찰가 중 최저가)
+) {
+    // 팩토리 메서드
+    public static InstantBuyPriceResponseDto of(Long productId, BigDecimal buyNowPrice) {
+        return new InstantBuyPriceResponseDto(productId, buyNowPrice);
+    }
+}

--- a/market/src/main/java/com/back/market/dto/response/InstantSellPriceResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/InstantSellPriceResponseDto.java
@@ -1,0 +1,18 @@
+package com.back.market.dto.response;
+
+import java.math.BigDecimal;
+
+/**
+ * 특정 상품의 즉시 판매가를 조회하기 위한 DTO
+ * @param productId 상품ID(PK)
+ * @param sellNowPrice 즉시 판매가
+ */
+public record InstantSellPriceResponseDto(
+        Long productId,          // 상품ID
+        BigDecimal sellNowPrice  // 즉시 판매가(=구매 입찰가 중 최고가)
+) {
+    // 팩토리 메서드
+    public static InstantSellPriceResponseDto of(Long productId, BigDecimal sellNowPrice) {
+        return new InstantSellPriceResponseDto(productId, sellNowPrice);
+    }
+}

--- a/market/src/main/java/com/back/market/mapper/BiddingMapper.java
+++ b/market/src/main/java/com/back/market/mapper/BiddingMapper.java
@@ -14,7 +14,7 @@ public class BiddingMapper {
         return Bidding.builder()
                 .marketUser(user)
                 .marketProduct(product)
-                .price(requestDto.getPrice())
+                .price(requestDto.price())
                 .position(position)
                 .status(BiddingStatus.PROCESS)
                 .build();

--- a/market/src/main/java/com/back/market/mapper/CashRequestMapper.java
+++ b/market/src/main/java/com/back/market/mapper/CashRequestMapper.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 public class CashRequestMapper {
     //구매 입찰용 요청 생성
     public PayAndHoldRequestDto toPayAndHoldRequestForBidding(Long userId, BigDecimal price, Long biddingId) {
-        return new PayAndHoldRequestDto(
+        return PayAndHoldRequestDto.of(
                 userId,
                 price,
                 "구매 입찰 포인트 충전",
@@ -21,7 +21,7 @@ public class CashRequestMapper {
 
     //주문용 요청 생성
     public PayAndHoldRequestDto toPayAndHoldRequestForOrder(Long userId, BigDecimal totalPrice, String productName, Long orderId) {
-        return new PayAndHoldRequestDto(
+        return PayAndHoldRequestDto.of(
                 userId,
                 totalPrice,
                 productName,

--- a/market/src/main/java/com/back/market/mapper/OrderMapper.java
+++ b/market/src/main/java/com/back/market/mapper/OrderMapper.java
@@ -1,0 +1,22 @@
+package com.back.market.mapper;
+
+import com.back.market.domain.Bidding;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.OrderStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class OrderMapper {
+    public Order toEntity(Bidding buyBid, Bidding sellBid, String address){
+        return Order.builder()
+                .buyBidding(buyBid)
+                .sellBidding(sellBid)
+                .price(sellBid.getPrice())
+                .address(address)
+                .orderStatus(OrderStatus.HOLD) //초기 상태 설정
+                .requestPaymentDate(LocalDateTime.now())
+                .build();
+    }
+}

--- a/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
+++ b/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
@@ -1,0 +1,104 @@
+package com.back.market;
+
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.mapper.BiddingMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class GetInstantPriceUseCaseTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired private BiddingRepository biddingRepository;
+    @Autowired private MarketUserRepository marketUserRepository;
+    @Autowired private MarketProductRepository marketProductRepository;
+    @Autowired private BiddingMapper biddingMapper;
+
+    @Test
+    @DisplayName("상품의 즉시 구매가(최저 판매 입찰가)를 조회한다")
+    void getBuyNowPrice_Success() throws Exception {
+        Long productId = 100L;
+        Long sellerId = 1L;
+
+        createBidding(productId, sellerId, 200000, BiddingPosition.SELL);
+        createBidding(productId, sellerId, 180000, BiddingPosition.SELL); // 정답 (최저가)
+        createBidding(productId, sellerId, 220000, BiddingPosition.SELL);
+
+        mockMvc.perform(get("/api/v1/market/product/{productId}/buy-now-price", productId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.productId").value(productId))
+                .andExpect(jsonPath("$.data.buyNowPrice").value(180000));
+    }
+
+    @Test
+    @DisplayName("상품의 즉시 판매가(최고 구매 입찰가)를 조회한다")
+    void getSellNowPrice_Success() throws Exception {
+        Long productId = 100L;
+        Long buyerId = 2L;
+
+        createBidding(productId, buyerId, 150000, BiddingPosition.BUY);
+        createBidding(productId, buyerId, 160000, BiddingPosition.BUY); // 정답 (최고가)
+        createBidding(productId, buyerId, 140000, BiddingPosition.BUY);
+
+        mockMvc.perform(get("/api/v1/market/product/{productId}/sell-now-price", productId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.productId").value(productId))
+                .andExpect(jsonPath("$.data.sellNowPrice").value(160000));
+    }
+
+    @Test
+    @DisplayName("등록된 입찰이 없으면 가격은 null을 반환한다")
+    void getPrice_WhenNoBids() throws Exception {
+        Long productId = 200L;
+
+        mockMvc.perform(get("/api/v1/market/product/{productId}/buy-now-price", productId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.buyNowPrice").isEmpty());
+
+        mockMvc.perform(get("/api/v1/market/product/{productId}/sell-now-price", productId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sellNowPrice").isEmpty());
+    }
+
+    // --- Helper Methods ---
+
+    private void createBidding(Long productId, Long userId, long price, BiddingPosition position) {
+        MarketProduct product = marketProductRepository.findById(productId).orElseThrow();
+        MarketUser user = marketUserRepository.findById(userId).orElseThrow();
+
+        BiddingRequestDto requestDto = new BiddingRequestDto(productId, BigDecimal.valueOf(price), "270");
+
+        Bidding bidding = biddingMapper.toEntity(requestDto, user, product, position);
+
+        biddingRepository.save(bidding);
+    }
+}

--- a/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
+++ b/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
@@ -1,95 +1,139 @@
 package com.back.market;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.MarketProductRepository;
 import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.app.usecase.GetInstantPriceUseCase;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.Role;
 import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.dto.response.InstantBuyPriceResponseDto;
+import com.back.market.dto.response.InstantSellPriceResponseDto;
 import com.back.market.mapper.BiddingMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
-@AutoConfigureMockMvc
 @Transactional
 class GetInstantPriceUseCaseTests {
 
     @Autowired
-    private MockMvc mockMvc;
+    private GetInstantPriceUseCase getInstantPriceUseCase;
+
     @Autowired private BiddingRepository biddingRepository;
     @Autowired private MarketUserRepository marketUserRepository;
     @Autowired private MarketProductRepository marketProductRepository;
     @Autowired private BiddingMapper biddingMapper;
 
     @Test
-    @DisplayName("상품의 즉시 구매가(최저 판매 입찰가)를 조회한다")
-    void getBuyNowPrice_Success() throws Exception {
-        Long productId = 100L;
-        Long sellerId = 1L;
+    @DisplayName("조회 실패: 존재하지 않는 상품 ID로 즉시구매가를 조회하면 PRODUCT_NOT_FOUND 예외가 발생해야 한다")
+    void getBuyNowPrice_fail_productNotFound() {
+        // [Given] 존재하지 않는 상품 ID
+        Long invalidProductId = 9999L;
 
-        createBidding(productId, sellerId, 200000, BiddingPosition.SELL);
-        createBidding(productId, sellerId, 180000, BiddingPosition.SELL); // 정답 (최저가)
-        createBidding(productId, sellerId, 220000, BiddingPosition.SELL);
+        // [When & Then] 예외 발생 확인 (RegisterBidUseCaseTests와 동일한 방식)
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            getInstantPriceUseCase.getBuyNowPrice(invalidProductId);
+        });
 
-        mockMvc.perform(get("/api/v1/market/product/{productId}/buy-now-price", productId)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.productId").value(productId))
-                .andExpect(jsonPath("$.data.buyNowPrice").value(180000));
+        // 에러 코드 검증
+        assertThat(exception.getMessage()).isEqualTo(FailureCode.PRODUCT_NOT_FOUND.getMessage());
     }
 
     @Test
-    @DisplayName("상품의 즉시 판매가(최고 구매 입찰가)를 조회한다")
-    void getSellNowPrice_Success() throws Exception {
+    @DisplayName("즉시 구매가 조회: 판매 입찰(SELL) 중 가장 낮은 가격을 반환해야 한다")
+    void getBuyNowPrice_Success() {
+        // [Given] 기초 데이터 및 입찰 데이터 세팅
         Long productId = 100L;
-        Long buyerId = 2L;
+        setupBaseData(productId, 1L);
 
-        createBidding(productId, buyerId, 150000, BiddingPosition.BUY);
-        createBidding(productId, buyerId, 160000, BiddingPosition.BUY); // 정답 (최고가)
-        createBidding(productId, buyerId, 140000, BiddingPosition.BUY);
+        // 판매 입찰 3개 등록 (20만, 18만, 22만)
+        createBidding(productId, 1L, 200000, BiddingPosition.SELL);
+        createBidding(productId, 1L, 180000, BiddingPosition.SELL); // 최저가 (정답)
+        createBidding(productId, 1L, 220000, BiddingPosition.SELL);
 
-        mockMvc.perform(get("/api/v1/market/product/{productId}/sell-now-price", productId)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.productId").value(productId))
-                .andExpect(jsonPath("$.data.sellNowPrice").value(160000));
+        // [When] UseCase 메서드 직접 호출
+        InstantBuyPriceResponseDto result = getInstantPriceUseCase.getBuyNowPrice(productId);
+
+        // [Then]
+        assertThat(result.productId()).isEqualTo(productId);
+        assertThat(result.buyNowPrice()).isEqualByComparingTo("180000"); // 18만원 확인
     }
 
     @Test
-    @DisplayName("등록된 입찰이 없으면 가격은 null을 반환한다")
-    void getPrice_WhenNoBids() throws Exception {
+    @DisplayName("즉시 판매가 조회: 구매 입찰(BUY) 중 가장 높은 가격을 반환해야 한다")
+    void getSellNowPrice_Success() {
+        // [Given] 기초 데이터 및 입찰 데이터 세팅
+        Long productId = 100L;
+        setupBaseData(productId, 2L);
+
+        // 구매 입찰 3개 등록 (15만, 16만, 14만)
+        createBidding(productId, 2L, 150000, BiddingPosition.BUY);
+        createBidding(productId, 2L, 160000, BiddingPosition.BUY); // 최고가 (정답)
+        createBidding(productId, 2L, 140000, BiddingPosition.BUY);
+
+        // [When] UseCase 메서드 직접 호출
+        InstantSellPriceResponseDto result = getInstantPriceUseCase.getSellNowPrice(productId);
+
+        // [Then]
+        assertThat(result.productId()).isEqualTo(productId);
+        assertThat(result.sellNowPrice()).isEqualByComparingTo("160000"); // 16만원 확인
+    }
+
+    @Test
+    @DisplayName("입찰 내역이 없는 경우: 결과값(Price)이 null로 반환되어야 한다")
+    void getPrice_ReturnNull_WhenNoBiddings() {
+        // [Given] 상품은 존재하지만 입찰 내역은 없는 상태
         Long productId = 200L;
+        setupBaseData(productId, 1L);
 
-        mockMvc.perform(get("/api/v1/market/product/{productId}/buy-now-price", productId))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.buyNowPrice").isEmpty());
+        // [When]
+        InstantBuyPriceResponseDto buyResult = getInstantPriceUseCase.getBuyNowPrice(productId);
+        InstantSellPriceResponseDto sellResult = getInstantPriceUseCase.getSellNowPrice(productId);
 
-        mockMvc.perform(get("/api/v1/market/product/{productId}/sell-now-price", productId))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.sellNowPrice").isEmpty());
+        // [Then]
+        assertThat(buyResult.buyNowPrice()).isNull();
+        assertThat(sellResult.sellNowPrice()).isNull();
     }
 
-    // --- Helper Methods ---
+    // --- Helper Methods (RegisterBidUseCaseTests 스타일과 통일) ---
+
+    private void setupBaseData(Long productId, Long userId) {
+        // 유저 생성
+        if (!marketUserRepository.existsById(userId)) {
+            marketUserRepository.save(MarketUser.builder()
+                    .id(userId)
+                    .nickname("tester")
+                    .email("test@test.com")
+                    .role(Role.USER)
+                    .build());
+        }
+        // 상품 생성
+        if (!marketProductRepository.existsById(productId)) {
+            marketProductRepository.save(MarketProduct.builder()
+                    .id(productId)
+                    .name("테스트 신발")
+                    .productNumber("TEST-001")
+                    .productOption("270")
+                    .brandName("TestBrand")
+                    .categoryName("Sneakers")
+                    .releasePrice(BigDecimal.valueOf(100000))
+                    .build());
+        }
+    }
 
     private void createBidding(Long productId, Long userId, long price, BiddingPosition position) {
         MarketProduct product = marketProductRepository.findById(productId).orElseThrow();
@@ -97,8 +141,8 @@ class GetInstantPriceUseCaseTests {
 
         BiddingRequestDto requestDto = new BiddingRequestDto(productId, BigDecimal.valueOf(price), "270");
 
+        // BiddingMapper를 사용하여 엔티티 생성 및 저장
         Bidding bidding = biddingMapper.toEntity(requestDto, user, product, position);
-
         biddingRepository.save(bidding);
     }
 }

--- a/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
+++ b/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
@@ -139,7 +139,7 @@ class GetInstantPriceUseCaseTests {
         MarketProduct product = marketProductRepository.findById(productId).orElseThrow();
         MarketUser user = marketUserRepository.findById(userId).orElseThrow();
 
-        BiddingRequestDto requestDto = new BiddingRequestDto(productId, BigDecimal.valueOf(price), "270");
+        BiddingRequestDto requestDto = BiddingRequestDto.of(productId, BigDecimal.valueOf(price), "270");
 
         // BiddingMapper를 사용하여 엔티티 생성 및 저장
         Bidding bidding = biddingMapper.toEntity(requestDto, user, product, position);

--- a/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
@@ -1,0 +1,90 @@
+package com.back.market;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.app.usecase.MatchInstantTradeUseCase;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.domain.enums.Role;
+import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.mapper.BiddingMapper;
+import com.back.market.mapper.MarketProductMapper;
+import com.back.market.mapper.MarketUserMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+// @Transactional을 제거하여 각 UseCase의 트랜잭션 결과가 DB에 즉시 반영되게 함
+public class MatchInstantTradeRollbackTests {
+
+    @Autowired
+    private MatchInstantTradeUseCase matchInstantTradeUseCase;
+    @Autowired private BiddingRepository biddingRepository;
+    @Autowired private MarketUserRepository marketUserRepository;
+    @Autowired private MarketProductRepository marketProductRepository;
+    @Autowired private BiddingMapper biddingMapper;
+    @Autowired private MarketUserMapper marketUserMapper;
+    @Autowired private MarketProductMapper marketProductMapper;
+
+    @Test
+    @DisplayName("통합 검증: 결제 실패 시(9999원) 예외가 던져지고 입찰 상태는 다시 PROCESS로 롤백되어야 한다")
+    void buyNow_integration_rollback_on_payment_fail() {
+        // [Given] 9999원 세팅 (FakeCashClient 실패 조건)
+        Long productId = 200L;
+        Long sellerId = 3L;
+        Long buyerId = 4L;
+        setupBaseData(productId, sellerId, buyerId, "인천시");
+
+        // 초기 상태 PROCESS인 입찰 생성
+        Bidding sellBid = createBidding(productId, sellerId, 9999, BiddingPosition.SELL);
+
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(9999), "270");
+
+        // [When] 결제 실패 상황 발생
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            matchInstantTradeUseCase.buyNow(buyerId, request); //
+        });
+
+        // [Then]
+        // 1. 에러 코드 확인
+        assertThat(exception.getMessage()).isEqualTo(FailureCode.WALLET_CHARGE_FAILED.getMessage());
+
+        // 2. 롤백 검증: 입찰 상태 확인 ✅
+        // 클래스에 @Transactional이 없으므로, 내부 트랜잭션의 롤백 결과가 즉시 DB에 반영됩니다.
+        Bidding rolledBackBid = biddingRepository.findById(sellBid.getId()).orElseThrow();
+        assertThat(rolledBackBid.getStatus()).isEqualTo(BiddingStatus.PROCESS); // ✅ 이제 드디어 PROCESS가 나옵니다!
+    }
+
+    // --- Helper Methods (데이터 정리를 위해 메서드 단위 Transactional 고려 가능) ---
+    private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
+        MarketUser seller = marketUserMapper.toEntity(sellerId, Role.USER, "seller", "s@t.com", "판매자주소", "010-1234-5678", "image");
+        marketUserRepository.save(seller);
+
+        MarketUser buyer = marketUserMapper.toEntity(buyerId, Role.USER, "buyer", "b@t.com", buyerAddress, "010-1234-5678", "image");
+        marketUserRepository.save(buyer);
+
+        if (!marketProductRepository.existsById(productId)) {
+            marketProductRepository.save(marketProductMapper.toEntity(productId, "N", "신발", "N1", "270", 100000L, "S", "image"));
+        }
+    }
+
+    private Bidding createBidding(Long productId, Long userId, long price, BiddingPosition position) {
+        MarketProduct product = marketProductRepository.findById(productId).orElseThrow();
+        MarketUser user = marketUserRepository.findById(userId).orElseThrow();
+        BiddingRequestDto requestDto = BiddingRequestDto.of(productId, BigDecimal.valueOf(price), "270");
+        return biddingRepository.save(biddingMapper.toEntity(requestDto, user, product, position));
+    }
+}

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseTests.java
@@ -1,0 +1,168 @@
+package com.back.market;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.app.usecase.MatchInstantTradeUseCase;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.domain.enums.OrderStatus;
+import com.back.market.domain.enums.Role;
+import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.mapper.BiddingMapper;
+import com.back.market.mapper.MarketProductMapper;
+import com.back.market.mapper.MarketUserMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+public class MatchInstantTradeUseCaseTests {
+    @Autowired private MatchInstantTradeUseCase matchInstantTradeUseCase;
+    @Autowired private BiddingRepository biddingRepository;
+    @Autowired private MarketUserRepository marketUserRepository;
+    @Autowired private MarketProductRepository marketProductRepository;
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private BiddingMapper biddingMapper;
+    @Autowired private MarketUserMapper marketUserMapper;
+    @Autowired private MarketProductMapper marketProductMapper;
+
+    @Test
+    @DisplayName("즉시 구매 실패: 해당 상품에 판매 입찰(SELL)이 하나도 없으면 예외가 발생한다")
+    void purchaseNow_fail_noBidding() {
+        // [Given] 상품은 존재하지만 판매 입찰은 없는 상태
+        Long productId = 300L;
+        Long buyerId = 5L;
+        setupBaseData(productId, 999L, buyerId, "서울");
+
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
+
+        // [When & Then] BIDDING_NOT_FOUND 예외 확인
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            matchInstantTradeUseCase.purchaseNow(buyerId, request);
+        });
+
+        assertThat(exception.getMessage()).isEqualTo(FailureCode.BIDDING_NOT_FOUND.getMessage()); //
+    }
+
+    @Test
+    @DisplayName("즉시 거래 실패: 본인이 등록한 입찰과 체결(자전거래)하려 하면 예외가 발생한다")
+    void executeTrade_fail_selfTrading() {
+        // [Given] 1번 유저가 판매 입찰을 올림
+        Long productId = 400L;
+        Long userId = 1L;
+        setupBaseData(productId, userId, userId, "주소");
+
+        createBidding(productId, userId, 200000, BiddingPosition.SELL);
+
+        // [When] 1번 유저가 본인의 매물을 즉시 구매 시도
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
+
+        // [Then] SELF_TRADING_NOT_ALLOWED 예외 확인
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            matchInstantTradeUseCase.purchaseNow(userId, request);
+        });
+
+        assertThat(exception.getMessage()).isEqualTo(FailureCode.SELF_TRADING_NOT_ALLOWED.getMessage()); //
+    }
+
+    @Test
+    @DisplayName("즉시 구매 성공: 판매 입찰이 있을 때 즉시 구매하면 Bidding 상태가 변경되고 Order가 생성된다")
+    void purchaseNow_success() {
+        // [Given] 기초 데이터 세팅
+        Long productId = 100L;
+        Long sellerId = 1L;
+        Long buyerId = 2L;
+        String buyerAddress = "서울시 강남구 역삼동";
+
+        setupBaseData(productId, sellerId, buyerId, buyerAddress);
+
+        // 판매자가 200,000원에 판매 입찰 등록해둔 상태
+        Bidding sellBid = createBidding(productId, sellerId, 200000, BiddingPosition.SELL);
+
+        // [When] 구매자가 즉시 구매 실행 (200,000원)
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
+        Long orderId = matchInstantTradeUseCase.purchaseNow(buyerId, request);
+
+        // [Then] 1. 주문 생성 확인
+        Order savedOrder = orderRepository.findById(orderId).orElseThrow();
+        assertThat(savedOrder.getPrice()).isEqualTo(BigDecimal.valueOf(200000));
+        assertThat(savedOrder.getAddress()).isEqualTo(buyerAddress);
+        assertThat(savedOrder.getOrderStatus()).isEqualTo(OrderStatus.HOLD);
+
+        // [Then] 2. 입찰 상태 변경 확인 (둘 다 MATCHED)
+        Bidding targetSellBid = biddingRepository.findById(sellBid.getId()).orElseThrow();
+        assertThat(targetSellBid.getStatus()).isEqualTo(BiddingStatus.MATCHED);
+
+        Bidding newBuyBid = savedOrder.getBuyBidding(); // 주문과 연결된 구매 입찰
+        assertThat(newBuyBid.getStatus()).isEqualTo(BiddingStatus.MATCHED);
+        assertThat(newBuyBid.getMarketUser().getId()).isEqualTo(buyerId);
+    }
+
+    @Test
+    @DisplayName("즉시 판매 성공: 구매 입찰이 있을 때 즉시 판매하면 Bidding 상태가 변경되고 Order가 생성된다")
+    void sellNow_success() {
+        // [Given] 기초 데이터 세팅
+        Long productId = 200L;
+        Long buyerId = 4L;
+        Long sellerId = 3L;
+        String buyerAddress = "경기도 성남시 분당구";
+
+        setupBaseData(productId, sellerId, buyerId, buyerAddress);
+
+        // 구매자가 150,000원에 구매 입찰 등록해둔 상태
+        Bidding buyBid = createBidding(productId, buyerId, 150000, BiddingPosition.BUY);
+
+        // [When] 판매자가 즉시 판매 실행 (150,000원)
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(150000), "270");
+        Long orderId = matchInstantTradeUseCase.sellNow(sellerId, request);
+
+        // [Then] 주문 정보 및 입찰 상태 검증
+        Order savedOrder = orderRepository.findById(orderId).orElseThrow();
+        assertThat(savedOrder.getPrice()).isEqualTo(BigDecimal.valueOf(150000));
+        assertThat(savedOrder.getAddress()).isEqualTo(buyerAddress); // 구매자의 주소 확인
+
+        assertThat(biddingRepository.findById(buyBid.getId()).get().getStatus()).isEqualTo(BiddingStatus.MATCHED);
+        assertThat(savedOrder.getSellBidding().getStatus()).isEqualTo(BiddingStatus.MATCHED);
+    }
+
+    // --- Helper Methods ---
+
+    private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
+        // 판매자 생성 혹은 업데이트
+        MarketUser seller = marketUserMapper.toEntity(sellerId, Role.USER, "seller", "s@t.com", "판매자주소", "010-1234-5678", "https://dummyimage.com/100x100/000/fff&text=Seller");
+        marketUserRepository.save(seller); // existsById 체크 없이 save(upsert) 수행
+
+        // 구매자 생성 혹은 업데이트 (테스트에 필요한 주소로 강제 반영)
+        MarketUser buyer = marketUserMapper.toEntity(buyerId, Role.USER, "buyer", "b@t.com", buyerAddress, "010-1234-5678", "https://dummyimage.com/100x100/000/fff&text=Buyer");
+        marketUserRepository.save(buyer);
+
+        // 상품 생성 혹은 업데이트
+        if (!marketProductRepository.existsById(productId)) {
+            marketProductRepository.save(marketProductMapper.toEntity(productId, "N", "신발", "N1", "270", 100000L, "S", "https://dummyimage.com/600x400/000/fff&text=N"));
+        }
+    }
+
+    private Bidding createBidding(Long productId, Long userId, long price, BiddingPosition position) {
+        MarketProduct product = marketProductRepository.findById(productId).orElseThrow();
+        MarketUser user = marketUserRepository.findById(userId).orElseThrow();
+        BiddingRequestDto requestDto = BiddingRequestDto.of(productId, BigDecimal.valueOf(price), "270");
+        Bidding bidding = biddingMapper.toEntity(requestDto, user, product, position);
+        return biddingRepository.save(bidding);
+    }
+}

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseTests.java
@@ -43,6 +43,30 @@ public class MatchInstantTradeUseCaseTests {
     @Autowired private MarketProductMapper marketProductMapper;
 
     @Test
+    @DisplayName("통합 검증: 즉시 구매 성공 시 결제 모듈(Fake)이 호출되고 주문이 최종 저장된다")
+    void buyNow_integration_success() {
+        // [Given]
+        Long productId = 100L;
+        Long sellerId = 1L;
+        Long buyerId = 2L;
+        setupBaseData(productId, sellerId, buyerId, "서울시 강남구");
+        createBidding(productId, sellerId, 200000, BiddingPosition.SELL);
+
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
+
+        // [When] 실제 UseCase 호출 (내부에서 FakeCashClient의 "요청 성공" 로직이 실행됨)
+        Long orderId = matchInstantTradeUseCase.buyNow(buyerId, request);
+
+        // [Then] 1. 주문 저장 확인 ✅
+        Order savedOrder = orderRepository.findById(orderId).orElseThrow();
+        assertThat(savedOrder.getPrice()).isEqualByComparingTo(BigDecimal.valueOf(200000));
+
+        // 2. 입찰 상태 변경 확인 ✅
+        Bidding buyBid = savedOrder.getBuyBidding();
+        assertThat(buyBid.getStatus()).isEqualTo(BiddingStatus.MATCHED);
+    }
+
+    @Test
     @DisplayName("즉시 구매 실패: 해당 상품에 판매 입찰(SELL)이 하나도 없으면 예외가 발생한다")
     void buyNow_fail_noBidding() {
         // [Given] 상품은 존재하지만 판매 입찰은 없는 상태

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseTests.java
@@ -44,7 +44,7 @@ public class MatchInstantTradeUseCaseTests {
 
     @Test
     @DisplayName("즉시 구매 실패: 해당 상품에 판매 입찰(SELL)이 하나도 없으면 예외가 발생한다")
-    void purchaseNow_fail_noBidding() {
+    void buyNow_fail_noBidding() {
         // [Given] 상품은 존재하지만 판매 입찰은 없는 상태
         Long productId = 300L;
         Long buyerId = 5L;
@@ -54,7 +54,7 @@ public class MatchInstantTradeUseCaseTests {
 
         // [When & Then] BIDDING_NOT_FOUND 예외 확인
         BadRequestException exception = assertThrows(BadRequestException.class, () -> {
-            matchInstantTradeUseCase.purchaseNow(buyerId, request);
+            matchInstantTradeUseCase.buyNow(buyerId, request);
         });
 
         assertThat(exception.getMessage()).isEqualTo(FailureCode.BIDDING_NOT_FOUND.getMessage()); //
@@ -75,7 +75,7 @@ public class MatchInstantTradeUseCaseTests {
 
         // [Then] SELF_TRADING_NOT_ALLOWED 예외 확인
         BadRequestException exception = assertThrows(BadRequestException.class, () -> {
-            matchInstantTradeUseCase.purchaseNow(userId, request);
+            matchInstantTradeUseCase.buyNow(userId, request);
         });
 
         assertThat(exception.getMessage()).isEqualTo(FailureCode.SELF_TRADING_NOT_ALLOWED.getMessage()); //
@@ -83,7 +83,7 @@ public class MatchInstantTradeUseCaseTests {
 
     @Test
     @DisplayName("즉시 구매 성공: 판매 입찰이 있을 때 즉시 구매하면 Bidding 상태가 변경되고 Order가 생성된다")
-    void purchaseNow_success() {
+    void buyNow_success() {
         // [Given] 기초 데이터 세팅
         Long productId = 100L;
         Long sellerId = 1L;
@@ -97,7 +97,7 @@ public class MatchInstantTradeUseCaseTests {
 
         // [When] 구매자가 즉시 구매 실행 (200,000원)
         BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
-        Long orderId = matchInstantTradeUseCase.purchaseNow(buyerId, request);
+        Long orderId = matchInstantTradeUseCase.buyNow(buyerId, request);
 
         // [Then] 1. 주문 생성 확인
         Order savedOrder = orderRepository.findById(orderId).orElseThrow();

--- a/market/src/test/java/com/back/market/RegisterBidUseCaseTests.java
+++ b/market/src/test/java/com/back/market/RegisterBidUseCaseTests.java
@@ -20,7 +20,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +61,7 @@ public class RegisterBidUseCaseTests {
 
         // [Given] 3. 요청 객체 생성 (위에서 정한 ID 사용)
         BigDecimal price = BigDecimal.valueOf(30000);
-        BiddingRequestDto request = new BiddingRequestDto(
+        BiddingRequestDto request = BiddingRequestDto.of(
                 productId, // 100L
                 price,
                 "270"
@@ -86,7 +85,7 @@ public class RegisterBidUseCaseTests {
         // given
         Long userId = 1L;
         BigDecimal invalidPrice = BigDecimal.valueOf(30500); // 500원 단위 (유효하지 않음)
-        BiddingRequestDto request = new BiddingRequestDto(1L, invalidPrice, "270");
+        BiddingRequestDto request = BiddingRequestDto.of(1L, invalidPrice, "270");
 
         // when & then
         BadRequestException exception = assertThrows(BadRequestException.class, () -> {
@@ -147,7 +146,7 @@ public class RegisterBidUseCaseTests {
 
 
         // [When] 내가 30,000원에 사겠다고 입찰 시도 (이미 파는 사람이 있으니 에러 나야 함)
-        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(30000), "270");
+        BiddingRequestDto request = BiddingRequestDto.of(productId, BigDecimal.valueOf(30000), "270");
 
         // [Then]
         BadRequestException exception = assertThrows(BadRequestException.class, () -> {
@@ -161,7 +160,7 @@ public class RegisterBidUseCaseTests {
     @DisplayName("잔액 부족 시 예외가 발생하고 DB에 저장되지 않아야 한다")
     void registerBuyBid_fail_rollback() {
         Long userId = 1L;
-        BiddingRequestDto requestDto = new BiddingRequestDto(1L, BigDecimal.valueOf(9999), "270");
+        BiddingRequestDto requestDto = BiddingRequestDto.of(1L, BigDecimal.valueOf(9999), "270");
 
         assertThrows(BadRequestException.class, () -> {
             usecase.registerBuyBid(userId, requestDto);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #39

## 🔎 작업 내용

- 기존에 있던 DTO를 record 클래스로 리팩터링
- 즉시구매가, 즉시판매가 조회 api 구현
- 즉시 거래 로직 및 주문 생성 api 구현
   - 주문 생성 후 cashclient를 통해 결제, 결제 실패 시 롤백

<br>

## 📷 테스트 결과
- 즉시구매가, 즉시판매가 조회 api 테스트
  <img width="50%" height="50%" alt="스크린샷 2026-01-19 220144" src="https://github.com/user-attachments/assets/705eb206-7f96-454b-a32a-cd98559e28e1" />
  <br>
- 즉시거래 및 주문 생성 api 테스트
  <img width="50%" height="50%" alt="스크린샷 2026-01-20 114825" src="https://github.com/user-attachments/assets/233cfbf7-536e-411a-b161-1760f56300b7" />

  <img width="50%" height="50%" alt="스크린샷 2026-01-20 114853" src="https://github.com/user-attachments/assets/759dcffc-b66e-4cce-b65e-3f4c37104c48" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수