### PR TITLE
[FEAT] 결제 요청 시 예치금/PG 분기 및 예치금 부분 홀딩 처리 (#64)

### DIFF
--- a/cash/src/main/java/com/back/cash/app/PayAndHoldUseCase.java
+++ b/cash/src/main/java/com/back/cash/app/PayAndHoldUseCase.java
@@ -7,8 +7,12 @@ import com.back.cash.domain.enums.PaymentStatus;
 import com.back.cash.dto.request.PayAndHoldRequestDto;
 import com.back.cash.dto.response.PayAndHoldResponseDto;
 import com.back.cash.mapper.PaymentMapper;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
@@ -22,29 +26,65 @@ public class PayAndHoldUseCase {
         Payment payment = paymentRepository.findByRelTypeAndRelId(dto.relType(), dto.relId())
                 .orElseGet(() -> paymentRepository.save(PaymentMapper.toPayment(dto)));
 
-        if (payment.getStatus() == PaymentStatus.DONE) {
-            return PaymentMapper.toPayAndHoldResponseDto(payment);
+        // 재호출일 경우 totalAmount가 다르면 에러 발생
+        if (payment.getTotalAmount().compareTo(dto.totalAmount()) != 0) {
+            throw new BadRequestException(FailureCode.AMOUNT_MISMATCH);
         }
 
-        processWalletDeduction(payment, dto.buyerId());
+        // 이미 완료된 결제면 PAID 응답
+        if (payment.getStatus() == PaymentStatus.DONE) {
+            return PaymentMapper.toPaidResponseDto(payment);
+        }
 
-        payment.markAsDone();
+        // 이미 PG 결제 필요 상태면 REQUIRES_PG 응답 반환 
+        if (isRequiresPgState(payment)) {
+            return PaymentMapper.toRequiresPgResponseDto(payment);
+        }
 
-        return PaymentMapper.toPayAndHoldResponseDto(payment);
-    }
-
-    private void processWalletDeduction(Payment payment, Long buyerId) {
-        Wallet buyerWallet = walletSupport.getUserWallet(buyerId);
+        Wallet buyerWallet = walletSupport.getUserWallet(dto.buyerId());
         Wallet systemWallet = walletSupport.getSystemWallet();
 
-        buyerWallet.withdraw(payment.getTotalAmount());
-        systemWallet.deposit(payment.getTotalAmount());
+        BigDecimal total = payment.getTotalAmount();
+        BigDecimal balance = buyerWallet.getBalance();
 
-        cashLogSupport.recordHoldingLog(
-                buyerWallet,
-                systemWallet,
-                payment.getTotalAmount(),
-                payment.getRelType(),
-                payment.getRelId());
+        BigDecimal walletUse = balance.min(total);
+        BigDecimal pgNeed = total.subtract(walletUse);
+
+        // 예치금 홀딩(가능한 만큼)
+        if (walletUse.signum() > 0) {
+            buyerWallet.withdraw(walletUse);
+            systemWallet.deposit(walletUse);
+
+            cashLogSupport.recordHoldingLog(
+                    buyerWallet,
+                    systemWallet,
+                    walletUse,
+                    payment.getRelType(),
+                    payment.getRelId()
+            );
+        }
+
+        payment.updateAmounts(walletUse, pgNeed);
+
+        // PG 필요 없으면 즉시 완료
+        if (pgNeed.signum() == 0) {
+            payment.markAsDone();
+
+            return PaymentMapper.toPaidResponseDto(payment);
+        }
+
+        // PG 필요하면 tossOrderId 발급 후 반환
+        payment.issueTossOrderIdIfAbsent(java.util.UUID.randomUUID().toString());
+
+        return PaymentMapper.toRequiresPgResponseDto(payment);
+    }
+
+    private boolean isRequiresPgState(Payment payment) {
+        return payment.getStatus() != PaymentStatus.DONE
+                && payment.getPgAmount() != null
+                && payment.getPgAmount().signum() > 0
+                && payment.getTossOrderId() != null;
     }
 }
+
+

--- a/cash/src/main/java/com/back/cash/domain/Payment.java
+++ b/cash/src/main/java/com/back/cash/domain/Payment.java
@@ -53,4 +53,15 @@ public class Payment extends BaseTimeEntity {
     public void markAsDone() {
         this.status = PaymentStatus.DONE;
     }
+
+    public void updateAmounts(BigDecimal walletUse, BigDecimal pgNeed) {
+        this.walletUsedAmount = walletUse;
+        this.pgAmount = pgNeed;
+    }
+
+    public void issueTossOrderIdIfAbsent(String tossOrderId) {
+        if (this.tossOrderId == null) {
+            this.tossOrderId = tossOrderId;
+        }
+    }
 }

--- a/cash/src/main/java/com/back/cash/mapper/PaymentMapper.java
+++ b/cash/src/main/java/com/back/cash/mapper/PaymentMapper.java
@@ -16,13 +16,16 @@ public class  PaymentMapper {
                 .relType(dto.relType())
                 .relId(dto.relId())
                 .totalAmount(dto.totalAmount())
-                .walletUsedAmount(dto.totalAmount())
+                .walletUsedAmount(BigDecimal.ZERO)
                 .pgAmount(BigDecimal.ZERO)
                 .status(PaymentStatus.READY)
                 .build();
     }
 
-    public static PayAndHoldResponseDto toPayAndHoldResponseDto(Payment payment) {
+    /**
+     * 예치금만으로 결제 완료(PAID) 응답
+     */
+    public static PayAndHoldResponseDto toPaidResponseDto(Payment payment) {
         return new PayAndHoldResponseDto(
                 PayAndHoldStatus.PAID,
                 payment.getRelType(),
@@ -30,6 +33,20 @@ public class  PaymentMapper {
                 payment.getWalletUsedAmount(),
                 BigDecimal.ZERO,
                 null
+        );
+    }
+
+    /**
+     * PG 필요(REQUIRES_PG) 응답
+     */
+    public static PayAndHoldResponseDto toRequiresPgResponseDto(Payment payment) {
+        return new PayAndHoldResponseDto(
+                PayAndHoldStatus.REQUIRES_PG,
+                payment.getRelType(),
+                payment.getRelId(),
+                payment.getWalletUsedAmount(),
+                payment.getPgAmount(),
+                payment.getTossOrderId()
         );
     }
 

--- a/cash/src/test/java/com/back/cash/PayAndHoldUseCaseTest.java
+++ b/cash/src/test/java/com/back/cash/PayAndHoldUseCaseTest.java
@@ -13,6 +13,8 @@ import com.back.cash.domain.enums.WalletType;
 import com.back.cash.dto.request.PayAndHoldRequestDto;
 import com.back.cash.dto.response.PayAndHoldResponseDto;
 import com.back.cash.mapper.PaymentMapper;
+import com.back.common.exception.BadRequestException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +26,7 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -42,54 +45,215 @@ class PayAndHoldUseCaseTest {
     @Mock
     private PaymentRepository paymentRepository;
 
+    private Long buyerId;
+    private Long relId;
+    private RelType relType;
+    private String orderName;
+
+    private Wallet buyerWallet;
+    private Wallet systemWallet;
+
+    @BeforeEach
+    void setUp() {
+        buyerId = 1L;
+        relId = 100L;
+        relType = RelType.ORDER;
+        orderName = "상품";
+    }
+
     @Test
-    @DisplayName("결제 요청 시 예치금이 충분하여 예치금 차감 결제인 경우 지갑 이동과 로그 기록이 호출된다")
-    void execute_Success() {
+    @DisplayName("[예치금 충분] balance >= total이면 예치금만으로 결제(PAID) + DONE 처리되고 홀딩 로그가 기록된다")
+    void execute_whenBalanceGreaterOrEqualTotal_thenPaidDone_andHoldLogged() {
         // given
-        Long buyerId = 1L;
-        BigDecimal amount = new BigDecimal("5000");
-        PayAndHoldRequestDto dto = new PayAndHoldRequestDto(RelType.ORDER, 100L, buyerId, amount, "나이키 운동화");
+        BigDecimal balance = bd("50000");
+        BigDecimal total = bd("30000");
 
-        Payment payment = PaymentMapper.toPayment(dto);
-
-        Wallet buyerWallet = spy(Wallet.builder()
-                .userId(buyerId)
-                .balance(amount)
-                .walletType(WalletType.USER)
-                .build());
-
-        Wallet systemWallet = spy(Wallet.builder()
-                .userId(null)
-                .balance(BigDecimal.ZERO)
-                .walletType(WalletType.SYSTEM)
-                .build());
-
-        given(paymentRepository.findByRelTypeAndRelId(any(), any())).willReturn(Optional.empty());
-        given(paymentRepository.save(any(Payment.class))).willReturn(payment);
-
-        given(walletSupport.getUserWallet(buyerId)).willReturn(buyerWallet);
-        given(walletSupport.getSystemWallet()).willReturn(systemWallet);
+        PayAndHoldRequestDto dto = dto(total);
+        Payment payment = givenNewPayment(dto);
+        givenWallets(balance);
 
         // when
         PayAndHoldResponseDto result = payAndHoldUseCase.execute(dto);
 
-        // Then: withdraw, deposit 메서드가 호출되었는가? (엔티티 상태 변경 확인)
-        assertThat(buyerWallet.getBalance()).isEqualByComparingTo(BigDecimal.ZERO);
-        assertThat(systemWallet.getBalance()).isEqualByComparingTo(amount);
+        // then: 지갑 이동(총액만큼 홀딩)
+        assertThat(buyerWallet.getBalance()).isEqualByComparingTo("20000");
+        assertThat(systemWallet.getBalance()).isEqualByComparingTo("30000");
 
-        assertThat(result.walletUsedAmount()).isEqualByComparingTo(amount);
+        // then: 응답
         assertThat(result.status()).isEqualTo(PayAndHoldStatus.PAID);
+        assertThat(result.walletUsedAmount()).isEqualByComparingTo("30000");
+        assertThat(result.pgRequiredAmount()).isEqualByComparingTo("0");
+        assertThat(result.tossOrderId()).isNull();
 
+        // then: payment 상태
         assertThat(payment.getStatus()).isEqualTo(PaymentStatus.DONE);
+        assertThat(payment.getWalletUsedAmount()).isEqualByComparingTo("30000");
+        assertThat(payment.getPgAmount()).isEqualByComparingTo("0");
 
+        // then: 홀딩 로그 기록(총액만큼)
+        verifyHoldingLogged("30000");
+    }
+
+    @Test
+    @DisplayName("[예치금 부분 부족] 0 < balance < total이면 부분 홀딩 후 REQUIRES_PG 응답을 반환하고 tossOrderId가 발급된다")
+    void execute_whenBalancePositiveButLessThanTotal_thenRequiresPg_andPartialHoldLogged() {
+        // given
+        BigDecimal balance = bd("12000");
+        BigDecimal total = bd("30000");
+
+        PayAndHoldRequestDto dto = dto(total);
+        Payment payment = givenNewPayment(dto);
+        givenWallets(balance);
+
+        // when
+        PayAndHoldResponseDto result = payAndHoldUseCase.execute(dto);
+
+        // then: 부분 홀딩(balance만큼)
+        assertThat(buyerWallet.getBalance()).isEqualByComparingTo("0");
+        assertThat(systemWallet.getBalance()).isEqualByComparingTo("12000");
+
+        // then: 응답(REQUIRES_PG)
+        assertThat(result.status()).isEqualTo(PayAndHoldStatus.REQUIRES_PG);
+        assertThat(result.walletUsedAmount()).isEqualByComparingTo("12000");
+        assertThat(result.pgRequiredAmount()).isEqualByComparingTo("18000");
+        assertThat(result.tossOrderId()).isNotNull();
+
+        // then: payment 상태(READY 유지)
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY);
+        assertThat(payment.getWalletUsedAmount()).isEqualByComparingTo("12000");
+        assertThat(payment.getPgAmount()).isEqualByComparingTo("18000");
+        assertThat(payment.getTossOrderId()).isNotNull();
+
+        // then: 홀딩 로그는 balance만큼
+        verifyHoldingLogged("12000");
+    }
+
+    @Test
+    @DisplayName("[예치금 부족-전액 PG] balance == 0이면 홀딩 없이 REQUIRES_PG 응답을 반환하고 tossOrderId가 발급된다")
+    void execute_whenBalanceZero_thenRequiresPg_andNoHoldingLog() {
+        // given
+        BigDecimal balance = bd("0");
+        BigDecimal total = bd("30000");
+
+        PayAndHoldRequestDto dto = dto(total);
+        Payment payment = givenNewPayment(dto);
+        givenWallets(balance);
+
+        // when
+        PayAndHoldResponseDto result = payAndHoldUseCase.execute(dto);
+
+        // then: 홀딩 없음
+        assertThat(buyerWallet.getBalance()).isEqualByComparingTo("0");
+        assertThat(systemWallet.getBalance()).isEqualByComparingTo("0");
+
+        // then: 응답(REQUIRES_PG)
+        assertThat(result.status()).isEqualTo(PayAndHoldStatus.REQUIRES_PG);
+        assertThat(result.walletUsedAmount()).isEqualByComparingTo("0");
+        assertThat(result.pgRequiredAmount()).isEqualByComparingTo("30000");
+        assertThat(result.tossOrderId()).isNotNull();
+
+        // then: payment 상태(READY 유지)
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY);
+        assertThat(payment.getWalletUsedAmount()).isEqualByComparingTo("0");
+        assertThat(payment.getPgAmount()).isEqualByComparingTo("30000");
+        assertThat(payment.getTossOrderId()).isNotNull();
+
+        // then: 홀딩 로그 없음
+        verify(cashLogSupport, never()).recordHoldingLog(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("[멱등 재호출] 이미 PG 필요 상태면 재호출 시 홀딩/로그 없이 동일 REQUIRES_PG 응답을 반환한다")
+    void execute_whenAlreadyRequiresPgState_thenIdempotentResponse_andNoMoreHolding() {
+        // given
+        BigDecimal total = bd("30000");
+        PayAndHoldRequestDto dto = dto(total);
+
+        Payment existing = Payment.builder()
+                .id(10L)
+                .userId(buyerId)
+                .relType(relType)
+                .relId(relId)
+                .totalAmount(total)
+                .walletUsedAmount(bd("12000"))
+                .pgAmount(bd("18000"))
+                .tossOrderId("existing-order-id")
+                .status(PaymentStatus.READY)
+                .build();
+
+        given(paymentRepository.findByRelTypeAndRelId(relType, relId)).willReturn(Optional.of(existing));
+
+        // when
+        PayAndHoldResponseDto result = payAndHoldUseCase.execute(dto);
+
+        // then: wallet/로그 로직 미진입
+        verify(walletSupport, never()).getUserWallet(anyLong());
+        verify(walletSupport, never()).getSystemWallet();
+        verify(cashLogSupport, never()).recordHoldingLog(any(), any(), any(), any(), any());
+
+        // then: 응답 동일
+        assertThat(result.status()).isEqualTo(PayAndHoldStatus.REQUIRES_PG);
+        assertThat(result.walletUsedAmount()).isEqualByComparingTo("12000");
+        assertThat(result.pgRequiredAmount()).isEqualByComparingTo("18000");
+        assertThat(result.tossOrderId()).isEqualTo("existing-order-id");
+    }
+
+    @Test
+    @DisplayName("[금액 불일치] 동일 relType/relId 재호출인데 totalAmount가 다르면 AMOUNT_MISMATCH 예외가 발생한다")
+    void execute_whenTotalAmountMismatch_thenThrowAmountMismatch() {
+        // given
+        PayAndHoldRequestDto first = dto(bd("30000"));
+        PayAndHoldRequestDto second = dto(bd("31000"));
+
+        Payment existing = PaymentMapper.toPayment(first);
+        given(paymentRepository.findByRelTypeAndRelId(relType, relId)).willReturn(Optional.of(existing));
+
+        // when / then
+        assertThatThrownBy(() -> payAndHoldUseCase.execute(second))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("결제 금액이 일치하지 않습니다.");
+    }
+
+    private PayAndHoldRequestDto dto(BigDecimal total) {
+        return new PayAndHoldRequestDto(relType, relId, buyerId, total, orderName);
+    }
+
+    private Payment givenNewPayment(PayAndHoldRequestDto dto) {
+        Payment payment = PaymentMapper.toPayment(dto);
+
+        given(paymentRepository.findByRelTypeAndRelId(relType, relId)).willReturn(Optional.empty());
+        given(paymentRepository.save(any(Payment.class))).willReturn(payment);
+
+        return payment;
+    }
+
+    private void givenWallets(BigDecimal buyerBalance) {
+        buyerWallet = Wallet.builder()
+                .userId(buyerId)
+                .balance(buyerBalance)
+                .walletType(WalletType.USER)
+                .build();
+
+        systemWallet = Wallet.builder()
+                .balance(BigDecimal.ZERO)
+                .walletType(WalletType.SYSTEM)
+                .build();
+
+        given(walletSupport.getUserWallet(buyerId)).willReturn(buyerWallet);
+        given(walletSupport.getSystemWallet()).willReturn(systemWallet);
+    }
+
+    private void verifyHoldingLogged(String amount) {
         verify(cashLogSupport, times(1)).recordHoldingLog(
                 eq(buyerWallet),
                 eq(systemWallet),
-                eq(amount),
-                eq(RelType.ORDER),
-                eq(100L)
+                eq(bd(amount)),
+                eq(relType),
+                eq(relId)
         );
-
     }
 
+    private static BigDecimal bd(String v) {
+        return new BigDecimal(v);
+    }
 }

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -26,7 +26,7 @@ public enum FailureCode {
     INVALID_BID_PRICE_SELL(HttpStatus.BAD_REQUEST, "INVALID_BID_PRICE_SELL","판매 입찰가는 즉시 판매가보다 높아야 합니다."),
     SELF_TRADING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "SELF_TRADING_NOT_ALLOWED", "본인의 입찰 상품과는 거래할 수 없습니다."),
     WALLET_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "WALLET_CHARGE_FAILED", "예치금 충전에 실패하였습니다."),
-
+    AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),
     /**
      * 401 Unauthorized
      */


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #64 

## 🔎 작업 내용

- 결제 요청시, 결제금액과 예치금 금액을 비교하여 예치금이 부족할 경우 PG사를 통한 결제 요청을 응답합니다. 
- 예치금은 먼저 홀딩하고 로그에 남깁니다, Payment테이블에 (tossOrderId, walletUsedAmount(예치금에서 사용 금액), pg_amount(PG사 요청 금액)를 기록합니다. 
- 같은 주문/거래로 결제요칭이 여러 번 호출돼도 기존 Payment를 재사용합니다. 
  - 이미 DONE면 그대로 PAID 응답 반환(추가 홀딩/로그 없음)) 
  - 이미 REQUIRES_PG 준비 상태면 추가 홀딩/로그 없이 동일 응답 반환 
  - 예치금이 부족해서 PG가 필요할 때만 tossOrderId(UUID)를 1번 발급합니다.
  - 재호출 시에는 새로 만들지 않고 기존 tossOrderId를 그대로 반환해서 결제 흐름이 끊기지 않게 합니다.
- 같은 (relType, relId)로 재호출인데 totalAmount가 다르면 AMOUNT_MISMATCH로 차단합니다.
<br>

## 📷 테스트 결과
- 사진에 대한 설명
  <br>
  <img width="748" height="516" alt="image" src="https://github.com/user-attachments/assets/0cb4a0cf-34fc-42f6-b6eb-2ca62d77cb66" />
<img width="1297" height="374" alt="image" src="https://github.com/user-attachments/assets/e5c76a21-7ced-4cd6-bf11-2bebc64f3383" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
