### PR TITLE
[FEAT] 알림 발송 파이프라인 구축 (SQS&Lambda) (#61)

### DIFF
--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
     // MongoDB
     implementation('org.springframework.boot:spring-boot-starter-data-mongodb')
+
+    // AWS SQS
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:4.0.0-RC1'
 }
 
 tasks.named('test') {

--- a/notification/src/main/java/com/back/notification/adapter/in/sqs/NotificationDispatchEventListener.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/sqs/NotificationDispatchEventListener.java
@@ -1,0 +1,19 @@
+package com.back.notification.adapter.in.sqs;
+
+import com.back.notification.adapter.out.sqs.NotificationEventPublisher;
+import com.back.notification.dto.NotificationCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationDispatchEventListener {
+    private final NotificationEventPublisher publisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(NotificationCreatedEvent event) {
+        publisher.send(event);
+    }
+}

--- a/notification/src/main/java/com/back/notification/adapter/out/NotificationUserRepository.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/NotificationUserRepository.java
@@ -3,11 +3,12 @@ package com.back.notification.adapter.out;
 import com.back.notification.domain.NotificationUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface NotificationUserRepository extends JpaRepository<NotificationUser, Long> {
 
     @Query("select u.fcmToken from NotificationUser u where u.id = :id")
-    Optional<String> findFcmTokenByUserId(Long userId);
+    Optional<String> findFcmTokenByUserId(@Param("id")Long userId);
 }

--- a/notification/src/main/java/com/back/notification/adapter/out/sqs/NotificationEventPublisher.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/sqs/NotificationEventPublisher.java
@@ -1,0 +1,62 @@
+package com.back.notification.adapter.out.sqs;
+
+import com.back.notification.app.NotificationSupport;
+import com.back.notification.app.NotificationUserSupport;
+import com.back.notification.domain.Notification;
+import com.back.notification.dto.NotificationCreatedEvent;
+import com.back.notification.dto.PushDispatchMessage;
+import com.back.notification.mapper.NotificationMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventPublisher {
+    private final SqsTemplate sqsTemplate;
+
+    private final NotificationSupport notificationSupport;
+    private final NotificationMapper mapper;
+    private final NotificationUserSupport notificationUserSupport;
+
+    @Value("${spring.cloud.aws.sqs.notification-queue}")
+    private String queue;
+
+    public void send(NotificationCreatedEvent event) {
+
+        for (String notificationId : event.notificationIds()) {
+            try {
+                Notification notification =
+                        notificationSupport.findById(notificationId);
+
+                String fcmToken =
+                        notificationUserSupport.findFcmToken(notification.getUserId());
+
+                if (fcmToken == null) {
+                    log.info("FCM 토큰 없음 - userId={}", notification.getUserId());
+                    continue;
+                }
+
+                PushDispatchMessage payload =
+                        mapper.toPushDispatchMessage(notification, fcmToken);
+
+                sqsTemplate.send(to -> to
+                        .queue(queue)
+                        .payload(payload)
+                );
+
+
+            } catch (Exception e) {
+                log.error(
+                        "알림 전송 실패 - notificationId={}, error={}",
+                        notificationId,
+                        e.getMessage(),
+                        e
+                );
+            }
+        }
+    }
+}

--- a/notification/src/main/java/com/back/notification/adapter/out/sqs/SqsConfig.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/sqs/SqsConfig.java
@@ -1,0 +1,35 @@
+package com.back.notification.adapter.out.sqs;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+@Configuration
+public class SqsConfig {
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    String accessKey;
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    String secretKey;
+
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                        accessKey,
+                        secretKey
+                )
+        );
+    }
+
+    @Bean
+    public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient) {
+        return SqsTemplate.builder()
+                .sqsAsyncClient(sqsAsyncClient)
+                .build();
+    }
+}

--- a/notification/src/main/java/com/back/notification/app/NotificationFacade.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationFacade.java
@@ -3,26 +3,41 @@ package com.back.notification.app;
 import com.back.notification.app.strategy.NotificationStrategyRegistry;
 import com.back.notification.domain.Notification;
 import com.back.notification.app.strategy.NotificationStrategy;
+import com.back.notification.dto.NotificationMessage;
 import com.back.notification.domain.enums.Type;
+import com.back.notification.mapper.NotificationMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationFacade {
 
     private final NotificationSaveUsecase notificationSaveUsecase;
-
     private final NotificationStrategyRegistry strategyRegistry;
+    private final NotificationMessageFactory notificationMessageFactory;
+    private final NotificationMapper mapper;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     public <T> void notify(Type type, T event) {
         NotificationStrategy<T> strategy = strategyRegistry.get(type);
 
         List<Notification> notifications = strategy.create(event);
 
+        Locale locale = Locale.KOREA;
+        notifications.forEach(notification -> {
+            NotificationMessage message = notificationMessageFactory.create(notification, locale);
+            notification.applyMessage(message, locale);
+        });
+
         notificationSaveUsecase.saveAll(notifications);
+
+        eventPublisher.publishEvent(mapper.toNotificationCreatedEvent(notifications));
     }
 
 }

--- a/notification/src/main/java/com/back/notification/app/NotificationMessageFactory.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationMessageFactory.java
@@ -84,7 +84,7 @@ public class NotificationMessageFactory {
             case SETTLEMENT_COMPLETED -> new TemplateSpec(
                     "notification.settlement.completed",
                     new Object[]{
-                            /* month */ 10,
+                            10, // 정산 월 (임시 하드코딩, 추후 이벤트 값으로 교체 예정)
                             c.get("endAt"),
                             c.get("totalNetAmount")
                     }

--- a/notification/src/main/java/com/back/notification/app/NotificationMessageFactory.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationMessageFactory.java
@@ -1,0 +1,94 @@
+package com.back.notification.app;
+
+import com.back.notification.domain.Notification;
+import com.back.notification.dto.NotificationMessage;
+import com.back.notification.domain.TemplateSpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationMessageFactory {
+
+    private final MessageSource messageSource;
+
+    public NotificationMessage create(Notification notification, Locale locale) {
+        TemplateSpec spec = extract(notification);
+
+        String title = messageSource.getMessage(
+                spec.templateKey() + ".title",
+                spec.args(),
+                locale
+        );
+
+        String body = messageSource.getMessage(
+                spec.templateKey() + ".body",
+                spec.args(),
+                locale
+        );
+
+        return new NotificationMessage(title, body);
+    }
+
+    private TemplateSpec extract(Notification notification) {
+        Map<String, Object> c = notification.getContent();
+
+        return switch (notification.getType()) {
+            case BID_COMPLETED -> new TemplateSpec(
+                    "notification.bid.completed",
+                    new Object[]{
+                            c.get("productName"),
+                            c.get("productSize"),
+                            c.get("price")
+                    }
+            );
+
+            case BID_FAILED -> new TemplateSpec(
+                    "notification.bid.failed",
+                    new Object[]{
+                            c.get("productName"),
+                            c.get("productSize"),
+                            c.get("price")
+                    }
+            );
+
+            case PURCHASE_CANCELED -> new TemplateSpec(
+                    "notification.purchase.canceled",
+                    new Object[]{
+                            c.get("productName"),
+                            c.get("productSize")
+                    }
+            );
+
+            case INSPECTION_COMPLETED -> new TemplateSpec(
+                    "notification.inspection.completed",
+                    new Object[]{
+                            c.get("productName"),
+                            c.get("productSize")
+                    }
+            );
+
+            case PRICE_DROPPED -> new TemplateSpec(
+                    "notification.price.dropped",
+                    new Object[]{
+                            c.get("productName"),
+                            c.get("productSize"),
+                            c.get("targetPrice")
+                    }
+            );
+
+            case SETTLEMENT_COMPLETED -> new TemplateSpec(
+                    "notification.settlement.completed",
+                    new Object[]{
+                            /* month */ 10,
+                            c.get("endAt"),
+                            c.get("totalNetAmount")
+                    }
+            );
+        };
+    }
+}

--- a/notification/src/main/java/com/back/notification/app/NotificationSupport.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationSupport.java
@@ -1,0 +1,19 @@
+package com.back.notification.app;
+
+import com.back.notification.adapter.out.NotificationRepository;
+import com.back.notification.domain.Notification;
+import com.back.notification.exception.NotificationNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class NotificationSupport {
+    private final NotificationRepository notificationRepository;
+
+   public Notification findById(String id) {
+       return notificationRepository.findById(id)
+               .orElseThrow(NotificationNotFoundException::new);
+   }
+
+}

--- a/notification/src/main/java/com/back/notification/app/NotificationUserSupport.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationUserSupport.java
@@ -1,0 +1,16 @@
+package com.back.notification.app;
+
+import com.back.notification.adapter.out.NotificationUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationUserSupport {
+    private final NotificationUserRepository notificationUserRepository;
+
+    public String findFcmToken(Long userId) {
+        return notificationUserRepository.findFcmTokenByUserId(userId)
+                .orElse(null);
+    }
+}

--- a/notification/src/main/java/com/back/notification/domain/Notification.java
+++ b/notification/src/main/java/com/back/notification/domain/Notification.java
@@ -2,6 +2,7 @@ package com.back.notification.domain;
 
 import com.back.common.entity.MongoBaseEntity;
 import com.back.notification.domain.enums.Type;
+import com.back.notification.dto.NotificationMessage;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.Locale;
 import java.util.Map;
 
 @Getter
@@ -22,6 +24,10 @@ public class Notification extends MongoBaseEntity {
 
     private Long userId;
 
+    private String title;
+    private String body;
+    private String locale;  // ko, en
+
     private Type type;
 
     private Map<String, Object> content;
@@ -30,4 +36,9 @@ public class Notification extends MongoBaseEntity {
 
     private boolean isRead;
 
+    public void applyMessage(NotificationMessage message, Locale locale) {
+        this.title = message.title();
+        this.body = message.body();
+        this.locale = locale.getLanguage(); // "ko", "en"
+    }
 }

--- a/notification/src/main/java/com/back/notification/domain/TemplateSpec.java
+++ b/notification/src/main/java/com/back/notification/domain/TemplateSpec.java
@@ -1,0 +1,7 @@
+package com.back.notification.domain;
+
+public record TemplateSpec(
+        String templateKey,
+        Object[] args
+) {
+}

--- a/notification/src/main/java/com/back/notification/dto/NotificationCreatedEvent.java
+++ b/notification/src/main/java/com/back/notification/dto/NotificationCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.back.notification.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationCreatedEvent(
+        List<String> notificationIds
+) {
+}

--- a/notification/src/main/java/com/back/notification/dto/NotificationMessage.java
+++ b/notification/src/main/java/com/back/notification/dto/NotificationMessage.java
@@ -1,0 +1,7 @@
+package com.back.notification.dto;
+
+public record NotificationMessage(
+        String title,
+        String body
+) {
+}

--- a/notification/src/main/java/com/back/notification/dto/PushDispatchMessage.java
+++ b/notification/src/main/java/com/back/notification/dto/PushDispatchMessage.java
@@ -1,0 +1,12 @@
+package com.back.notification.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PushDispatchMessage (
+        String title,
+        String body,
+        String fcmToken,
+        String deepLink
+){
+}

--- a/notification/src/main/java/com/back/notification/exception/NotificationNotFoundException.java
+++ b/notification/src/main/java/com/back/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,10 @@
+package com.back.notification.exception;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+
+public class NotificationNotFoundException extends CustomException {
+    public NotificationNotFoundException(){
+        super("존재하지 않는 알림입니다.", FailureCode.ENTITY_NOT_FOUND);
+    }
+}

--- a/notification/src/main/java/com/back/notification/mapper/NotificationMapper.java
+++ b/notification/src/main/java/com/back/notification/mapper/NotificationMapper.java
@@ -10,8 +10,11 @@ import com.back.notification.domain.Notification;
 import com.back.notification.domain.NotificationProduct;
 import com.back.notification.domain.enums.NotificationTargetRole;
 import com.back.notification.domain.enums.Type;
+import com.back.notification.dto.NotificationCreatedEvent;
+import com.back.notification.dto.PushDispatchMessage;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -122,6 +125,25 @@ public class NotificationMapper {
                 ))
                 .deepLink("/products/" + event.productId())     // Todo : 실제 딥링크로 수정
                 .isRead(false)
+                .build();
+    }
+
+    public NotificationCreatedEvent toNotificationCreatedEvent(List<Notification> notifications) {
+        return NotificationCreatedEvent.builder()
+                .notificationIds(notifications
+                        .stream()
+                        .map(Notification::getId)
+                        .toList()
+                )
+                .build();
+    }
+
+    public PushDispatchMessage toPushDispatchMessage(Notification notification, String fcmToken) {
+        return PushDispatchMessage.builder()
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .deepLink(notification.getDeepLink())
+                .fcmToken(fcmToken)
                 .build();
     }
 }

--- a/notification/src/main/resources/messages_ko.properties
+++ b/notification/src/main/resources/messages_ko.properties
@@ -1,0 +1,40 @@
+############################################
+# BID COMPLETED
+############################################
+notification.bid.completed.title=Resello
+notification.bid.completed.body=[{0}] [사이즈 {1}] 상품 거래가 {2,number,#,###}원에 확정되었습니다.
+
+
+############################################
+# BID FAILED
+############################################
+notification.bid.failed.title=Resello
+notification.bid.failed.body=[{0}] [사이즈 {1}] {2,number,#,###}원 거래가 성사되지 않았습니다.
+
+
+############################################
+# PURCHASE CANCELED
+############################################
+notification.purchase.canceled.title=Resello
+notification.purchase.canceled.body=[{0}] [사이즈 {1}] 상품의 구매가 취소되어 거래가 성사되지 않았습니다.
+
+
+############################################
+# INSPECTION COMPLETED
+############################################
+notification.inspection.completed.title=Resello
+notification.inspection.completed.body=[{0}] [사이즈 {1}] 상품 검수가 완료되었습니다.
+
+
+############################################
+# PRICE DROPPED
+############################################
+notification.price.dropped.title=Resello
+notification.price.dropped.body=[{0}] [사이즈 {1}] 상품 가격이 {2,number,#,###}원으로 하락하였습니다.
+
+
+############################################
+# SETTLEMENT COMPLETED
+############################################
+notification.settlement.completed.title=Resello
+notification.settlement.completed.body=[{0} 정산] {1} 지급 완료 (총 {2,number,#,###}원)


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #61 

## 🔎 작업 내용

- 알림 발송 파이프라인(SQS → Lambda → FCM) 연동 완료
- PushDispatchMessage 기반으로 알림 payload 구조 정리
  - title / body / fcmToken / deepLink 분리
- Lambda에서 SQS 메시지 JSON 파싱 하여 
- MessageSource 기반 알림 메시지 템플릿(messages_ko.properties) 추가

<br>


## 📌 참고 사항
- 기타 안내 사항
  - 정산 월은 하드코딩 되어있어서 다음 PR에서 수정 예정입니다
- 주의해야 할 점 <!--(선택 사항)-->
    - 운영 환경에서는 반드시 클라이언트에서 토큰 갱신 API 호출 필요

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 거래 실패 알림
<img width="388" height="180" alt="image" src="https://github.com/user-attachments/assets/c10d7c7b-1429-4dc1-9154-f0792d0e2b08" />
- 가격 하락 알림
<img width="381" height="192" alt="image" src="https://github.com/user-attachments/assets/b9da4bc0-d5a8-4d00-a2be-64f52511289a" />



<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
