### PR TITLE
[FEAT] 알림 생성 및 조회 API 구현 #73

### DIFF
--- a/notification/src/main/java/com/back/notification/adapter/in/ApiV1NotificationController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/ApiV1NotificationController.java
@@ -1,0 +1,33 @@
+package com.back.notification.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.notification.app.NotificationFacade;
+import com.back.notification.dto.NotificationIdResponseDto;
+import com.back.security.principal.AuthPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class ApiV1NotificationController implements NotificationController {
+
+    private final NotificationFacade notificationFacade;
+
+    @Override
+    @PatchMapping("/{notificationId}")
+    public CommonResponse<NotificationIdResponseDto> markAsRead(
+            @AuthenticationPrincipal AuthPrincipal authPrincipal,
+            @PathVariable String notificationId
+    ) {
+        NotificationIdResponseDto response =
+                notificationFacade.markUserNotificationAsRead(authPrincipal.getUserId(), notificationId);
+
+        return CommonResponse.successWithData(HttpStatus.OK, response);
+    }
+}

--- a/notification/src/main/java/com/back/notification/adapter/in/ApiV1NotificationController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/ApiV1NotificationController.java
@@ -3,14 +3,12 @@ package com.back.notification.adapter.in;
 import com.back.common.response.CommonResponse;
 import com.back.notification.app.NotificationFacade;
 import com.back.notification.dto.NotificationIdResponseDto;
+import com.back.notification.dto.response.NotificationListResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/notifications")
@@ -18,6 +16,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApiV1NotificationController implements NotificationController {
 
     private final NotificationFacade notificationFacade;
+
+    @GetMapping()
+    @Override
+    public CommonResponse<NotificationListResponseDto> getNotifications(
+            @AuthenticationPrincipal AuthPrincipal authPrincipal,
+            @RequestParam(value = "page", defaultValue = "0") int pageNumber,
+            @RequestParam(value = "size", defaultValue = "20") int pageSize) {
+        NotificationListResponseDto response = notificationFacade.getRecentNotifications(
+                authPrincipal.getUserId(), pageNumber, pageSize);
+
+        return CommonResponse.successWithData(HttpStatus.OK, response);
+    }
 
     @Override
     @PatchMapping("/{notificationId}")

--- a/notification/src/main/java/com/back/notification/adapter/in/ApiV1NotificationController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/ApiV1NotificationController.java
@@ -1,12 +1,12 @@
 package com.back.notification.adapter.in;
 
+import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.notification.app.NotificationFacade;
 import com.back.notification.dto.NotificationIdResponseDto;
 import com.back.notification.dto.response.NotificationListResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +26,7 @@ public class ApiV1NotificationController implements NotificationController {
         NotificationListResponseDto response = notificationFacade.getRecentNotifications(
                 authPrincipal.getUserId(), pageNumber, pageSize);
 
-        return CommonResponse.successWithData(HttpStatus.OK, response);
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 
     @Override
@@ -38,6 +38,6 @@ public class ApiV1NotificationController implements NotificationController {
         NotificationIdResponseDto response =
                 notificationFacade.markUserNotificationAsRead(authPrincipal.getUserId(), notificationId);
 
-        return CommonResponse.successWithData(HttpStatus.OK, response);
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/notification/src/main/java/com/back/notification/adapter/in/NotificationController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/NotificationController.java
@@ -2,14 +2,48 @@ package com.back.notification.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.notification.dto.NotificationIdResponseDto;
+import com.back.notification.dto.response.NotificationListResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Notification", description = "알림 관련 API")
 public interface NotificationController {
+
+    @Operation(
+            summary = "최근 알림 조회",
+            description = """
+                사용자의 최근 알림 목록을 조회합니다.
+                읽음 여부와 관계없이 생성일 기준 최신 순으로 반환됩니다.
+                페이징을 위해 `page`(페이지 번호)와 `size`(페이지 크기)를 지원합니다.
+                """
+    )
+    @Parameters({
+            @Parameter(
+                    name = "page",
+                    description = "조회할 페이지 번호 (0부터 시작)",
+                    example = "0"
+            ),
+            @Parameter(
+                    name = "size",
+                    description = "페이지당 항목 수",
+                    example = "20"
+            )
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공적으로 알림 목록을 반환함")
+    })
+    CommonResponse<NotificationListResponseDto> getNotifications(
+            @AuthenticationPrincipal AuthPrincipal authPrincipal,
+            @RequestParam("page") int pageNumber,
+            @RequestParam("size") int pageSize);
 
     @Operation(summary = "알림 읽음 처리", description = "사용자의 특정 알림을 읽음 처리합니다.")
     @ApiResponse(responseCode = "200", description = "읽음 처리 성공")

--- a/notification/src/main/java/com/back/notification/adapter/in/NotificationController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/NotificationController.java
@@ -1,0 +1,23 @@
+package com.back.notification.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.notification.dto.NotificationIdResponseDto;
+import com.back.security.principal.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Notification", description = "알림 관련 API")
+public interface NotificationController {
+
+    @Operation(summary = "알림 읽음 처리", description = "사용자의 특정 알림을 읽음 처리합니다.")
+    @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content)
+    @ApiResponse(responseCode = "404", description = "알림 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<NotificationIdResponseDto> markAsRead(AuthPrincipal principal,
+                                                         String notificationId);
+
+}

--- a/notification/src/main/java/com/back/notification/adapter/out/NotificationRepository.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/NotificationRepository.java
@@ -1,8 +1,11 @@
 package com.back.notification.adapter.out;
 
 import com.back.notification.domain.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface NotificationRepository extends MongoRepository<Notification, String>,
         NotificationRepositoryCustom {
+    Slice<Notification> findPageByUserId(Pageable pageable, Long userId);
 }

--- a/notification/src/main/java/com/back/notification/adapter/out/NotificationRepository.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/NotificationRepository.java
@@ -3,5 +3,6 @@ package com.back.notification.adapter.out;
 import com.back.notification.domain.Notification;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface NotificationRepository extends MongoRepository<Notification, String> {
+public interface NotificationRepository extends MongoRepository<Notification, String>,
+        NotificationRepositoryCustom {
 }

--- a/notification/src/main/java/com/back/notification/adapter/out/NotificationRepositoryCustom.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/NotificationRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.back.notification.adapter.out;
+
+public interface NotificationRepositoryCustom {
+    void markAsRead(String notificationId);
+}

--- a/notification/src/main/java/com/back/notification/adapter/out/NotificationRepositoryCustomImpl.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,27 @@
+package com.back.notification.adapter.out;
+
+import com.back.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom{
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void markAsRead(String notificationId) {
+        Query query = Query.query(Criteria.where("_id").is(notificationId));
+        Update update = new Update()
+                .set("isRead", true)
+                .set("updatedAt", LocalDateTime.now());
+
+        mongoTemplate.updateFirst(query, update, Notification.class);
+    }
+}

--- a/notification/src/main/java/com/back/notification/app/NotificationFacade.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationFacade.java
@@ -7,10 +7,15 @@ import com.back.notification.domain.NotificationUser;
 import com.back.notification.dto.NotificationIdResponseDto;
 import com.back.notification.dto.NotificationMessage;
 import com.back.notification.domain.enums.Type;
+import com.back.notification.dto.response.NotificationListResponseDto;
 import com.back.notification.exception.NotificationAccessDeniedException;
 import com.back.notification.mapper.NotificationMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,5 +71,17 @@ public class NotificationFacade {
         if(!notification.getUserId().equals(user.getId())) {
             throw new NotificationAccessDeniedException();
         }
+    }
+
+    public NotificationListResponseDto getRecentNotifications(Long userId, int pageNumber, int pageSize) {
+        NotificationUser user = notificationUserSupport.findById(userId);
+        Pageable pageable = PageRequest.of(pageNumber,
+                pageSize,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Slice<Notification> notifications = notificationSupport.findRecentNotifications(user, pageable);
+
+        return mapper.toNotificationListResponseDto(notifications);
     }
 }

--- a/notification/src/main/java/com/back/notification/app/NotificationMessageFactory.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationMessageFactory.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.Locale;
 import java.util.Map;
 
@@ -81,14 +84,22 @@ public class NotificationMessageFactory {
                     }
             );
 
-            case SETTLEMENT_COMPLETED -> new TemplateSpec(
-                    "notification.settlement.completed",
-                    new Object[]{
-                            10, // 정산 월 (임시 하드코딩, 추후 이벤트 값으로 교체 예정)
-                            c.get("endAt"),
-                            c.get("totalNetAmount")
-                    }
-            );
+            case SETTLEMENT_COMPLETED -> {
+                LocalDate startDate = ((LocalDateTime) c.get("startAt")).toLocalDate();
+                LocalDate endDate = ((LocalDateTime) c.get("endAt")).toLocalDate();
+                YearMonth settlementMonth = YearMonth.from(startDate);
+
+                yield new TemplateSpec(
+                        "notification.settlement.completed",
+                        new Object[]{
+                                settlementMonth.getMonthValue(),
+                                java.sql.Date.valueOf(startDate),
+                                java.sql.Date.valueOf(endDate),
+                                c.get("totalNetAmount")
+                        }
+                );
+            }
+
         };
     }
 }

--- a/notification/src/main/java/com/back/notification/app/NotificationSupport.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationSupport.java
@@ -2,9 +2,12 @@ package com.back.notification.app;
 
 import com.back.notification.adapter.out.NotificationRepository;
 import com.back.notification.domain.Notification;
+import com.back.notification.domain.NotificationUser;
 import com.back.notification.exception.NotificationNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 @Configuration
 @RequiredArgsConstructor
@@ -16,4 +19,8 @@ public class NotificationSupport {
                .orElseThrow(NotificationNotFoundException::new);
    }
 
+    public Slice<Notification> findRecentNotifications(NotificationUser user, Pageable pageable) {
+       return notificationRepository
+               .findPageByUserId(pageable, user.getId());
+    }
 }

--- a/notification/src/main/java/com/back/notification/app/NotificationUpdateUsecase.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationUpdateUsecase.java
@@ -1,0 +1,15 @@
+package com.back.notification.app;
+
+import com.back.notification.adapter.out.NotificationRepository;
+import com.back.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationUpdateUsecase {
+    private final NotificationRepository notificationRepository;
+    public void markUserNotificationAsRead(Notification notification) {
+        notificationRepository.markAsRead(notification.getId());
+    }
+}

--- a/notification/src/main/java/com/back/notification/app/NotificationUserSupport.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationUserSupport.java
@@ -1,6 +1,8 @@
 package com.back.notification.app;
 
 import com.back.notification.adapter.out.NotificationUserRepository;
+import com.back.notification.domain.NotificationUser;
+import com.back.notification.exception.NotificationUserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,5 +14,10 @@ public class NotificationUserSupport {
     public String findFcmToken(Long userId) {
         return notificationUserRepository.findFcmTokenByUserId(userId)
                 .orElse(null);
+    }
+
+    public NotificationUser findById(Long userId) {
+        return notificationUserRepository.findById(userId)
+                .orElseThrow(NotificationUserNotFoundException::new);
     }
 }

--- a/notification/src/main/java/com/back/notification/dto/NotificationIdResponseDto.java
+++ b/notification/src/main/java/com/back/notification/dto/NotificationIdResponseDto.java
@@ -1,0 +1,9 @@
+package com.back.notification.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationIdResponseDto(
+        String id
+) {
+}

--- a/notification/src/main/java/com/back/notification/dto/response/NotificationListResponseDto.java
+++ b/notification/src/main/java/com/back/notification/dto/response/NotificationListResponseDto.java
@@ -1,0 +1,12 @@
+package com.back.notification.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationListResponseDto(
+        List<NotificationResponseDto> notificationResponses,
+        boolean hasNext
+) {
+}

--- a/notification/src/main/java/com/back/notification/dto/response/NotificationResponseDto.java
+++ b/notification/src/main/java/com/back/notification/dto/response/NotificationResponseDto.java
@@ -1,0 +1,18 @@
+package com.back.notification.dto.response;
+
+import com.back.notification.domain.enums.Type;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record NotificationResponseDto (
+        String id,
+        String title,
+        String body,
+        String deepLink,
+        Type type,
+        boolean isRead,
+        LocalDateTime createdAt
+) {
+}

--- a/notification/src/main/java/com/back/notification/exception/NotificationAccessDeniedException.java
+++ b/notification/src/main/java/com/back/notification/exception/NotificationAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.back.notification.exception;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+
+public class NotificationAccessDeniedException extends CustomException {
+    public NotificationAccessDeniedException(){
+        super("해당 알림에 접근할 수 없습니다.", FailureCode.FORBIDDEN);
+    }
+}

--- a/notification/src/main/java/com/back/notification/mapper/NotificationMapper.java
+++ b/notification/src/main/java/com/back/notification/mapper/NotificationMapper.java
@@ -11,6 +11,7 @@ import com.back.notification.domain.NotificationProduct;
 import com.back.notification.domain.enums.NotificationTargetRole;
 import com.back.notification.domain.enums.Type;
 import com.back.notification.dto.NotificationCreatedEvent;
+import com.back.notification.dto.NotificationIdResponseDto;
 import com.back.notification.dto.PushDispatchMessage;
 import org.springframework.stereotype.Component;
 
@@ -144,6 +145,12 @@ public class NotificationMapper {
                 .body(notification.getBody())
                 .deepLink(notification.getDeepLink())
                 .fcmToken(fcmToken)
+                .build();
+    }
+
+    public NotificationIdResponseDto toNotificationIdResponseDto(Notification notification) {
+        return NotificationIdResponseDto.builder()
+                .id(notification.getId())
                 .build();
     }
 }

--- a/notification/src/main/java/com/back/notification/mapper/NotificationMapper.java
+++ b/notification/src/main/java/com/back/notification/mapper/NotificationMapper.java
@@ -13,6 +13,9 @@ import com.back.notification.domain.enums.Type;
 import com.back.notification.dto.NotificationCreatedEvent;
 import com.back.notification.dto.NotificationIdResponseDto;
 import com.back.notification.dto.PushDispatchMessage;
+import com.back.notification.dto.response.NotificationListResponseDto;
+import com.back.notification.dto.response.NotificationResponseDto;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -151,6 +154,29 @@ public class NotificationMapper {
     public NotificationIdResponseDto toNotificationIdResponseDto(Notification notification) {
         return NotificationIdResponseDto.builder()
                 .id(notification.getId())
+                .build();
+    }
+
+    public NotificationListResponseDto toNotificationListResponseDto(Slice<Notification> notifications) {
+        return NotificationListResponseDto.builder()
+                .notificationResponses(
+                        notifications.getContent().stream()
+                                .map(this::toNotificationResponseDto)
+                                .toList()
+                )
+                .hasNext(notifications.hasNext())
+                .build();
+    }
+
+    private NotificationResponseDto toNotificationResponseDto(Notification notification) {
+        return NotificationResponseDto.builder()
+                .id(notification.getId())
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .deepLink(notification.getDeepLink())
+                .type(notification.getType())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
                 .build();
     }
 }

--- a/notification/src/main/resources/messages_ko.properties
+++ b/notification/src/main/resources/messages_ko.properties
@@ -37,4 +37,4 @@ notification.price.dropped.body=[{0}] [사이즈 {1}] 상품 가격이 {2,number
 # SETTLEMENT COMPLETED
 ############################################
 notification.settlement.completed.title=Resello
-notification.settlement.completed.body=[{0} 정산] {1} 지급 완료 (총 {2,number,#,###}원)
+notification.settlement.completed.body=[{0}월 정산] {1,date,yyyy-MM-dd} ~ {2,date,yyyy-MM-dd} 정산 완료 (총 {3,number,#,###}원)


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #73 

## 🔎 작업 내용

- 알림 조회 API 구현 (페이징 + 최신순 조회)
- 알림 읽음 처리 기능 추가
- 정산 완료 알림 메시지 템플릿 수정
  - 정산 월(startAt 기반) 표시 추가
  - 메시지 형식: `[{0}월 정산] {1,date,yyyy-MM-dd} ~ {2,date,yyyy-MM-dd} 정산 완료 (총 {3,number,#,###}원)` 적용


<br>


## 📌 참고 사항

- 기타 안내 사항 <!--(선택 사항)-->
    - LocalDateTime → java.sql.Date 변환으로 MessageFormat 호환 처리
    - 응답 메세지와 코
- 주의해야 할 점
  - 다국어(i18n) 확장 시 {0}월 처리 방식 (Month display) 추가 검토 필요
  - 다국어 처리 가능하도록 확장성 있게 설계했어서 주의할 점에 씁니다
 
<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 알림 조회

```json
{
    "code": "OK",
    "data": {
        "notificationResponses": [
            {
                "id": "69703e063839624ca3728066",
                "title": "Resello",
                "body": "[1월 정산] 2026-01-01 ~ 2026-01-31 정산 완료 (총 1,254,000원)",
                "deepLink": "/settlements/1",
                "type": "SETTLEMENT_COMPLETED",
                "isRead": false,
                "createdAt": "2026-01-21T11:46:30.008"
            },
            {
                "id": "69703a876292ecfab910901d",
                "title": "Resello",
                "body": "[1월 정산] 2026-01-01 ~ 2026-01-31 정산 완료 (총 1,254,000원)",
                "deepLink": "/settlements/1",
                "type": "SETTLEMENT_COMPLETED",
                "isRead": false,
                "createdAt": "2026-01-21T11:31:35.232"
            },
            {
                "id": "696efa2c269621270c3f8b2e",
                "title": "Resello",
                "body": "[나이키 에어 포스 1 ’07 WB] [사이즈 270] 상품 가격이 9,000원으로 하락하였습니다.",
                "deepLink": "/products/1001",
                "type": "PRICE_DROPPED",
                "isRead": false,
                "createdAt": "2026-01-20T12:44:44.721"
            },
            {
                "id": "696ef9c7594a86cc16fc38ac",
                "title": "Resello",
                "body": "구매하신 [아디다스 이지부스트 350] [사이즈 265] 상품의 구매가 취소되어 거래가 성사되지 않았습니다.",
                "deepLink": "/biddings/12345",
                "type": "PURCHASE_CANCELED",
                "isRead": false,
                "createdAt": "2026-01-20T12:43:03.139"
            },
            {
                "id": "696ef9bb594a86cc16fc38aa",
                "title": "Resello",
                "body": "[나이키 에어 포스 1 '07] [사이즈 270] 상품 거래가 54,000원에 확정되었습니다.",
                "deepLink": "/biddings/1",
                "type": "BID_COMPLETED",
                "isRead": false,
                "createdAt": "2026-01-20T12:42:51.516"
            }
        ],
        "hasNext": true
    },
    "message": "요청이 성공했습니다.",
    "status": 200
}
```
- 정산 알림
<img width="384" height="176" alt="image" src="https://github.com/user-attachments/assets/9fbeb53e-0147-4c5e-b9d7-af3e2cffe430" />
<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
