### PR TITLE
[FEAT] 사용자 FCM 토큰 관리 API 추가 (#82)

### DIFF
--- a/user/src/main/java/com/back/user/adapter/in/ApiV1UserController.java
+++ b/user/src/main/java/com/back/user/adapter/in/ApiV1UserController.java
@@ -6,6 +6,7 @@ import com.back.security.principal.AuthPrincipal;
 import com.back.user.app.UserFacade;
 import com.back.user.dto.request.UpdateFcmTokenRequest;
 import com.back.user.dto.response.UserIdResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,7 +23,7 @@ public class ApiV1UserController implements UserApiV1 {
     @Override
     @PatchMapping("/me/fcm-token")
     public CommonResponse<UserIdResponse> registerOrUpdateFcmToken(@AuthenticationPrincipal AuthPrincipal authPrincipal,
-                                                      @RequestBody UpdateFcmTokenRequest request) {
+                                                      @Valid @RequestBody UpdateFcmTokenRequest request) {
         UserIdResponse response = userFacade.registerOrUpdateFcmToken(authPrincipal.getUserId(), request);
         return CommonResponse.success(SuccessCode.OK, response);
     }

--- a/user/src/main/java/com/back/user/adapter/in/ApiV1UserController.java
+++ b/user/src/main/java/com/back/user/adapter/in/ApiV1UserController.java
@@ -1,0 +1,29 @@
+package com.back.user.adapter.in;
+
+import com.back.common.code.SuccessCode;
+import com.back.common.response.CommonResponse;
+import com.back.security.principal.AuthPrincipal;
+import com.back.user.app.UserFacade;
+import com.back.user.dto.request.UpdateFcmTokenRequest;
+import com.back.user.dto.response.UserIdResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class ApiV1UserController implements UserApiV1 {
+    private final UserFacade userFacade;
+
+    @Override
+    @PatchMapping("/me/fcm-token")
+    public CommonResponse<UserIdResponse> registerOrUpdateFcmToken(@AuthenticationPrincipal AuthPrincipal authPrincipal,
+                                                      @RequestBody UpdateFcmTokenRequest request) {
+        UserIdResponse response = userFacade.registerOrUpdateFcmToken(authPrincipal.getUserId(), request);
+        return CommonResponse.success(SuccessCode.OK, response);
+    }
+}

--- a/user/src/main/java/com/back/user/adapter/in/UserApiV1.java
+++ b/user/src/main/java/com/back/user/adapter/in/UserApiV1.java
@@ -1,0 +1,31 @@
+package com.back.user.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.security.principal.AuthPrincipal;
+import com.back.user.dto.request.UpdateFcmTokenRequest;
+import com.back.user.dto.response.UserIdResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User", description = "사용자 관련 API")
+public interface UserApiV1 {
+
+    @Operation(
+            summary = "FCM 토큰 등록/변경",
+            description = """
+                로그인한 사용자의 FCM 토큰을 등록하거나 변경합니다.
+                FCM 토큰이 없던 사용자에게는 새로 등록하며,
+                기존 토큰이 있는 경우에는 새로운 값으로 업데이트합니다.
+                """
+    )
+    @ApiResponse(responseCode = "200", description = "토큰 등록/변경 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<UserIdResponse> registerOrUpdateFcmToken(
+            AuthPrincipal authPrincipal,
+            UpdateFcmTokenRequest request
+    );
+
+}

--- a/user/src/main/java/com/back/user/adapter/out/UserRepository.java
+++ b/user/src/main/java/com/back/user/adapter/out/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderId(Provider authProvider, String providerId);
 
     boolean existsByNickname(String candidate);
+
+    Optional<User> findById(Long id);
 }

--- a/user/src/main/java/com/back/user/app/UserFacade.java
+++ b/user/src/main/java/com/back/user/app/UserFacade.java
@@ -1,0 +1,24 @@
+package com.back.user.app;
+
+import com.back.user.domain.User;
+import com.back.user.dto.request.UpdateFcmTokenRequest;
+import com.back.user.dto.response.UserIdResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+    private final UserSupport userSupport;
+    private final UserUpdateUsecase userUpdateUsecase;
+
+    @Transactional
+    public UserIdResponse registerOrUpdateFcmToken(Long userId, UpdateFcmTokenRequest request) {
+        User user = userSupport.findById(userId);
+
+        userUpdateUsecase.updateFcmToken(user, request);
+
+        return UserIdResponse.of(user);
+    }
+}

--- a/user/src/main/java/com/back/user/app/UserSupport.java
+++ b/user/src/main/java/com/back/user/app/UserSupport.java
@@ -1,0 +1,20 @@
+package com.back.user.app;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.EntityNotFoundException;
+import com.back.user.adapter.out.UserRepository;
+import com.back.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSupport {
+    private final UserRepository userRepository;
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
+    }
+
+}

--- a/user/src/main/java/com/back/user/app/UserUpdateUsecase.java
+++ b/user/src/main/java/com/back/user/app/UserUpdateUsecase.java
@@ -1,0 +1,15 @@
+package com.back.user.app;
+
+import com.back.user.domain.User;
+import com.back.user.dto.request.UpdateFcmTokenRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserUpdateUsecase {
+
+    public void updateFcmToken(User user, UpdateFcmTokenRequest request) {
+        user.updateFcmToken(request.fcmToken());
+    }
+}

--- a/user/src/main/java/com/back/user/domain/User.java
+++ b/user/src/main/java/com/back/user/domain/User.java
@@ -59,4 +59,7 @@ public class User extends BaseTimeEntity {
                 .build();
     }
 
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/user/src/main/java/com/back/user/dto/request/UpdateFcmTokenRequest.java
+++ b/user/src/main/java/com/back/user/dto/request/UpdateFcmTokenRequest.java
@@ -1,0 +1,6 @@
+package com.back.user.dto.request;
+
+public record UpdateFcmTokenRequest(
+        String fcmToken
+) {
+}

--- a/user/src/main/java/com/back/user/dto/request/UpdateFcmTokenRequest.java
+++ b/user/src/main/java/com/back/user/dto/request/UpdateFcmTokenRequest.java
@@ -1,6 +1,8 @@
 package com.back.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record UpdateFcmTokenRequest(
-        String fcmToken
+        @NotBlank String fcmToken
 ) {
 }

--- a/user/src/main/java/com/back/user/dto/response/UserIdResponse.java
+++ b/user/src/main/java/com/back/user/dto/response/UserIdResponse.java
@@ -1,0 +1,15 @@
+package com.back.user.dto.response;
+
+import com.back.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record UserIdResponse(
+        Long userId
+) {
+    public static UserIdResponse of(User user) {
+        return UserIdResponse.builder()
+                .userId(user.getId())
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #82 

## 🔎 작업 내용

-사용자 FCM 토큰 등록/업데이트 API 구현
- UserController에 `/me/fcm-token` 엔드포인트 추가

<br>


## 📌 참고 사항

- 기타 안내 사항 <!--(선택 사항)-->
    - fcmToken이 null 또는 빈 문자열일 시 예외처리가 됩니다
    - 추후에 유저 탈퇴를 진행하게 되면, fcmToken을 null로 수정해야 합니다

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- fcmToken에 null 값이 오는 경우
```json
{
    "code": "VALIDATION_FAILED",
    "data": {
        "fcmToken": "공백일 수 없습니다"
    },
    "message": "요청 데이터가 유효하지 않습니다.",
    "status": 400
}
```

- 토큰 수정에 성공한 경우
```json
{
    "code": "OK",
    "data": {
        "userId": 1
    },
    "message": "요청이 성공했습니다.",
    "status": 200
}
```

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
