### PR TITLE
[FEAT] Product Command API 구현 (#29)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-webmvc'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+        implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
         compileOnly 'org.projectlombok:lombok'
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         runtimeOnly 'com.h2database:h2'

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -57,6 +57,7 @@ public enum FailureCode {
     BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "BRAND_NOT_FOUND", "존재하지 않는 브랜드입니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
     OPTION_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_VALUE_NOT_FOUND", "존재하지 않는 옵션 값입니다."),
+    PRODUCT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_INFO_NOT_FOUND", "존재하지 않는 상품 기본 정보입니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_MESSAGE_NOT_FOUND", "해당 메시지를 찾을 수 없습니다."),
 
     /**

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -54,6 +54,9 @@ public enum FailureCode {
     SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT_NOT_FOUND", "해당 정산서를 찾을 수 없습니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_ROOM_NOT_FOUND", "해당 채팅방을 찾을 수 없습니다."),
     WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "WALLET_NOT_FOUND", "사용자 지갑을 찾을 수 없습니다."),
+    BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "BRAND_NOT_FOUND", "존재하지 않는 브랜드입니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
+    OPTION_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_VALUE_NOT_FOUND", "존재하지 않는 옵션 값입니다."),
 
     /**
      * 405 Method Not Allowed
@@ -67,6 +70,7 @@ public enum FailureCode {
     CONFLICT(HttpStatus.CONFLICT, "CONFLICT", "이미 존재하는 리소스입니다."),
     BRAND_NAME_DUPLICATE(HttpStatus.CONFLICT, "BRAND_NAME_DUPLICATE", "이미 존재하는 브랜드 이름입니다."),
     CATEGORY_NAME_DUPLICATE(HttpStatus.CONFLICT, "CATEGORY_NAME_DUPLICATE", "이미 존재하는 카테고리 이름입니다."),
+    DUPLICATE_PRODUCT_INFO(HttpStatus.CONFLICT, "DUPLICATE_PRODUCT_INFO", "이미 존재하는 상품 정보입니다."),
 
     /**
      * 500 Internal Server Error

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -54,6 +54,9 @@ public enum FailureCode {
     SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT_NOT_FOUND", "해당 정산서를 찾을 수 없습니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_ROOM_NOT_FOUND", "해당 채팅방을 찾을 수 없습니다."),
     WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "WALLET_NOT_FOUND", "사용자 지갑을 찾을 수 없습니다."),
+    BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "BRAND_NOT_FOUND", "존재하지 않는 브랜드입니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
+    OPTION_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_VALUE_NOT_FOUND", "존재하지 않는 옵션 값입니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_MESSAGE_NOT_FOUND", "해당 메시지를 찾을 수 없습니다."),
 
     /**
@@ -69,6 +72,7 @@ public enum FailureCode {
     BRAND_NAME_DUPLICATE(HttpStatus.CONFLICT, "BRAND_NAME_DUPLICATE", "이미 존재하는 브랜드 이름입니다."),
     CATEGORY_NAME_DUPLICATE(HttpStatus.CONFLICT, "CATEGORY_NAME_DUPLICATE", "이미 존재하는 카테고리 이름입니다."),
     REPORT_DUPLICATE(HttpStatus.CONFLICT, "REPORT_DUPLICATE", "이미 신고한 메시지입니다."),
+    DUPLICATE_PRODUCT_INFO(HttpStatus.CONFLICT, "DUPLICATE_PRODUCT_INFO", "이미 존재하는 상품 정보입니다."),
 
     /**
      * 500 Internal Server Error

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -57,6 +57,7 @@ public enum FailureCode {
     BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, "BRAND_NOT_FOUND", "존재하지 않는 브랜드입니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
     OPTION_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_VALUE_NOT_FOUND", "존재하지 않는 옵션 값입니다."),
+    PRODUCT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_INFO_NOT_FOUND", "존재하지 않는 상품 기본 정보입니다."),
 
     /**
      * 405 Method Not Allowed

--- a/common/src/main/java/com/back/common/code/SuccessCode.java
+++ b/common/src/main/java/com/back/common/code/SuccessCode.java
@@ -16,7 +16,12 @@ public enum SuccessCode {
     /**
      * 201 CREATED SUCCESS
      */
-    CREATED(HttpStatus.CREATED, "CREATED", "요청이 성공했습니다.");
+    CREATED(HttpStatus.CREATED, "CREATED", "요청이 성공했습니다."),
+
+    /**
+     * 204 NO_CONTENT SUCCESS
+     */
+    NO_CONTENT(HttpStatus.NO_CONTENT, "NO_CONTENT", "요청이 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
@@ -22,9 +22,7 @@ public class ApiV1ProductController implements ProductApiController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<ProductResponseDto> createProduct(@Valid @RequestBody ProductCreateRequestDto request) {
-        ProductResponseDto response = ProductResponseDto.builder()
-                .products(productFacade.createProduct(request))
-                .build();
+        ProductResponseDto response = productFacade.createProduct(request);
         return CommonResponse.success(SuccessCode.CREATED, response);
     }
 
@@ -34,9 +32,7 @@ public class ApiV1ProductController implements ProductApiController {
             @PathVariable Long productInfoId,
             @Valid @RequestBody ProductUpdateRequestDto request
     ) {
-        ProductResponseDto response = ProductResponseDto.builder()
-                .products(productFacade.updateProduct(productInfoId, request))
-                .build();
+        ProductResponseDto response = productFacade.updateProduct(productInfoId, request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
 

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
@@ -39,4 +39,12 @@ public class ApiV1ProductController implements ProductApiController {
                 .build();
         return CommonResponse.success(SuccessCode.OK, response);
     }
+
+    @Override
+    @DeleteMapping("/{productInfoId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public CommonResponse<?> deleteProduct(@PathVariable Long productInfoId) {
+        productFacade.deleteProduct(productInfoId);
+        return CommonResponse.success(SuccessCode.NO_CONTENT, null);
+    }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
@@ -1,0 +1,29 @@
+package com.back.product.adapter.in;
+
+import com.back.common.code.SuccessCode;
+import com.back.common.response.CommonResponse;
+import com.back.product.app.ProductFacade;
+import com.back.product.dto.request.ProductCreateRequestDto;
+import com.back.product.dto.response.ProductResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(path = "/api/v1/products", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class ApiV1ProductController implements ProductApiController {
+    private final ProductFacade productFacade;
+
+    @Override
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<ProductResponseDto> createProduct(@Valid @RequestBody ProductCreateRequestDto request) {
+        ProductResponseDto response = ProductResponseDto.builder()
+                .products(productFacade.createProduct(request))
+                .build();
+        return CommonResponse.success(SuccessCode.CREATED, response);
+    }
+}

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
@@ -4,6 +4,7 @@ import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.ProductCreateRequestDto;
+import com.back.product.dto.request.ProductUpdateRequestDto;
 import com.back.product.dto.response.ProductResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +26,17 @@ public class ApiV1ProductController implements ProductApiController {
                 .products(productFacade.createProduct(request))
                 .build();
         return CommonResponse.success(SuccessCode.CREATED, response);
+    }
+
+    @Override
+    @PutMapping("/{productInfoId}")
+    public CommonResponse<ProductResponseDto> updateProduct(
+            @PathVariable Long productInfoId,
+            @Valid @RequestBody ProductUpdateRequestDto request
+    ) {
+        ProductResponseDto response = ProductResponseDto.builder()
+                .products(productFacade.updateProduct(productInfoId, request))
+                .build();
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
@@ -10,14 +10,27 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Product", description = "상품 관련 API")
 public interface ProductApiController {
-    @Operation(summary = "상품 생성", description = "새로운 상품을 생성합니다.")
+    @Operation(summary = "상품 생성", description = """
+            새로운 상품을 생성합니다.
+            상품(Product) 생성 시, 옵션의 개수 N개 만큼 생성합니다.
+            옵션은 기존에 존재하는 데이터를 선택할 수 있도록 합니다.
+            생성되는 상품마다 이미지를 N개 설정할 수 있습니다.
+    """)
     @ApiResponse(responseCode = "201", description = "상품 생성 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> createProduct(ProductCreateRequestDto request);
 
-    @Operation(summary = "상품 수정", description = "기존 상품을 수정합니다.")
+    @Operation(summary = "상품 수정", description = """
+            존재하는 상품을 수정합니다.
+            상품 공통 정보(ProductInfo)를 수정할 수 있습니다.
+            상품의 옵션(ProductOptionValues)와 이미지(ProductImage)를 수정할 수 있습니다.
+            상품의 옵션 및 이미지(Variants)의 입력 값은 아래와 같습니다.
+            - productId의 유무에 따라, Variant 수정/추가를 합니다.
+            - 옵션 및 이미지는 기존의 데이터들을 삭제한 후 새로운 데이터를 추가합니다.
+            - productId에 매칭되지 않는 기존 Product들은 삭제합니다.
+    """)
     @ApiResponse(responseCode = "200", description = "상품 수정 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)

--- a/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
@@ -36,4 +36,15 @@ public interface ProductApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> updateProduct(Long productInfoId, ProductUpdateRequestDto request);
+
+    @Operation(summary = "상품 삭제", description = """
+            상품을 삭제합니다.
+            상품의 기본 정보 (ProductInfo)에 매칭되는 모든 상품들(Product)을 삭제합니다.
+            삭제되는 상품에 매칭되는 상품 옵션(ProductOptionValues) 및 이미지(ProductImage)를 삭제합니다.
+            모든 삭제는 Soft Delete를 준수합니다.
+    """)
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> deleteProduct(Long productInfoId);
 }

--- a/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
@@ -2,6 +2,7 @@ package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.ProductCreateRequestDto;
+import com.back.product.dto.request.ProductUpdateRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,4 +16,11 @@ public interface ProductApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> createProduct(ProductCreateRequestDto request);
+
+    @Operation(summary = "상품 수정", description = "기존 상품을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "상품 수정 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> updateProduct(Long productInfoId, ProductUpdateRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
@@ -1,0 +1,18 @@
+package com.back.product.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.product.dto.request.ProductCreateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Product", description = "상품 관련 API")
+public interface ProductApiController {
+    @Operation(summary = "상품 생성", description = "새로운 상품을 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "상품 생성 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> createProduct(ProductCreateRequestDto request);
+}

--- a/product/src/main/java/com/back/product/adapter/out/OptionGroupRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/OptionGroupRepository.java
@@ -1,0 +1,7 @@
+package com.back.product.adapter.out;
+
+import com.back.product.domain.OptionGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> {
+}

--- a/product/src/main/java/com/back/product/adapter/out/OptionValueRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/OptionValueRepository.java
@@ -1,0 +1,8 @@
+package com.back.product.adapter.out;
+
+import com.back.product.domain.OptionValue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionValueRepository extends JpaRepository<OptionValue, Long>
+{
+}

--- a/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
@@ -5,6 +5,7 @@ import com.back.product.domain.ProductImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -12,7 +13,7 @@ import java.util.List;
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
     @Modifying
     @Query("update ProductImage pi set pi.deletedAt = now() where pi.product in :products")
-    void deleteAllByProductIn(List<Product> existsProducts);
+    void deleteAllByProductIn(@Param("products") List<Product> existsProducts);
 
     List<ProductImage> findALlByProductIn(List<Product> products);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
@@ -1,0 +1,7 @@
+package com.back.product.adapter.out;
+
+import com.back.product.domain.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+}

--- a/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
@@ -1,7 +1,18 @@
 package com.back.product.adapter.out;
 
+import com.back.product.domain.Product;
 import com.back.product.domain.ProductImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+    @Modifying
+    @Query("update ProductImage pi set pi.deletedAt = now() where pi.product in :products")
+    void deleteAllByProductIn(List<Product> existsProducts);
+
+    List<ProductImage> findALlByProductIn(List<Product> products);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductInfoRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductInfoRepository.java
@@ -1,0 +1,9 @@
+package com.back.product.adapter.out;
+
+import com.back.product.domain.Brand;
+import com.back.product.domain.ProductInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductInfoRepository extends JpaRepository<ProductInfo, Long> {
+    boolean existsProductInfoByBrandAndProductCodeIgnoreCase(Brand brand, String code);
+}

--- a/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
@@ -5,13 +5,14 @@ import com.back.product.domain.ProductOptionValues;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ProductOptionValuesRepository extends JpaRepository<ProductOptionValues, Long> {
     @Modifying
     @Query("update ProductOptionValues pov set pov.deletedAt = now() where pov.product in :products")
-    void deleteAllByProductIn(List<Product> products);
+    void deleteAllByProductIn(@Param("products") List<Product> products);
 
     List<ProductOptionValues> findAllByProductIn(List<Product> products);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
@@ -1,7 +1,17 @@
 package com.back.product.adapter.out;
 
+import com.back.product.domain.Product;
 import com.back.product.domain.ProductOptionValues;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ProductOptionValuesRepository extends JpaRepository<ProductOptionValues, Long> {
+    @Modifying
+    @Query("update ProductOptionValues pov set pov.deletedAt = now() where pov.product in :products")
+    void deleteAllByProductIn(List<Product> products);
+
+    List<ProductOptionValues> findAllByProductIn(List<Product> products);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
@@ -1,0 +1,7 @@
+package com.back.product.adapter.out;
+
+import com.back.product.domain.ProductOptionValues;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductOptionValuesRepository extends JpaRepository<ProductOptionValues, Long> {
+}

--- a/product/src/main/java/com/back/product/adapter/out/ProductRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductRepository.java
@@ -1,7 +1,11 @@
 package com.back.product.adapter.out;
 
 import com.back.product.domain.Product;
+import com.back.product.domain.ProductInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findAllByProductInfo(ProductInfo productInfo);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.back.product.adapter.out;
+
+import com.back.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -1,23 +1,29 @@
 package com.back.product.app;
 
-import com.back.product.app.usecase.BrandUseCase;
-import com.back.product.app.usecase.CategoryUseCase;
+import com.back.product.app.usecase.*;
+import com.back.product.domain.*;
 import com.back.product.dto.CategoryDto;
+import com.back.product.dto.ProductDto;
 import com.back.product.dto.request.BrandCreateRequestDto;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.request.ProductCreateRequestDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class ProductFacade {
     private final BrandUseCase brandUseCase;
     private final CategoryUseCase categoryUseCase;
+    private final OptionUseCase optionUseCase;
+    private final ProductInfoUseCase productInfoUseCase;
+    private final ProductUseCase productUseCase;
 
     @Transactional(readOnly = true)
     public List<BrandDto> getBrands() {
@@ -37,5 +43,20 @@ public class ProductFacade {
     @Transactional
     public CategoryDto createCategory(@Valid CategoryCreateRequestDto request) {
         return categoryUseCase.createCategory(request);
+    }
+
+    @Transactional
+    public List<ProductDto> createProduct(@Valid ProductCreateRequestDto request) {
+        Brand brand = brandUseCase.findBrandExists(request.productInfo().brandId());
+
+        Category category = categoryUseCase.findCategoryExists(request.productInfo().categoryId());
+
+        List<Long> optionValueIds = request.variants().stream()
+                .flatMap(variant -> variant.optionValueIds().stream()).distinct().toList();
+        Map<Long, OptionValue> optionValueMap = optionUseCase.findOptionValuesAsMap(optionValueIds);
+
+        ProductInfo productInfo = productInfoUseCase.createProductInfo(brand, category, request.productInfo());
+
+        return productUseCase.createProducts(productInfo, request.variants(), optionValueMap);
     }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -57,4 +57,19 @@ public class ProductFacade {
 
         return productUseCase.createMultipleProduct(productInfo, request.variants(), optionValueMap);
     }
+
+    @Transactional
+    public List<ProductDto> updateProduct(Long productInfoId, @Valid ProductUpdateRequestDto request) {
+        Brand brand = brandUseCase.findBrandExists(request.productInfo().brandId());
+
+        Category category = categoryUseCase.findCategoryExists(request.productInfo().categoryId());
+
+        List<Long> optionValueIds = request.variants().stream()
+                .flatMap(variant -> variant.optionValueIds().stream()).distinct().toList();
+        Map<Long, OptionValue> optionValueMap = optionUseCase.findOptionValuesAsMap(optionValueIds);
+
+        ProductInfo productInfo = productInfoUseCase.updateProductInfo(productInfoId, brand, category, request.productInfo());
+
+        return productUseCase.updateMultipleProduct(productInfo, request.variants(), optionValueMap);
+    }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -4,10 +4,8 @@ import com.back.product.app.usecase.*;
 import com.back.product.domain.*;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.ProductDto;
-import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.*;
 import com.back.product.dto.BrandDto;
-import com.back.product.dto.request.CategoryCreateRequestDto;
-import com.back.product.dto.request.ProductCreateRequestDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,6 +55,6 @@ public class ProductFacade {
 
         ProductInfo productInfo = productInfoUseCase.createProductInfo(brand, category, request.productInfo());
 
-        return productUseCase.createProducts(productInfo, request.variants(), optionValueMap);
+        return productUseCase.createMultipleProduct(productInfo, request.variants(), optionValueMap);
     }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -72,4 +72,11 @@ public class ProductFacade {
 
         return productUseCase.updateMultipleProduct(productInfo, request.variants(), optionValueMap);
     }
+
+    @Transactional
+    public void deleteProduct(Long productInfoId) {
+        productUseCase.deleteMultipleProduct(productInfoId);
+
+        productInfoUseCase.deleteProductInfo(productInfoId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
@@ -8,6 +8,8 @@ import com.back.product.dto.request.BrandCreateRequestDto;
 import com.back.product.dto.BrandDto;
 import com.back.product.mapper.BrandMapper;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,5 +43,11 @@ public class BrandUseCase {
         if (productSupport.existsBrandByName(name)) {
             throw new CustomException(FailureCode.BRAND_NAME_DUPLICATE);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Brand findBrandExists(Long brandId) {
+        return productSupport.findBrandById(brandId)
+                .orElseThrow(() -> new CustomException(FailureCode.BRAND_NOT_FOUND));
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
@@ -8,6 +8,8 @@ import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
 import com.back.product.mapper.CategoryMapper;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,5 +43,11 @@ public class CategoryUseCase {
         if (productSupport.existsCategoryByName(name)) {
             throw new CustomException(FailureCode.CATEGORY_NAME_DUPLICATE);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Category findCategoryExists(Long categoryId) {
+        return productSupport.findCategoryById(categoryId)
+                .orElseThrow(() -> new CustomException(FailureCode.CATEGORY_NOT_FOUND));
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -1,0 +1,31 @@
+package com.back.product.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.domain.OptionValue;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OptionUseCase {
+    private final ProductSupport productSupport;
+
+    @Transactional(readOnly = true)
+    public Map<Long, OptionValue> findOptionValuesAsMap(@Valid List<Long> optionValueIds) {
+        List<OptionValue> foundValues = productSupport.getAllOptionValues(optionValueIds);
+
+        if (foundValues.size() != optionValueIds.size()) {
+            throw new CustomException(FailureCode.OPTION_VALUE_NOT_FOUND);
+        }
+
+        return foundValues.stream()
+                .collect(Collectors.toMap(OptionValue::getId, value -> value));
+    }
+}

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -52,4 +52,12 @@ public class ProductInfoUseCase {
 
         return productInfo;
     }
+
+    @Transactional
+    public void deleteProductInfo(Long productInfoId) {
+        ProductInfo productInfo = productSupport.findProductInfoById(productInfoId)
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_NOT_FOUND));
+
+        productInfoRepository.delete(productInfo);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -1,0 +1,37 @@
+package com.back.product.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.adapter.out.ProductInfoRepository;
+import com.back.product.domain.Brand;
+import com.back.product.domain.Category;
+import com.back.product.domain.ProductInfo;
+import com.back.product.dto.request.ProductInfoCreateRequestDto;
+import com.back.product.mapper.ProductInfoMapper;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductInfoUseCase {
+    private final ProductInfoMapper productInfoMapper;
+    private final ProductInfoRepository productInfoRepository;
+    private final ProductSupport productSupport;
+
+    @Transactional
+    public ProductInfo createProductInfo(Brand brand, Category category, @Valid ProductInfoCreateRequestDto request) {
+        isDuplicateProductInfo(brand, request.code());
+
+        ProductInfo productInfo = productInfoMapper.toEntity(brand, category, request);
+
+        return productInfoRepository.save(productInfo);
+    }
+
+    private void isDuplicateProductInfo(Brand brand, String code) {
+        if (productSupport.existsProductInfoByBrandAndCode(brand, code)) {
+            throw new CustomException(FailureCode.DUPLICATE_PRODUCT_INFO);
+        }
+    }
+}

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -7,6 +7,7 @@ import com.back.product.domain.Brand;
 import com.back.product.domain.Category;
 import com.back.product.domain.ProductInfo;
 import com.back.product.dto.request.ProductInfoCreateRequestDto;
+import com.back.product.dto.request.ProductInfoUpdateRequestDto;
 import com.back.product.mapper.ProductInfoMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,22 @@ public class ProductInfoUseCase {
         if (productSupport.existsProductInfoByBrandAndCode(brand, code)) {
             throw new CustomException(FailureCode.DUPLICATE_PRODUCT_INFO);
         }
+    }
+
+    @Transactional
+    public ProductInfo updateProductInfo(Long productInfoId, Brand brand, Category category, @Valid ProductInfoUpdateRequestDto request) {
+        ProductInfo productInfo = productSupport.findProductInfoById(productInfoId)
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_NOT_FOUND));
+
+        productInfo.update(
+            brand,
+            category,
+            request.name(),
+            request.code(),
+            request.releasePrice(),
+            request.releasedDate()
+        );
+
+        return productInfo;
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -56,7 +56,7 @@ public class ProductInfoUseCase {
     @Transactional
     public void deleteProductInfo(Long productInfoId) {
         ProductInfo productInfo = productSupport.findProductInfoById(productInfoId)
-                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
 
         productInfoRepository.delete(productInfo);
     }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -85,7 +85,7 @@ public class ProductSupport {
     @Transactional(readOnly = true)
     public List<Product> getAllProductsByProductInfoId(Long productInfoId) {
         ProductInfo productInfo = productInfoRepository.findById(productInfoId)
-                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
 
         return productRepository.findAllByProductInfo(productInfo);
     }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -1,12 +1,7 @@
 package com.back.product.app.usecase;
 
-import com.back.product.adapter.out.BrandRepository;
-import com.back.product.adapter.out.CategoryRepository;
-import com.back.product.adapter.out.OptionValueRepository;
-import com.back.product.adapter.out.ProductInfoRepository;
-import com.back.product.domain.Brand;
-import com.back.product.domain.Category;
-import com.back.product.domain.OptionValue;
+import com.back.product.adapter.out.*;
+import com.back.product.domain.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +16,9 @@ public class ProductSupport {
     private final CategoryRepository categoryRepository;
     private final ProductInfoRepository productInfoRepository;
     private final OptionValueRepository optionValueRepository;
+    private final ProductRepository productRepository;
+    private final ProductOptionValuesRepository productOptionValuesRepository;
+    private final ProductImageRepository productImageRepository;
 
     @Transactional(readOnly = true)
     public List<Brand> getAllBrands() {
@@ -60,5 +58,25 @@ public class ProductSupport {
     @Transactional(readOnly = true)
     public List<OptionValue> getAllOptionValues(List<Long> optionValueIds) {
         return optionValueRepository.findAllById(optionValueIds);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ProductInfo> findProductInfoById(Long productInfoId) {
+        return productInfoRepository.findById(productInfoId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Product> getAllProductsByProductInfo(ProductInfo productInfo) {
+        return productRepository.findAllByProductInfo(productInfo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductOptionValues> getAllProductOptionValuesByProductsIn(List<Product> products) {
+        return productOptionValuesRepository.findAllByProductIn(products);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductImage> getAllProductImagesByProductsIn(List<Product> products) {
+        return productImageRepository.findALlByProductIn(products);
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -2,19 +2,25 @@ package com.back.product.app.usecase;
 
 import com.back.product.adapter.out.BrandRepository;
 import com.back.product.adapter.out.CategoryRepository;
+import com.back.product.adapter.out.OptionValueRepository;
+import com.back.product.adapter.out.ProductInfoRepository;
 import com.back.product.domain.Brand;
 import com.back.product.domain.Category;
+import com.back.product.domain.OptionValue;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ProductSupport {
     private final BrandRepository brandRepository;
     private final CategoryRepository categoryRepository;
+    private final ProductInfoRepository productInfoRepository;
+    private final OptionValueRepository optionValueRepository;
 
     @Transactional(readOnly = true)
     public List<Brand> getAllBrands() {
@@ -34,5 +40,25 @@ public class ProductSupport {
     @Transactional(readOnly = true)
     public boolean existsCategoryByName(String name) {
         return categoryRepository.existsCategoryByNameIgnoreCase(name);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Brand> findBrandById(Long brandId) {
+        return brandRepository.findById(brandId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Category> findCategoryById(Long categoryId) {
+        return categoryRepository.findById(categoryId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsProductInfoByBrandAndCode(Brand brand, String code) {
+        return productInfoRepository.existsProductInfoByBrandAndProductCodeIgnoreCase(brand, code);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionValue> getAllOptionValues(List<Long> optionValueIds) {
+        return optionValueRepository.findAllById(optionValueIds);
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -1,5 +1,7 @@
 package com.back.product.app.usecase;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.*;
 import com.back.product.domain.*;
 import lombok.RequiredArgsConstructor;
@@ -78,5 +80,13 @@ public class ProductSupport {
     @Transactional(readOnly = true)
     public List<ProductImage> getAllProductImagesByProductsIn(List<Product> products) {
         return productImageRepository.findALlByProductIn(products);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Product> getAllProductsByProductInfoId(Long productInfoId) {
+        ProductInfo productInfo = productInfoRepository.findById(productInfoId)
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_NOT_FOUND));
+
+        return productRepository.findAllByProductInfo(productInfo);
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -7,16 +7,13 @@ import com.back.product.domain.*;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.request.ProductVariantCreateRequestDto;
 import com.back.product.mapper.ProductImageMapper;
-import com.back.product.mapper.ProductInfoMapper;
 import com.back.product.mapper.ProductMapper;
 import com.back.product.mapper.ProductOptionValuesMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,33 +37,56 @@ public class ProductUseCase {
         List<ProductImage> createdImages = new ArrayList<>();
 
         variants.forEach(variant -> {
-            // 1. Create Product
-            Product newProduct = productMapper.toEntity(productInfo, variant);
+            Product newProduct = createProduct(productInfo, variant.inventory());
             createdProducts.add(newProduct);
 
-            // 2. Create ProductOptionValues (상품과 옵션 간의 관계 설정)
-            List<ProductOptionValues> newProductOptionValues = variant.optionValueIds().stream().map(optionValueId -> {
-                OptionValue optionValue = optionValueMap.get(optionValueId);
-                return productOptionValuesMapper.toEntity(newProduct, optionValue);
-            }).toList();
+            List<ProductOptionValues> newProductOptionValues = createProductOptionValues(newProduct, variant.optionValueIds(), optionValueMap);
             createdProductOptionValues.addAll(newProductOptionValues);
 
-            // 3. Create ProductImage
-            List<ProductImage> newProductImages = variant.imageUrls().stream()
-                    .map(imageUrl ->  productImageMapper.toEntity(newProduct, imageUrl)).toList();
+            List<ProductImage> newProductImages = createProductImages(newProduct, variant.imageUrls());
             createdImages.addAll(newProductImages);
         });
 
         List<Product> newProducts = productRepository.saveAll(createdProducts);
-        Map<Product, List<ProductOptionValues>> newProductOptionValuesAsMap = productOptionValuesRepository.saveAll(createdProductOptionValues)
-                .stream().collect(Collectors.groupingBy(ProductOptionValues::getProduct));
-        Map<Product, List<ProductImage>> newProductImagesAsMap = productImageRepository.saveAll(createdImages)
-                .stream().collect(Collectors.groupingBy(ProductImage::getProduct));
+        List<ProductOptionValues> newProductOptionValues = productOptionValuesRepository.saveAll(createdProductOptionValues);
+        List<ProductImage> newProductImages = productImageRepository.saveAll(createdImages);
 
-        return newProducts.stream().map(product -> {
-            List<ProductOptionValues> productOptionValues = newProductOptionValuesAsMap.get(product);
-            List<ProductImage> productImages = newProductImagesAsMap.get(product);
-            return productMapper.toDto(product, productOptionValues, productImages);
+        return convertToDto(newProducts, newProductOptionValues, newProductImages);
+    }
+    
+    private Product createProduct(ProductInfo productInfo, Long inventory) {
+        return productMapper.toEntity(productInfo, inventory);
+    }
+
+    private List<ProductOptionValues> createProductOptionValues(Product product, List<Long> optionValueIds, Map<Long, OptionValue> optionValueMap) {
+        return optionValueIds.stream().map(optionValueId -> {
+            OptionValue optionValue = optionValueMap.get(optionValueId);
+            return productOptionValuesMapper.toEntity(product, optionValue);
         }).toList();
+    }
+
+    private List<ProductImage> createProductImages(Product product, List<String> imageUrls) {
+        return imageUrls.stream().map(imageUrl ->
+                productImageMapper.toEntity(product, imageUrl)
+        ).toList();
+    }
+
+    private List<ProductDto> convertToDto(
+            List<Product> products,
+            List<ProductOptionValues> productOptionValues,
+            List<ProductImage> productImages
+    ) {
+        Map<Product, List<ProductOptionValues>> productOptionValuesAsMap = productOptionValues
+                .stream().collect(Collectors.groupingBy(ProductOptionValues::getProduct));
+        Map<Product, List<ProductImage>> productImagesAsMap = productImages.stream()
+                .collect(Collectors.groupingBy(ProductImage::getProduct));
+
+        return products.stream().map(product ->
+            productMapper.toDto(
+                product,
+                productOptionValuesAsMap.get(product),
+                productImagesAsMap.get(product)
+            )
+        ).toList();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -78,6 +78,12 @@ public class ProductUseCase {
         return convertToDto(updatedProducts, updatedProductOptionValues, updatedProductImages);
     }
 
+    @Transactional
+    public void deleteMultipleProduct(Long productInfoId) {
+        List<Product> deletedProducts = productSupport.getAllProductsByProductInfoId(productInfoId);
+        deleteProducts(deletedProducts);
+    }
+
     private void handleCreations(ProductInfo productInfo, List<ProductVariantUpdateRequestDto> variantsToCreate, Map<Long, OptionValue> optionValueMap) {
         List<Product> createdProducts = new ArrayList<>();
         List<ProductOptionValues> createdProductOptionValues = new ArrayList<>();

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -27,7 +27,7 @@ public class ProductUseCase {
     private final ProductImageRepository productImageRepository;
 
     @Transactional
-    public List<ProductDto> createProducts(
+    public List<ProductDto> createMultipleProduct(
             ProductInfo productInfo,
             List<ProductVariantCreateRequestDto> variants,
             Map<Long, OptionValue> optionValueMap

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -1,0 +1,72 @@
+package com.back.product.app.usecase;
+
+import com.back.product.adapter.out.ProductImageRepository;
+import com.back.product.adapter.out.ProductOptionValuesRepository;
+import com.back.product.adapter.out.ProductRepository;
+import com.back.product.domain.*;
+import com.back.product.dto.ProductDto;
+import com.back.product.dto.request.ProductVariantCreateRequestDto;
+import com.back.product.mapper.ProductImageMapper;
+import com.back.product.mapper.ProductInfoMapper;
+import com.back.product.mapper.ProductMapper;
+import com.back.product.mapper.ProductOptionValuesMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProductUseCase {
+    private final ProductMapper productMapper;
+    private final ProductImageMapper productImageMapper;
+    private final ProductOptionValuesMapper productOptionValuesMapper;
+    private final ProductRepository productRepository;
+    private final ProductOptionValuesRepository productOptionValuesRepository;
+    private final ProductImageRepository productImageRepository;
+
+    @Transactional
+    public List<ProductDto> createProducts(
+            ProductInfo productInfo,
+            List<ProductVariantCreateRequestDto> variants,
+            Map<Long, OptionValue> optionValueMap
+    ) {
+        List<Product> createdProducts = new ArrayList<>();
+        List<ProductOptionValues> createdProductOptionValues = new ArrayList<>();
+        List<ProductImage> createdImages = new ArrayList<>();
+
+        variants.forEach(variant -> {
+            // 1. Create Product
+            Product newProduct = productMapper.toEntity(productInfo, variant);
+            createdProducts.add(newProduct);
+
+            // 2. Create ProductOptionValues (상품과 옵션 간의 관계 설정)
+            List<ProductOptionValues> newProductOptionValues = variant.optionValueIds().stream().map(optionValueId -> {
+                OptionValue optionValue = optionValueMap.get(optionValueId);
+                return productOptionValuesMapper.toEntity(newProduct, optionValue);
+            }).toList();
+            createdProductOptionValues.addAll(newProductOptionValues);
+
+            // 3. Create ProductImage
+            List<ProductImage> newProductImages = variant.imageUrls().stream()
+                    .map(imageUrl ->  productImageMapper.toEntity(newProduct, imageUrl)).toList();
+            createdImages.addAll(newProductImages);
+        });
+
+        List<Product> newProducts = productRepository.saveAll(createdProducts);
+        Map<Product, List<ProductOptionValues>> newProductOptionValuesAsMap = productOptionValuesRepository.saveAll(createdProductOptionValues)
+                .stream().collect(Collectors.groupingBy(ProductOptionValues::getProduct));
+        Map<Product, List<ProductImage>> newProductImagesAsMap = productImageRepository.saveAll(createdImages)
+                .stream().collect(Collectors.groupingBy(ProductImage::getProduct));
+
+        return newProducts.stream().map(product -> {
+            List<ProductOptionValues> productOptionValues = newProductOptionValuesAsMap.get(product);
+            List<ProductImage> productImages = newProductImagesAsMap.get(product);
+            return productMapper.toDto(product, productOptionValues, productImages);
+        }).toList();
+    }
+}

--- a/product/src/main/java/com/back/product/domain/Product.java
+++ b/product/src/main/java/com/back/product/domain/Product.java
@@ -28,4 +28,9 @@ public class Product extends BaseTimeEntity {
     @Min(0)
     @Builder.Default
     private Long inventory = 0L;
+
+    public void update(ProductInfo productInfo, Long inventory) {
+        this.productInfo = productInfo;
+        this.inventory = inventory;
+    }
 }

--- a/product/src/main/java/com/back/product/domain/Product.java
+++ b/product/src/main/java/com/back/product/domain/Product.java
@@ -26,5 +26,6 @@ public class Product extends BaseTimeEntity {
 
     @Column(nullable = false)
     @Min(0)
-    private Long inventory;
+    @Builder.Default
+    private Long inventory = 0L;
 }

--- a/product/src/main/java/com/back/product/domain/ProductInfo.java
+++ b/product/src/main/java/com/back/product/domain/ProductInfo.java
@@ -17,7 +17,11 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @SQLDelete(sql = "UPDATE PRODUCT_INFO SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
-@Table(name = "product_info")
+@Table(name = "product_info",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_product_info_brand_code", columnNames = {"brand_id", "code"})
+    }
+)
 public class ProductInfo extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/product/src/main/java/com/back/product/domain/ProductInfo.java
+++ b/product/src/main/java/com/back/product/domain/ProductInfo.java
@@ -2,7 +2,7 @@ package com.back.product.domain;
 
 import com.back.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -47,4 +47,13 @@ public class ProductInfo extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDateTime releasedDate;
+
+    public void update(Brand brand, Category category, String name, String code, BigDecimal releasePrice, LocalDateTime releasedDate) {
+        this.brand = brand;
+        this.category = category;
+        this.name = name;
+        this.productCode = code;
+        this.releasePrice = releasePrice;
+        this.releasedDate = releasedDate;
+    }
 }

--- a/product/src/main/java/com/back/product/dto/BrandDto.java
+++ b/product/src/main/java/com/back/product/dto/BrandDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record BrandDto(
+        Long brandId,
         String name,
         String logoUrl
 ) {

--- a/product/src/main/java/com/back/product/dto/CategoryDto.java
+++ b/product/src/main/java/com/back/product/dto/CategoryDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record CategoryDto(
+        Long categoryId,
         String name,
         String imageUrl
 ) {

--- a/product/src/main/java/com/back/product/dto/ProductDto.java
+++ b/product/src/main/java/com/back/product/dto/ProductDto.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Builder
 public record ProductDto(
-        ProductInfoDto productInfo,
+        Long productId,
         Long inventory,
         List<ProductOptionDto> options,
         List<String> imageUrls

--- a/product/src/main/java/com/back/product/dto/ProductDto.java
+++ b/product/src/main/java/com/back/product/dto/ProductDto.java
@@ -1,0 +1,15 @@
+package com.back.product.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductDto(
+        ProductInfoDto productInfo,
+        Long inventory,
+        List<ProductOptionDto> options,
+        List<String> imageUrls
+) {
+}
+

--- a/product/src/main/java/com/back/product/dto/ProductInfoDto.java
+++ b/product/src/main/java/com/back/product/dto/ProductInfoDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 @Builder
 public record ProductInfoDto(
+        Long productInfoId,
         BrandDto brand,
         CategoryDto category,
         String name,

--- a/product/src/main/java/com/back/product/dto/ProductInfoDto.java
+++ b/product/src/main/java/com/back/product/dto/ProductInfoDto.java
@@ -1,0 +1,17 @@
+package com.back.product.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Builder
+public record ProductInfoDto(
+        BrandDto brand,
+        CategoryDto category,
+        String name,
+        String code,
+        BigDecimal releasePrice,
+        LocalDateTime releaseDate
+) {
+}

--- a/product/src/main/java/com/back/product/dto/ProductOptionDto.java
+++ b/product/src/main/java/com/back/product/dto/ProductOptionDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ProductOptionDto(
+        Long productOptionValueId,
         String groupName,
         String value
 ) {

--- a/product/src/main/java/com/back/product/dto/ProductOptionDto.java
+++ b/product/src/main/java/com/back/product/dto/ProductOptionDto.java
@@ -1,0 +1,10 @@
+package com.back.product.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ProductOptionDto(
+        String groupName,
+        String value
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/BrandCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/BrandCreateRequestDto.java
@@ -3,6 +3,7 @@ package com.back.product.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 
 public record BrandCreateRequestDto(
         @NotBlank(message = "브랜드 이름은 필수입니다.")
@@ -12,6 +13,7 @@ public record BrandCreateRequestDto(
 
         @NotBlank(message = "로고 URL은 필수입니다.")
         @Size(min=1, max=255, message = "로고 URL은 1자 이상 255자 이하여야 합니다.")
+        @URL(message = "유효한 URL 형식이 아닙니다.")
         String logoUrl
 ) {
 }

--- a/product/src/main/java/com/back/product/dto/request/CategoryCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/CategoryCreateRequestDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
+import org.hibernate.validator.constraints.URL;
 
 @Builder
 public record CategoryCreateRequestDto(
@@ -14,6 +15,7 @@ public record CategoryCreateRequestDto(
 
         @NotBlank(message = "이미지 URL은 필수입니다.")
         @Size(min=1, max=255, message = "이미지 URL은 1자 이상 255자 이하여야 합니다.")
+        @URL(message = "유효한 URL 형식이 아닙니다.")
         String imageUrl
 ) {
 }

--- a/product/src/main/java/com/back/product/dto/request/ProductCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductCreateRequestDto(
+        @NotNull(message = "Product info cannot be null")
+        @Valid
+        ProductInfoCreateRequestDto productInfo,
+
+        @NotEmpty(message = "Product variants cannot be empty")
+        @Valid
+        List<ProductVariantCreateRequestDto> variants
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/ProductInfoCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductInfoCreateRequestDto.java
@@ -1,0 +1,34 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Builder
+public record ProductInfoCreateRequestDto(
+        @NotNull(message = "Brand ID cannot be null")
+        @Min(value = 1, message = "Brand ID must be a Integer value")
+        Long brandId,
+
+        @NotNull(message = "Category ID cannot be null")
+        @Min(value = 1, message = "Category ID must be a Integer value")
+        Long categoryId,
+
+        @NotBlank(message = "Name cannot be blank")
+        @Pattern(regexp = "^[A-Za-z0-9 ]{1,50}$", message = "Name must be alphanumeric and up to 50 characters")
+        String name,
+
+        @NotBlank(message = "Code cannot be blank")
+        @Size(min = 1, max = 50, message = "Code must be between 1 and 50 characters")
+        String code,
+
+        @NotNull(message = "Release price cannot be null")
+        @Min(value = 1, message = "Release price must be at least 1")
+        BigDecimal releasePrice,
+
+        @NotNull(message = "Released date cannot be null")
+        LocalDateTime releasedDate
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/ProductInfoUpdateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductInfoUpdateRequestDto.java
@@ -1,0 +1,34 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Builder
+public record ProductInfoUpdateRequestDto(
+        @NotNull(message = "Brand ID cannot be null")
+        @Min(value = 1, message = "Brand ID must be a Integer value")
+        Long brandId,
+
+        @NotNull(message = "Category ID cannot be null")
+        @Min(value = 1, message = "Category ID must be a Integer value")
+        Long categoryId,
+
+        @NotBlank(message = "Name cannot be blank")
+        @Pattern(regexp = "^[A-Za-z0-9 ]{1,50}$", message = "Name must be alphanumeric and up to 50 characters")
+        String name,
+
+        @NotBlank(message = "Code cannot be blank")
+        @Size(min = 1, max = 50, message = "Code must be between 1 and 50 characters")
+        String code,
+
+        @NotNull(message = "Release price cannot be null")
+        @Min(value = 1, message = "Release price must be at least 1")
+        BigDecimal releasePrice,
+
+        @NotNull(message = "Released date cannot be null")
+        LocalDateTime releasedDate
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/ProductUpdateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductUpdateRequestDto(
+        @NotNull(message = "Product info cannot be null")
+        @Valid
+        ProductInfoUpdateRequestDto productInfo,
+
+        @NotEmpty(message = "Product variants cannot be empty")
+        @Valid
+        List<ProductVariantUpdateRequestDto> variants
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/ProductVariantCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductVariantCreateRequestDto.java
@@ -1,0 +1,21 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.URL;
+
+import java.util.List;
+
+public record ProductVariantCreateRequestDto(
+        @NotEmpty(message = "Option values for variant cannot be empty")
+        List<Long> optionValueIds,
+
+        @NotNull(message = "Inventory cannot be null")
+        @Min(value = 0, message = "Inventory must be a non-negative value")
+        Long inventory,
+
+        @NotEmpty(message = "Image URLs for variant cannot be empty")
+        List<@URL(message = "유효한 URL 형식이 아닙니다.") String> imageUrls
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/ProductVariantCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductVariantCreateRequestDto.java
@@ -3,10 +3,12 @@ package com.back.product.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
 
+@Builder
 public record ProductVariantCreateRequestDto(
         @NotEmpty(message = "Option values for variant cannot be empty")
         List<Long> optionValueIds,

--- a/product/src/main/java/com/back/product/dto/request/ProductVariantUpdateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductVariantUpdateRequestDto.java
@@ -4,10 +4,12 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
 
+@Builder
 public record ProductVariantUpdateRequestDto (
         @Nullable
         Long productId,

--- a/product/src/main/java/com/back/product/dto/request/ProductVariantUpdateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductVariantUpdateRequestDto.java
@@ -1,0 +1,25 @@
+package com.back.product.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.URL;
+
+import java.util.List;
+
+public record ProductVariantUpdateRequestDto (
+        @Nullable
+        Long productId,
+
+        @NotEmpty(message = "Option values for variant cannot be empty")
+        List<Long> optionValueIds,
+
+        @NotNull(message = "Inventory cannot be null")
+        @Min(value = 0, message = "Inventory must be a non-negative value")
+        Long inventory,
+
+        @NotEmpty(message = "Image URLs for variant cannot be empty")
+        List<@URL(message = "유효한 URL 형식이 아닙니다.") String> imageUrls
+) {
+}

--- a/product/src/main/java/com/back/product/dto/response/ProductResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/ProductResponseDto.java
@@ -1,12 +1,14 @@
 package com.back.product.dto.response;
 
 import com.back.product.dto.ProductDto;
+import com.back.product.dto.ProductInfoDto;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record ProductResponseDto(
+        ProductInfoDto productInfo,
         List<ProductDto> products
 ) {
 }

--- a/product/src/main/java/com/back/product/dto/response/ProductResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/ProductResponseDto.java
@@ -1,0 +1,12 @@
+package com.back.product.dto.response;
+
+import com.back.product.dto.ProductDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductResponseDto(
+        List<ProductDto> products
+) {
+}

--- a/product/src/main/java/com/back/product/mapper/BrandMapper.java
+++ b/product/src/main/java/com/back/product/mapper/BrandMapper.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 public class BrandMapper {
     public BrandDto toDto(Brand brand) {
         return BrandDto.builder()
+                .brandId(brand.getId())
                 .name(brand.getName())
                 .logoUrl(brand.getImageUrl())
                 .build();

--- a/product/src/main/java/com/back/product/mapper/CategoryMapper.java
+++ b/product/src/main/java/com/back/product/mapper/CategoryMapper.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 public class CategoryMapper {
     public CategoryDto toDto(Category category) {
         return CategoryDto.builder()
+                .categoryId(category.getId())
                 .name(category.getName())
                 .imageUrl(category.getImageUrl())
                 .build();

--- a/product/src/main/java/com/back/product/mapper/ProductImageMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductImageMapper.java
@@ -1,0 +1,19 @@
+package com.back.product.mapper;
+
+import com.back.product.domain.Product;
+import com.back.product.domain.ProductImage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductImageMapper {
+    public ProductImage toEntity(Product product, String url) {
+        return ProductImage.builder()
+                .product(product)
+                .imageUrl(url)
+                .build();
+    }
+
+    public String toDto(ProductImage productImage) {
+        return productImage.getImageUrl();
+    }
+}

--- a/product/src/main/java/com/back/product/mapper/ProductInfoMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductInfoMapper.java
@@ -27,6 +27,7 @@ public class ProductInfoMapper {
 
     public ProductInfoDto toDto(ProductInfo productInfo) {
         return ProductInfoDto.builder()
+                .productInfoId(productInfo.getId())
                 .brand(brandMapper.toDto(productInfo.getBrand()))
                 .category(categoryMapper.toDto(productInfo.getCategory()))
                 .name(productInfo.getName())

--- a/product/src/main/java/com/back/product/mapper/ProductInfoMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductInfoMapper.java
@@ -1,0 +1,38 @@
+package com.back.product.mapper;
+
+import com.back.product.domain.Brand;
+import com.back.product.domain.Category;
+import com.back.product.domain.ProductInfo;
+import com.back.product.dto.ProductInfoDto;
+import com.back.product.dto.request.ProductInfoCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductInfoMapper {
+    private final BrandMapper brandMapper;
+    private final CategoryMapper categoryMapper;
+
+    public ProductInfo toEntity(Brand brand, Category category, ProductInfoCreateRequestDto request) {
+        return ProductInfo.builder()
+                .brand(brand)
+                .category(category)
+                .name(request.name())
+                .productCode(request.code())
+                .releasePrice(request.releasePrice())
+                .releasedDate(request.releasedDate())
+                .build();
+    }
+
+    public ProductInfoDto toDto(ProductInfo productInfo) {
+        return ProductInfoDto.builder()
+                .brand(brandMapper.toDto(productInfo.getBrand()))
+                .category(categoryMapper.toDto(productInfo.getCategory()))
+                .name(productInfo.getName())
+                .code(productInfo.getProductCode())
+                .releasePrice(productInfo.getReleasePrice())
+                .releaseDate(productInfo.getReleasedDate())
+                .build();
+    }
+}

--- a/product/src/main/java/com/back/product/mapper/ProductMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductMapper.java
@@ -7,6 +7,7 @@ import com.back.product.domain.ProductOptionValues;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.ProductOptionDto;
 import com.back.product.dto.request.ProductVariantCreateRequestDto;
+import com.back.product.dto.request.ProductVariantUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,13 @@ public class ProductMapper {
         return Product.builder()
                 .productInfo(productInfo)
                 .inventory(variant.inventory())
+                .build();
+    }
+
+    public Product toEntity(ProductInfo productInfo, Long inventory) {
+        return Product.builder()
+                .productInfo(productInfo)
+                .inventory(inventory)
                 .build();
     }
 

--- a/product/src/main/java/com/back/product/mapper/ProductMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductMapper.java
@@ -1,0 +1,40 @@
+package com.back.product.mapper;
+
+import com.back.product.domain.Product;
+import com.back.product.domain.ProductImage;
+import com.back.product.domain.ProductInfo;
+import com.back.product.domain.ProductOptionValues;
+import com.back.product.dto.ProductDto;
+import com.back.product.dto.ProductOptionDto;
+import com.back.product.dto.request.ProductVariantCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMapper {
+    private final ProductInfoMapper productInfoMapper;
+    private final ProductOptionMapper productOptionMapper;
+    private final ProductImageMapper productImageMapper;
+
+    public Product toEntity(ProductInfo productInfo, ProductVariantCreateRequestDto variant) {
+        return Product.builder()
+                .productInfo(productInfo)
+                .inventory(variant.inventory())
+                .build();
+    }
+
+    public ProductDto toDto(Product product, List<ProductOptionValues> options, List<ProductImage> images) {
+        List<ProductOptionDto> optionDtos = options.stream().map(productOptionMapper::toDto).toList();
+        List<String> imageUrlDtos = images.stream().map(productImageMapper::toDto).toList();
+
+        return ProductDto.builder()
+                .productInfo(productInfoMapper.toDto(product.getProductInfo()))
+                .inventory(product.getInventory())
+                .options(optionDtos)
+                .imageUrls(imageUrlDtos)
+                .build();
+    }
+}

--- a/product/src/main/java/com/back/product/mapper/ProductMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductMapper.java
@@ -16,16 +16,8 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class ProductMapper {
-    private final ProductInfoMapper productInfoMapper;
     private final ProductOptionMapper productOptionMapper;
     private final ProductImageMapper productImageMapper;
-
-    public Product toEntity(ProductInfo productInfo, ProductVariantCreateRequestDto variant) {
-        return Product.builder()
-                .productInfo(productInfo)
-                .inventory(variant.inventory())
-                .build();
-    }
 
     public Product toEntity(ProductInfo productInfo, Long inventory) {
         return Product.builder()
@@ -39,7 +31,7 @@ public class ProductMapper {
         List<String> imageUrlDtos = images.stream().map(productImageMapper::toDto).toList();
 
         return ProductDto.builder()
-                .productInfo(productInfoMapper.toDto(product.getProductInfo()))
+                .productId(product.getId())
                 .inventory(product.getInventory())
                 .options(optionDtos)
                 .imageUrls(imageUrlDtos)

--- a/product/src/main/java/com/back/product/mapper/ProductOptionMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductOptionMapper.java
@@ -1,0 +1,15 @@
+package com.back.product.mapper;
+
+import com.back.product.domain.ProductOptionValues;
+import com.back.product.dto.ProductOptionDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductOptionMapper {
+    public ProductOptionDto toDto(ProductOptionValues productOptionValues) {
+        return ProductOptionDto.builder()
+                .groupName(productOptionValues.getOptionValue().getOptionGroup().getName())
+                .value(productOptionValues.getOptionValue().getValue())
+                .build();
+    }
+}

--- a/product/src/main/java/com/back/product/mapper/ProductOptionMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductOptionMapper.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 public class ProductOptionMapper {
     public ProductOptionDto toDto(ProductOptionValues productOptionValues) {
         return ProductOptionDto.builder()
+                .productOptionValueId(productOptionValues.getId())
                 .groupName(productOptionValues.getOptionValue().getOptionGroup().getName())
                 .value(productOptionValues.getOptionValue().getValue())
                 .build();

--- a/product/src/main/java/com/back/product/mapper/ProductOptionValuesMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductOptionValuesMapper.java
@@ -1,0 +1,16 @@
+package com.back.product.mapper;
+
+import com.back.product.domain.OptionValue;
+import com.back.product.domain.Product;
+import com.back.product.domain.ProductOptionValues;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductOptionValuesMapper {
+    public ProductOptionValues toEntity(Product product, OptionValue optionValue) {
+        return ProductOptionValues.builder()
+                .product(product)
+                .optionValue(optionValue)
+                .build();
+    }
+}

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
@@ -80,8 +80,8 @@ class ApiV1BrandControllerTest {
         @WithMockUser
         void createBrand_Success() throws Exception {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("New Balance", "logo.png");
-            BrandDto responseDto = BrandDto.builder().name("New Balance").logoUrl("logo.png").build();
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("New Balance", "https://exmaple.com/logo.png");
+            BrandDto responseDto = BrandDto.builder().name("New Balance").logoUrl("https://exmaple.com/logo.png").build();
 
             given(productFacade.createBrand(any(BrandCreateRequestDto.class))).willReturn(responseDto);
 
@@ -94,7 +94,7 @@ class ApiV1BrandControllerTest {
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.code").value("CREATED"))
                     .andExpect(jsonPath("$.data.brand.name").value("New Balance"))
-                    .andExpect(jsonPath("$.data.brand.logoUrl").value("logo.png"));
+                    .andExpect(jsonPath("$.data.brand.logoUrl").value("https://exmaple.com/logo.png"));
 
             verify(productFacade).createBrand(any(BrandCreateRequestDto.class));
         }
@@ -104,7 +104,7 @@ class ApiV1BrandControllerTest {
         @WithMockUser
         void createBrand_Fail_DuplicateName() throws Exception {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("Existing Brand", "logo.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("Existing Brand", "https://exmaple.com/logo.png");
             given(productFacade.createBrand(any(BrandCreateRequestDto.class)))
                     .willThrow(new CustomException(FailureCode.BRAND_NAME_DUPLICATE));
 
@@ -124,7 +124,7 @@ class ApiV1BrandControllerTest {
         @WithMockUser
         void createBrand_Fail_Validation() throws Exception {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(" ", "logo.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(" ", "https://exmaple.com/logo.png");
 
             // when & then
             mockMvc.perform(

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
@@ -79,7 +79,7 @@ class ApiV1CategoryControllerTest {
         @WithMockUser
         void createCategory_Success() throws Exception {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Tops").imageUrl("image.png").build();
+            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Tops").imageUrl("https://exmaple.com/image.png").build();
             CategoryDto responseDto = CategoryDto.builder().name("Tops").build();
 
             given(productFacade.createCategory(any(CategoryCreateRequestDto.class))).willReturn(responseDto);
@@ -102,7 +102,7 @@ class ApiV1CategoryControllerTest {
         @WithMockUser
         void createCategory_Fail_DuplicateName() throws Exception {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Existed").imageUrl("image.png").build();
+            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Existed").imageUrl("https://exmaple.com/image.png").build();
             given(productFacade.createCategory(any(CategoryCreateRequestDto.class)))
                     .willThrow(new CustomException(FailureCode.CATEGORY_NAME_DUPLICATE));
 
@@ -122,7 +122,7 @@ class ApiV1CategoryControllerTest {
         @WithMockUser
         void createCategory_Fail_Validation() throws Exception {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name(" ").name("image.png").build();
+            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name(" ").name("https://exmaple.com/image.png").build();
 
             // when & then
             mockMvc.perform(

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductControllerTest.java
@@ -1,0 +1,217 @@
+package com.back.product.adapter.in;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.app.ProductFacade;
+import com.back.product.dto.request.ProductCreateRequestDto;
+import com.back.product.dto.request.ProductUpdateRequestDto;
+import com.back.product.dto.response.ProductResponseDto;
+import com.back.product.util.RequestFixture;
+import com.back.security.jwt.JWTUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApiV1ProductController.class)
+@DisplayName("ApiV1ProductController 테스트")
+class ApiV1ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JWTUtil jwtUtil;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private ProductFacade productFacade;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setupObjectMapper() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/products")
+    class CreateProductTest {
+
+        @Test
+        @DisplayName("상품 생성을 성공한다")
+        @WithMockUser
+        void createProduct_Success() throws Exception {
+            // given
+            ProductCreateRequestDto request = RequestFixture.createProductCreateRequest();
+            ProductResponseDto response = RequestFixture.createProductResponse();
+
+            given(productFacade.createProduct(any(ProductCreateRequestDto.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(
+                            post("/api/v1/products")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value("CREATED"))
+                    .andExpect(jsonPath("$.data.productInfo.productInfoId").value(response.productInfo().productInfoId()))
+                    .andExpect(jsonPath("$.data.productInfo.name").value(response.productInfo().name()));
+
+            verify(productFacade).createProduct(any(ProductCreateRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청 값으로 생성 시 400 Bad Request를 반환한다")
+        @WithMockUser
+        void createProduct_Fail_Validation() throws Exception {
+            // given
+            ProductCreateRequestDto request = null;
+
+            // when & then
+            mockMvc.perform(
+                            post("/api/v1/products")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).createProduct(any(ProductCreateRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/products/{productInfoId}")
+    class UpdateProductTest {
+
+        @Test
+        @DisplayName("상품 수정을 성공한다")
+        @WithMockUser
+        void updateProduct_Success() throws Exception {
+            // given
+            long productInfoId = 1L;
+            ProductUpdateRequestDto request = RequestFixture.createProductUpdateRequest();
+            ProductResponseDto response = RequestFixture.createUpdatedProductResponse();
+
+            given(productFacade.updateProduct(anyLong(), any(ProductUpdateRequestDto.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/{productInfoId}", productInfoId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("OK"))
+                    .andExpect(jsonPath("$.data.productInfo.productInfoId").value(response.productInfo().productInfoId()))
+                    .andExpect(jsonPath("$.data.productInfo.name").value(response.productInfo().name()));
+
+            verify(productFacade).updateProduct(anyLong(), any(ProductUpdateRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 정보 ID로 수정 시 404 Not Found를 반환한다")
+        @WithMockUser
+        void updateProduct_Fail_NotFound() throws Exception {
+            // given
+            long productInfoId = 999L;
+            ProductUpdateRequestDto request = RequestFixture.createProductUpdateRequest();
+            given(productFacade.updateProduct(anyLong(), any(ProductUpdateRequestDto.class)))
+                    .willThrow(new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/{productInfoId}", productInfoId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isNotFound());
+
+            verify(productFacade).updateProduct(anyLong(), any(ProductUpdateRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청 값으로 수정 시 400 Bad Request를 반환한다")
+        @WithMockUser
+        void updateProduct_Fail_Validation() throws Exception {
+            // given
+            long productInfoId = 1L;
+            ProductUpdateRequestDto request = null;
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/{productInfoId}", productInfoId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).updateProduct(anyLong(), any(ProductUpdateRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/products/{productInfoId}")
+    class DeleteProductTest {
+
+        @Test
+        @DisplayName("상품 삭제를 성공한다")
+        @WithMockUser
+        void deleteProduct_Success() throws Exception {
+            // given
+            long productInfoId = 1L;
+            willDoNothing().given(productFacade).deleteProduct(productInfoId);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/products/{productInfoId}", productInfoId)
+                    ).andDo(print())
+                    .andExpect(status().isNoContent());
+
+            verify(productFacade).deleteProduct(productInfoId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 정보 ID로 삭제 시 404 Not Found를 반환한다")
+        @WithMockUser
+        void deleteProduct_Fail_NotFound() throws Exception {
+            // given
+            long productInfoId = 999L;
+            willThrow(new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND))
+                    .given(productFacade).deleteProduct(productInfoId);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/products/{productInfoId}", productInfoId)
+                    ).andDo(print())
+                    .andExpect(status().isNotFound());
+
+            verify(productFacade).deleteProduct(productInfoId);
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/ProductCommandTest.java
+++ b/product/src/test/java/com/back/product/app/ProductCommandTest.java
@@ -10,14 +10,12 @@ import com.back.product.dto.request.ProductInfoUpdateRequestDto;
 import com.back.product.dto.request.ProductVariantUpdateRequestDto;
 import com.back.product.dto.request.ProductUpdateRequestDto;
 import com.back.product.dto.response.ProductResponseDto;
-import com.back.product.util.RequestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -27,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @DisplayName("ProductFacade 통합 테스트")
-class ProductFacadeTest {
+class ProductCommandTest {
 
     @Autowired
     private ProductFacade productFacade;

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@Transactional
 @DisplayName("ProductFacade 통합 테스트")
 class ProductFacadeTest {
 

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -1,0 +1,249 @@
+package com.back.product.app;
+
+import com.back.product.adapter.out.*;
+import com.back.product.domain.*;
+import com.back.product.dto.ProductDto;
+import com.back.product.dto.request.ProductCreateRequestDto;
+import com.back.product.dto.request.ProductInfoCreateRequestDto;
+import com.back.product.dto.request.ProductVariantCreateRequestDto;
+import com.back.product.dto.request.ProductInfoUpdateRequestDto;
+import com.back.product.dto.request.ProductVariantUpdateRequestDto;
+import com.back.product.dto.request.ProductUpdateRequestDto;
+import com.back.product.dto.response.ProductResponseDto;
+import com.back.product.util.RequestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@DisplayName("ProductFacade 통합 테스트")
+class ProductFacadeTest {
+
+    @Autowired
+    private ProductFacade productFacade;
+
+    // DB-Setup & Verification
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductInfoRepository productInfoRepository;
+    @Autowired private ProductImageRepository productImageRepository;
+    @Autowired private ProductOptionValuesRepository productOptionValuesRepository;
+    @Autowired private BrandRepository brandRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private OptionGroupRepository optionGroupRepository;
+    @Autowired private OptionValueRepository optionValueRepository;
+
+
+    private Brand savedBrand;
+    private Category savedCategory;
+    private OptionValue savedOptionValueBlack;
+    private OptionValue savedOptionValueWhite;
+    private OptionValue savedOptionValue95;
+    private OptionValue savedOptionValue100;
+
+    @BeforeEach
+    void setUp() {
+        // Clean all repositories to ensure a clean state for each test
+        productImageRepository.deleteAll();
+        productOptionValuesRepository.deleteAll();
+        productRepository.deleteAll();
+        productInfoRepository.deleteAll();
+        optionValueRepository.deleteAll();
+        optionGroupRepository.deleteAll();
+        brandRepository.deleteAll();
+        categoryRepository.deleteAll();
+
+        // Given: Prerequisite data
+        savedBrand = brandRepository.save(Brand.builder().name("Test Brand").imageUrl("logo.png").build());
+        savedCategory = categoryRepository.save(Category.builder().name("Test Category").imageUrl("img.png").build());
+
+        OptionGroup savedOptionGroupColor = optionGroupRepository.save(OptionGroup.builder().name("Color").build());
+        OptionGroup savedOptionGroupSize = optionGroupRepository.save(OptionGroup.builder().name("Size").build());
+
+        savedOptionValueBlack = optionValueRepository.save(OptionValue.builder().optionGroup(savedOptionGroupColor).value("Black").build());
+        savedOptionValueWhite = optionValueRepository.save(OptionValue.builder().optionGroup(savedOptionGroupColor).value("White").build());
+        savedOptionValue95 = optionValueRepository.save(OptionValue.builder().optionGroup(savedOptionGroupSize).value("95").build());
+        savedOptionValue100 = optionValueRepository.save(OptionValue.builder().optionGroup(savedOptionGroupSize).value("100").build());
+    }
+
+    @Nested
+    @DisplayName("createProduct 메서드")
+    class CreateProductTest {
+
+        @Test
+        @DisplayName("성공: 상품 정보와 여러 variant를 포함하는 완전한 상품을 생성한다")
+        void createProduct_Success() {
+            // given
+            ProductInfoCreateRequestDto productInfoRequest = ProductInfoCreateRequestDto.builder()
+                    .brandId(savedBrand.getId())
+                    .categoryId(savedCategory.getId())
+                    .name("New Awesome Product")
+                    .code("NAP-001")
+                    .releasePrice(BigDecimal.valueOf(150000))
+                    .releasedDate(LocalDateTime.now())
+                    .build();
+
+            ProductVariantCreateRequestDto variant1 = new ProductVariantCreateRequestDto(
+                    List.of(savedOptionValueBlack.getId(), savedOptionValue95.getId()),
+                    50L,
+                    List.of("image_black_95.jpg")
+            );
+
+            ProductVariantCreateRequestDto variant2 = new ProductVariantCreateRequestDto(
+                    List.of(savedOptionValueWhite.getId(), savedOptionValue100.getId()),
+                    100L,
+                    List.of("image_white_100_1.jpg", "image_white_100_2.jpg")
+            );
+
+            ProductCreateRequestDto request = new ProductCreateRequestDto(productInfoRequest, List.of(variant1, variant2));
+
+            // when
+            ProductResponseDto response = productFacade.createProduct(request);
+
+            // then
+            // 1. Response DTO Verification
+            assertThat(response).isNotNull();
+            assertThat(response.productInfo().code()).isEqualTo("NAP-001");
+            assertThat(response.products()).hasSize(2);
+            assertThat(response.products().stream().mapToLong(ProductDto::inventory).sum()).isEqualTo(150L);
+
+            // 2. Database Verification
+            assertThat(productInfoRepository.count()).isEqualTo(1);
+            assertThat(productRepository.count()).isEqualTo(2);
+            assertThat(productOptionValuesRepository.count()).isEqualTo(4); // 2 options per variant
+            assertThat(productImageRepository.count()).isEqualTo(3); // 1 + 2 images
+
+            // 3. Verify association
+            Long savedProductInfoId = response.productInfo().productInfoId();
+            List<Product> savedProducts = productRepository.findAll();
+            assertThat(savedProducts.get(0).getProductInfo().getId()).isEqualTo(savedProductInfoId);
+            assertThat(savedProducts.get(1).getProductInfo().getId()).isEqualTo(savedProductInfoId);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProduct 메서드")
+    class UpdateProductTest {
+        private ProductInfo initialProductInfo;
+        private Product variantToUpdate;
+        private Product variantToDelete;
+
+        @BeforeEach
+        void setUp() {
+            // given: 먼저 상품과 2개의 variant를 생성
+            initialProductInfo = productInfoRepository.save(ProductInfo.builder()
+                    .brand(savedBrand)
+                    .category(savedCategory)
+                    .name("Initial Product")
+                    .productCode("IP-001")
+                    .releasePrice(BigDecimal.valueOf(100000))
+                    .releasedDate(LocalDateTime.now())
+                    .build());
+
+            variantToUpdate = productRepository.save(Product.builder().productInfo(initialProductInfo).inventory(10L).build());
+            productOptionValuesRepository.saveAll(List.of(
+                    ProductOptionValues.builder().product(variantToUpdate).optionValue(savedOptionValueBlack).build(),
+                    ProductOptionValues.builder().product(variantToUpdate).optionValue(savedOptionValue95).build()
+            ));
+
+            variantToDelete = productRepository.save(Product.builder().productInfo(initialProductInfo).inventory(20L).build());
+            productOptionValuesRepository.saveAll(List.of(
+                    ProductOptionValues.builder().product(variantToDelete).optionValue(savedOptionValueWhite).build(),
+                    ProductOptionValues.builder().product(variantToDelete).optionValue(savedOptionValue100).build()
+            ));
+        }
+
+        @Test
+        @DisplayName("성공: 상품 정보와 variant들을 수정, 추가, 삭제한다")
+        void updateProduct_Success() {
+            // given
+            // 1. 상품 정보 수정
+            ProductInfoUpdateRequestDto productInfoUpdate = ProductInfoUpdateRequestDto.builder()
+                    .brandId(savedBrand.getId())
+                    .categoryId(savedCategory.getId())
+                    .name("Updated Awesome Product")
+                    .code("UAP-001")
+                    .releasePrice(BigDecimal.valueOf(120000))
+                    .releasedDate(LocalDateTime.now())
+                    .build();
+
+            // 2. Variant 수정 (variantToUpdate)
+            ProductVariantUpdateRequestDto variantUpdate = new ProductVariantUpdateRequestDto(
+                    variantToUpdate.getId(),
+                    List.of(savedOptionValueBlack.getId(), savedOptionValue100.getId()), // 옵션 변경
+                    5L, // 재고 변경
+                    List.of("updated_image.jpg")
+            );
+
+            // 3. Variant 추가
+            ProductVariantUpdateRequestDto variantCreate = new ProductVariantUpdateRequestDto(
+                    null,
+                    List.of(savedOptionValueWhite.getId(), savedOptionValue95.getId()),
+                    30L,
+                    List.of("new_image.jpg")
+            );
+
+            // variantToDelete는 요청에 포함하지 않아 삭제될 것
+            ProductUpdateRequestDto request = new ProductUpdateRequestDto(productInfoUpdate, List.of(variantUpdate, variantCreate));
+
+            // when
+            ProductResponseDto response = productFacade.updateProduct(initialProductInfo.getId(), request);
+
+            // then
+            // 1. Response DTO 검증
+            assertThat(response.productInfo().code()).isEqualTo("UAP-001");
+            assertThat(response.productInfo().releasePrice()).isEqualTo(BigDecimal.valueOf(120000));
+            assertThat(response.products()).hasSize(2); // 1개 수정, 1개 추가
+
+            // 2. DB 검증
+            assertThat(productInfoRepository.findById(initialProductInfo.getId()).get().getProductCode()).isEqualTo("UAP-001");
+            assertThat(productRepository.count()).isEqualTo(2);
+            assertThat(productRepository.findById(variantToUpdate.getId()).get().getInventory()).isEqualTo(5L);
+            assertThat(productRepository.existsById(variantToDelete.getId())).isFalse(); // soft-delete
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteProduct 메서드")
+    class DeleteProductTest {
+
+        @Test
+        @DisplayName("성공: 상품 정보와 하위 variant들을 모두 삭제(soft-delete)한다")
+        void deleteProduct_Success() {
+            // given: 상품과 2개의 variant를 생성
+            ProductInfo productInfo = productInfoRepository.save(ProductInfo.builder()
+                    .brand(savedBrand).category(savedCategory).name("To Be Deleted").productCode("TBD-001")
+                    .releasePrice(BigDecimal.valueOf(100000)).releasedDate(LocalDateTime.now()).build());
+
+            Product variant1 = productRepository.save(Product.builder().productInfo(productInfo).inventory(10L).build());
+            Product variant2 = productRepository.save(Product.builder().productInfo(productInfo).inventory(20L).build());
+            productImageRepository.save(ProductImage.builder().product(variant1).imageUrl("img.jpg").build());
+            productOptionValuesRepository.save(ProductOptionValues.builder().product(variant1).optionValue(savedOptionValueBlack).build());
+
+            assertThat(productInfoRepository.count()).isEqualTo(1);
+            assertThat(productRepository.count()).isEqualTo(2);
+            assertThat(productImageRepository.count()).isEqualTo(1);
+            assertThat(productOptionValuesRepository.count()).isEqualTo(1);
+
+            // when
+            productFacade.deleteProduct(productInfo.getId());
+
+            // then
+            // @SQLDelete 와 @SQLRestriction 에 의해 count, findById 등이 모두 정상적으로 동작해야 함
+            assertThat(productInfoRepository.count()).isZero();
+            assertThat(productRepository.count()).isZero();
+            assertThat(productImageRepository.count()).isZero();
+            assertThat(productOptionValuesRepository.count()).isZero();
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/usecase/BrandUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/BrandUseCaseTest.java
@@ -5,10 +5,7 @@ import com.back.product.adapter.out.BrandRepository;
 import com.back.product.domain.Brand;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.request.BrandCreateRequestDto;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,8 +26,8 @@ class BrandUseCaseTest {
     @Autowired
     private BrandRepository brandRepository;
 
-    @AfterEach
-    void tearDown() {
+    @BeforeEach
+    void setUp() {
         brandRepository.deleteAll();
     }
 
@@ -43,8 +40,8 @@ class BrandUseCaseTest {
         void getBrands_Success() {
             // given
             brandRepository.saveAll(List.of(
-                    Brand.builder().name("Nike").imageUrl("logo1.png").build(),
-                    Brand.builder().name("Adidas").imageUrl("logo2.png").build()
+                    Brand.builder().name("Nike").imageUrl("https://example.com/logo1.png").build(),
+                    Brand.builder().name("Adidas").imageUrl("https://example.com/logo2.png").build()
             ));
 
             // when
@@ -64,14 +61,14 @@ class BrandUseCaseTest {
         @DisplayName("새로운 브랜드를 DB에 저장하고 생성된 정보를 반환한다")
         void createBrand_Success() {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("New Balance", "logo.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("New Balance", "https://example.com/logo.png");
 
             // when
             BrandDto result = brandUseCase.createBrand(requestDto);
 
             // then
             assertThat(result.name()).isEqualTo("New Balance");
-            assertThat(result.logoUrl()).isEqualTo("logo.png");
+            assertThat(result.logoUrl()).isEqualTo("https://example.com/logo.png");
 
             // DB에 실제 저장되었는지, ID는 생성되었는지 재검증
             List<Brand> allBrands = brandRepository.findAll();
@@ -85,8 +82,8 @@ class BrandUseCaseTest {
         void createBrand_Fail_DuplicateName() {
             // given
             // DB에 미리 같은 이름의 브랜드를 저장
-            brandRepository.save(Brand.builder().name("Existing Brand").imageUrl("logo.png").build());
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("Existing Brand", "logo.png");
+            brandRepository.save(Brand.builder().name("Existing Brand").imageUrl("https://example.com/logo.png").build());
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("Existing Brand", "https://example.com/logo.png");
 
             // when & then
             assertThatThrownBy(() -> brandUseCase.createBrand(requestDto))

--- a/product/src/test/java/com/back/product/app/usecase/CategoryUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/CategoryUseCaseTest.java
@@ -5,10 +5,7 @@ import com.back.product.adapter.out.CategoryRepository;
 import com.back.product.domain.Category;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,8 +26,8 @@ class CategoryUseCaseTest {
     @Autowired
     private CategoryRepository categoryRepository;
 
-    @AfterEach
-    void tearDown() {
+    @BeforeEach
+    void setUp() {
         categoryRepository.deleteAll();
     }
 
@@ -43,8 +40,8 @@ class CategoryUseCaseTest {
         void getCategories_Success() {
             // given
             categoryRepository.saveAll(List.of(
-                    Category.builder().name("Tops").imageUrl("image.png").build(),
-                    Category.builder().name("Bottoms").imageUrl("image.png").build()
+                    Category.builder().name("Tops").imageUrl("https://example.com/image.png").build(),
+                    Category.builder().name("Bottoms").imageUrl("https://example.com/image.png").build()
             ));
 
             // when
@@ -64,7 +61,7 @@ class CategoryUseCaseTest {
         @DisplayName("새로운 카테고리를 DB에 저장하고 생성된 정보를 반환한다")
         void createCategory_Success() {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Accessories").imageUrl("image.png").build();
+            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Accessories").imageUrl("https://example.com/image.png").build();
 
             // when
             CategoryDto result = categoryUseCase.createCategory(requestDto);
@@ -84,8 +81,8 @@ class CategoryUseCaseTest {
         void createCategory_Fail_DuplicateName() {
             // given
             // DB에 미리 같은 이름의 카테고리를 저장
-            categoryRepository.save(Category.builder().name("Existed").imageUrl("image.png").build());
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Existed").imageUrl("image.png").build();
+            categoryRepository.save(Category.builder().name("Existed").imageUrl("https://example.com/image.png").build());
+            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Existed").imageUrl("https://example.com/image.png").build();
 
             // when & then
             assertThatThrownBy(() -> categoryUseCase.createCategory(requestDto))

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -1,0 +1,73 @@
+package com.back.product.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.domain.OptionValue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OptionUseCase 단위 테스트")
+class OptionUseCaseTest {
+
+    @InjectMocks
+    private OptionUseCase optionUseCase;
+
+    @Mock
+    private ProductSupport productSupport;
+
+    @Nested
+    @DisplayName("findOptionValuesAsMap 메서드")
+    class FindOptionValuesAsMapTest {
+
+        @Test
+        @DisplayName("성공: ID 목록으로 OptionValue 맵을 반환한다")
+        void findOptionValuesAsMap_Success() {
+            // given
+            List<Long> ids = List.of(1L, 2L);
+            OptionValue value1 = OptionValue.builder().id(1L).value("Black").build();
+            OptionValue value2 = OptionValue.builder().id(2L).value("95").build();
+            List<OptionValue> values = List.of(value1, value2);
+
+            given(productSupport.getAllOptionValues(ids)).willReturn(values);
+
+            // when
+            Map<Long, OptionValue> result = optionUseCase.findOptionValuesAsMap(ids);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(1L).getValue()).isEqualTo("Black");
+            assertThat(result.get(2L).getValue()).isEqualTo("95");
+        }
+
+        @Test
+        @DisplayName("실패: 요청한 ID와 조회된 결과의 개수가 다르면 예외를 발생시킨다")
+        void findOptionValuesAsMap_Fail_NotFound() {
+            // given
+            List<Long> ids = List.of(1L, 2L, 99L); // 99L is not found
+            OptionValue value1 = OptionValue.builder().id(1L).value("Black").build();
+            OptionValue value2 = OptionValue.builder().id(2L).value("95").build();
+            List<OptionValue> foundValues = List.of(value1, value2);
+
+            given(productSupport.getAllOptionValues(ids)).willReturn(foundValues);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    optionUseCase.findOptionValuesAsMap(ids)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_VALUE_NOT_FOUND);
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/usecase/ProductInfoUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductInfoUseCaseTest.java
@@ -1,0 +1,199 @@
+package com.back.product.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.adapter.out.ProductInfoRepository;
+import com.back.product.domain.Brand;
+import com.back.product.domain.Category;
+import com.back.product.domain.ProductInfo;
+import com.back.product.dto.request.ProductInfoCreateRequestDto;
+import com.back.product.dto.request.ProductInfoUpdateRequestDto;
+import com.back.product.mapper.ProductInfoMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductInfoUseCase 단위 테스트")
+class ProductInfoUseCaseTest {
+
+    @InjectMocks
+    private ProductInfoUseCase productInfoUseCase;
+
+    @Mock
+    private ProductInfoMapper productInfoMapper;
+
+    @Mock
+    private ProductInfoRepository productInfoRepository;
+
+    @Mock
+    private ProductSupport productSupport;
+
+    private Brand brand;
+    private Category category;
+    private ProductInfo productInfo;
+
+    @BeforeEach
+    void setUp() {
+        brand = Brand.builder().name("Test Brand").imageUrl("logo.png").build();
+        category = Category.builder().name("Test Category").imageUrl("img.png").build();
+        productInfo = ProductInfo.builder()
+                .id(1L)
+                .brand(brand)
+                .category(category)
+                .name("Test Product")
+                .productCode("TP-01")
+                .releasePrice(BigDecimal.valueOf(10000))
+                .releasedDate(LocalDateTime.now())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("createProductInfo 메서드")
+    class CreateProductInfoTest {
+
+        @Test
+        @DisplayName("성공: 새로운 상품 정보를 생성한다")
+        void createProductInfo_Success() {
+            // given
+            ProductInfoCreateRequestDto request = ProductInfoCreateRequestDto.builder()
+                    .brandId(brand.getId())
+                    .categoryId(category.getId())
+                    .name("New Product")
+                    .code("NP-01")
+                    .releasePrice(BigDecimal.valueOf(20000))
+                    .releasedDate(LocalDateTime.now())
+                    .build();
+            given(productSupport.existsProductInfoByBrandAndCode(any(Brand.class), anyString())).willReturn(false);
+            given(productInfoMapper.toEntity(brand, category, request)).willReturn(productInfo);
+            given(productInfoRepository.save(productInfo)).willReturn(productInfo);
+
+            // when
+            ProductInfo result = productInfoUseCase.createProductInfo(brand, category, request);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getProductCode()).isEqualTo("TP-01");
+            verify(productSupport).existsProductInfoByBrandAndCode(brand, "NP-01");
+            verify(productInfoRepository).save(productInfo);
+        }
+
+        @Test
+        @DisplayName("실패: 동일한 브랜드 내에 상품 코드가 중복되면 예외를 발생시킨다")
+        void createProductInfo_Fail_DuplicateCode() {
+            // given
+            ProductInfoCreateRequestDto request = ProductInfoCreateRequestDto.builder()
+                    .brandId(brand.getId())
+                    .categoryId(category.getId())
+                    .name("New Product")
+                    .code("TP-01")
+                    .releasePrice(BigDecimal.valueOf(20000))
+                    .releasedDate(LocalDateTime.now())
+                    .build();
+            given(productSupport.existsProductInfoByBrandAndCode(brand, "TP-01")).willReturn(true);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productInfoUseCase.createProductInfo(brand, category, request)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.DUPLICATE_PRODUCT_INFO);
+            verify(productInfoRepository, never()).save(any(ProductInfo.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProductInfo 메서드")
+    class UpdateProductInfoTest {
+        @Test
+        @DisplayName("성공: 상품 정보를 수정한다")
+        void updateProductInfo_Success() {
+            // given
+            ProductInfoUpdateRequestDto request = ProductInfoUpdateRequestDto.builder()
+                    .brandId(brand.getId())
+                    .categoryId(category.getId())
+                    .name("Updated Name")
+                    .code("UTP-01")
+                    .releasePrice(BigDecimal.valueOf(12000))
+                    .releasedDate(LocalDateTime.now())
+                    .build();
+
+            given(productSupport.findProductInfoById(1L)).willReturn(Optional.of(productInfo));
+
+            // when
+            ProductInfo result = productInfoUseCase.updateProductInfo(1L, brand, category, request);
+
+            // then
+            assertThat(result.getName()).isEqualTo("Updated Name");
+            assertThat(result.getProductCode()).isEqualTo("UTP-01");
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 상품 정보 ID이면 예외를 발생시킨다")
+        void updateProductInfo_Fail_NotFound() {
+            // given
+            ProductInfoUpdateRequestDto request = ProductInfoUpdateRequestDto.builder()
+                    .brandId(brand.getId())
+                    .categoryId(category.getId())
+                    .name("Updated Name")
+                    .code("UTP-01")
+                    .releasePrice(BigDecimal.valueOf(12000))
+                    .releasedDate(LocalDateTime.now())
+                    .build();
+            given(productSupport.findProductInfoById(99L)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productInfoUseCase.updateProductInfo(99L, brand, category, request)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.PRODUCT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteProductInfo 메서드")
+    class DeleteProductInfoTest {
+        @Test
+        @DisplayName("성공: 상품 정보를 삭제한다")
+        void deleteProductInfo_Success() {
+            // given
+            given(productSupport.findProductInfoById(1L)).willReturn(Optional.of(productInfo));
+
+            // when
+            productInfoUseCase.deleteProductInfo(1L);
+
+            // then
+            verify(productInfoRepository).delete(productInfo);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 상품 정보 ID이면 예외를 발생시킨다")
+        void deleteProductInfo_Fail_NotFound() {
+            // given
+            given(productSupport.findProductInfoById(99L)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productInfoUseCase.deleteProductInfo(99L)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.PRODUCT_INFO_NOT_FOUND);
+            verify(productInfoRepository, never()).delete(any(ProductInfo.class));
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/usecase/ProductUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductUseCaseTest.java
@@ -1,0 +1,240 @@
+package com.back.product.app.usecase;
+
+import com.back.product.adapter.out.ProductImageRepository;
+import com.back.product.adapter.out.ProductOptionValuesRepository;
+import com.back.product.adapter.out.ProductRepository;
+import com.back.product.domain.OptionValue;
+import com.back.product.domain.Product;
+import com.back.product.domain.ProductInfo;
+import com.back.product.domain.ProductOptionValues;
+import com.back.product.dto.ProductDto;
+import com.back.product.dto.request.ProductVariantCreateRequestDto;
+import com.back.product.dto.request.ProductVariantUpdateRequestDto;
+import com.back.product.mapper.ProductImageMapper;
+import com.back.product.mapper.ProductMapper;
+import com.back.product.mapper.ProductOptionValuesMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductUseCase 단위 테스트")
+class ProductUseCaseTest {
+
+    @InjectMocks
+    private ProductUseCase productUseCase;
+
+    @Mock
+    private ProductMapper productMapper;
+    @Mock
+    private ProductImageMapper productImageMapper;
+    @Mock
+    private ProductOptionValuesMapper productOptionValuesMapper;
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private ProductOptionValuesRepository productOptionValuesRepository;
+    @Mock
+    private ProductImageRepository productImageRepository;
+    @Mock
+    private ProductSupport productSupport; // Though not used in create, good to have for other methods
+
+    private ProductInfo productInfo;
+    private OptionValue optionValue1, optionValue2;
+
+    @BeforeEach
+    void setUp() {
+        productInfo = ProductInfo.builder().id(1L).name("Test Product Info").build();
+        optionValue1 = OptionValue.builder().id(10L).value("Black").build();
+        optionValue2 = OptionValue.builder().id(20L).value("95").build();
+    }
+
+    @Nested
+    @DisplayName("createMultipleProduct 메서드")
+    class CreateMultipleProductTest {
+
+        @Test
+        @DisplayName("성공: 여러 상품(variant)을 생성하고 DTO로 변환하여 반환한다")
+        void createMultipleProduct_Success() {
+            // given
+            ProductVariantCreateRequestDto variantDto1 = new ProductVariantCreateRequestDto(List.of(10L, 20L), 100L, List.of("img1.jpg"));
+            ProductVariantCreateRequestDto variantDto2 = new ProductVariantCreateRequestDto(List.of(10L), 50L, List.of("img2.jpg"));
+            List<ProductVariantCreateRequestDto> variants = List.of(variantDto1, variantDto2);
+            Map<Long, OptionValue> optionValueMap = Map.of(10L, optionValue1, 20L, optionValue2);
+
+            Product product1 = Product.builder().id(1L).inventory(100L).build();
+            Product product2 = Product.builder().id(2L).inventory(50L).build();
+
+            // Mocking mappers
+            given(productMapper.toEntity(productInfo, 100L)).willReturn(product1);
+            given(productMapper.toEntity(productInfo, 50L)).willReturn(product2);
+            given(productOptionValuesMapper.toEntity(any(Product.class), any(OptionValue.class)))
+                    .willAnswer(invocation -> {
+                        Product p = invocation.getArgument(0);
+                        OptionValue ov = invocation.getArgument(1);
+                        return ProductOptionValues.builder().product(p).optionValue(ov).build();
+                    });
+            given(productImageMapper.toEntity(any(Product.class), any(String.class)))
+                    .willAnswer(invocation -> {
+                        Product p = invocation.getArgument(0);
+                        String url = invocation.getArgument(1);
+                        return com.back.product.domain.ProductImage.builder().product(p).imageUrl(url).build();
+                    });
+
+            // Mocking repository saves
+            given(productRepository.saveAll(any(List.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(productOptionValuesRepository.saveAll(any(List.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(productImageRepository.saveAll(any(List.class))).willAnswer(invocation -> invocation.getArgument(0));
+            
+            // Mocking final DTO conversion
+            given(productMapper.toDto(any(Product.class), any(List.class), any(List.class)))
+                    .willAnswer(invocation -> {
+                        Product p = invocation.getArgument(0);
+                        return ProductDto.builder().productId(p.getId()).inventory(p.getInventory()).build();
+                    });
+
+
+            // when
+            List<ProductDto> resultDtos = productUseCase.createMultipleProduct(productInfo, variants, optionValueMap);
+
+            // then
+            // Verify mappers were called correctly
+            verify(productMapper, times(2)).toEntity(any(ProductInfo.class), any(Long.class));
+            verify(productOptionValuesMapper, times(3)).toEntity(any(Product.class), any(OptionValue.class)); // 2 for variant1, 1 for variant2
+            verify(productImageMapper, times(2)).toEntity(any(Product.class), any(String.class));
+
+            // Verify repositories were called to save entities
+            ArgumentCaptor<List<Product>> productCaptor = ArgumentCaptor.forClass(List.class);
+            verify(productRepository).saveAll(productCaptor.capture());
+            assertThat(productCaptor.getValue()).hasSize(2);
+
+            ArgumentCaptor<List<ProductOptionValues>> povCaptor = ArgumentCaptor.forClass(List.class);
+            verify(productOptionValuesRepository).saveAll(povCaptor.capture());
+            assertThat(povCaptor.getValue()).hasSize(3);
+
+            ArgumentCaptor<List<com.back.product.domain.ProductImage>> imageCaptor = ArgumentCaptor.forClass(List.class);
+            verify(productImageRepository).saveAll(imageCaptor.capture());
+            assertThat(imageCaptor.getValue()).hasSize(2);
+
+            // Verify the final result
+            assertThat(resultDtos).hasSize(2);
+            assertThat(resultDtos.stream().map(ProductDto::inventory).toList()).containsExactlyInAnyOrder(100L, 50L);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMultipleProduct 메서드")
+    class UpdateMultipleProductTest {
+
+        @Test
+        @DisplayName("성공: 상품(variant)들을 수정, 추가, 삭제한다")
+        void updateMultipleProduct_Success() {
+            // given
+            Product existProductToUpdate = Product.builder().id(1L).inventory(100L).productInfo(productInfo).build();
+            Product existProductToDelete = Product.builder().id(2L).inventory(200L).productInfo(productInfo).build();
+            List<Product> existProducts = List.of(existProductToUpdate, existProductToDelete);
+
+            ProductVariantUpdateRequestDto updateDto = new ProductVariantUpdateRequestDto(1L, List.of(10L), 150L, List.of("update.jpg"));
+            ProductVariantUpdateRequestDto createDto = new ProductVariantUpdateRequestDto(null, List.of(20L), 300L, List.of("new.jpg"));
+            List<ProductVariantUpdateRequestDto> variants = List.of(updateDto, createDto);
+
+            Map<Long, OptionValue> optionValueMap = Map.of(10L, optionValue1, 20L, optionValue2);
+            Product newProduct = Product.builder().inventory(300L).productInfo(productInfo).build();
+
+            // Mocking for the first part of the method
+            given(productSupport.getAllProductsByProductInfo(productInfo)).willReturn(existProducts);
+
+            // Mocking for mappers called during update AND creation
+            given(productMapper.toEntity(productInfo, 300L)).willReturn(newProduct);
+            given(productOptionValuesMapper.toEntity(any(Product.class), any(OptionValue.class)))
+                    .willAnswer(invocation -> {
+                        Product p = invocation.getArgument(0);
+                        OptionValue ov = invocation.getArgument(1);
+                        return ProductOptionValues.builder().product(p).optionValue(ov).build();
+                    });
+            given(productImageMapper.toEntity(any(Product.class), any(String.class)))
+                    .willAnswer(invocation -> {
+                        Product p = invocation.getArgument(0);
+                        String url = invocation.getArgument(1);
+                        return com.back.product.domain.ProductImage.builder().product(p).imageUrl(url).build();
+                    });
+
+            // Mocking for the final DTO conversion part to prevent NPE
+            given(productSupport.getAllProductOptionValuesByProductsIn(any())).willReturn(List.of());
+            given(productSupport.getAllProductImagesByProductsIn(any())).willReturn(List.of());
+            given(productMapper.toDto(any(), any(), any())).willReturn(ProductDto.builder().build());
+
+
+            // when
+            productUseCase.updateMultipleProduct(productInfo, variants, optionValueMap);
+
+            // then
+            // 1. Verify deletions
+            ArgumentCaptor<List<Product>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+            verify(productRepository).deleteAll(deleteCaptor.capture());
+            assertThat(deleteCaptor.getValue()).hasSize(1);
+            assertThat(deleteCaptor.getValue().get(0).getId()).isEqualTo(existProductToDelete.getId());
+
+            // 2. Verify updates
+            assertThat(existProductToUpdate.getInventory()).isEqualTo(150L);
+
+            // 3. Verify creations and saveAll invocations
+            ArgumentCaptor<List<Product>> createdProductsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(productRepository).saveAll(createdProductsCaptor.capture());
+            List<Product> savedProducts = createdProductsCaptor.getValue();
+            assertThat(savedProducts).hasSize(1);
+            assertThat(savedProducts.get(0)).isEqualTo(newProduct);
+
+            verify(productOptionValuesRepository, times(2)).saveAll(any());
+            verify(productImageRepository, times(2)).saveAll(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMultipleProduct 메서드")
+    class DeleteMultipleProductTest {
+
+        @Test
+        @DisplayName("성공: ProductInfo에 속한 모든 상품(variant)들을 삭제한다")
+        void deleteMultipleProduct_Success() {
+            // given
+            long productInfoId = 1L;
+            Product product1 = Product.builder().id(1L).build();
+            Product product2 = Product.builder().id(2L).build();
+            List<Product> productsToDelete = List.of(product1, product2);
+
+            given(productSupport.getAllProductsByProductInfoId(productInfoId)).willReturn(productsToDelete);
+
+            // when
+            productUseCase.deleteMultipleProduct(productInfoId);
+
+            // then
+            verify(productSupport).getAllProductsByProductInfoId(productInfoId);
+
+            ArgumentCaptor<List<Product>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+            verify(productOptionValuesRepository).deleteAllByProductIn(deleteCaptor.capture());
+            assertThat(deleteCaptor.getValue()).hasSize(2);
+
+            verify(productImageRepository).deleteAllByProductIn(deleteCaptor.capture());
+            assertThat(deleteCaptor.getValue()).hasSize(2);
+
+            verify(productRepository).deleteAll(deleteCaptor.capture());
+            assertThat(deleteCaptor.getValue()).hasSize(2);
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/util/RequestFixture.java
+++ b/product/src/test/java/com/back/product/util/RequestFixture.java
@@ -1,0 +1,146 @@
+package com.back.product.util;
+
+import com.back.product.dto.BrandDto;
+import com.back.product.dto.CategoryDto;
+import com.back.product.dto.ProductDto;
+import com.back.product.dto.ProductInfoDto;
+import com.back.product.dto.ProductOptionDto;
+import com.back.product.dto.request.ProductCreateRequestDto;
+import com.back.product.dto.request.ProductInfoCreateRequestDto;
+import com.back.product.dto.request.ProductUpdateRequestDto;
+import com.back.product.dto.request.ProductInfoUpdateRequestDto;
+import com.back.product.dto.request.ProductVariantCreateRequestDto;
+import com.back.product.dto.request.ProductVariantUpdateRequestDto;
+import com.back.product.dto.response.ProductResponseDto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class RequestFixture {
+
+    public static ProductCreateRequestDto createProductCreateRequest() {
+        ProductInfoCreateRequestDto productInfo = ProductInfoCreateRequestDto.builder()
+                .brandId(1L)
+                .categoryId(1L)
+                .name("Test Product")
+                .code("TP001")
+                .releasePrice(BigDecimal.valueOf(10000))
+                .releasedDate(LocalDateTime.of(2026, 1, 21, 0, 0))
+                .build();
+
+        ProductVariantCreateRequestDto variant = ProductVariantCreateRequestDto.builder()
+                .optionValueIds(List.of(1L, 2L))
+                .inventory(100L)
+                .imageUrls(List.of("http://example.com/image.jpg"))
+                .build();
+
+        return ProductCreateRequestDto.builder()
+                .productInfo(productInfo)
+                .variants(List.of(variant))
+                .build();
+    }
+
+    public static ProductUpdateRequestDto createProductUpdateRequest() {
+        ProductInfoUpdateRequestDto productInfo = ProductInfoUpdateRequestDto.builder()
+                .brandId(1L)
+                .categoryId(1L)
+                .name("Updated Product")
+                .code("TP001-U")
+                .releasePrice(BigDecimal.valueOf(12000))
+                .releasedDate(LocalDateTime.of(2026, 1, 21, 0, 0))
+                .build();
+
+        ProductVariantUpdateRequestDto variant = ProductVariantUpdateRequestDto.builder()
+                .productId(1L)
+                .optionValueIds(List.of(1L, 2L))
+                .inventory(150L)
+                .imageUrls(List.of("http://example.com/updated_image.jpg"))
+                .build();
+
+        return ProductUpdateRequestDto.builder()
+                .productInfo(productInfo)
+                .variants(List.of(variant))
+                .build();
+    }
+
+    public static ProductResponseDto createProductResponse() {
+        BrandDto brand = BrandDto.builder()
+                .brandId(1L)
+                .name("Test Brand")
+                .logoUrl("http://example.com/logo.png")
+                .build();
+        CategoryDto category = CategoryDto.builder()
+                .categoryId(1L)
+                .name("Test Category")
+                .imageUrl("http://example.com/category.png")
+                .build();
+
+        ProductInfoDto productInfo = ProductInfoDto.builder()
+                .productInfoId(1L)
+                .brand(brand)
+                .category(category)
+                .name("Test Product")
+                .code("TP001")
+                .releasePrice(BigDecimal.valueOf(10000))
+                .releaseDate(LocalDateTime.now())
+                .build();
+
+        ProductOptionDto option = ProductOptionDto.builder()
+                .productOptionValueId(1L)
+                .groupName("Color")
+                .value("Black")
+                .build();
+        ProductDto product = ProductDto.builder()
+                .productId(1L)
+                .inventory(100L)
+                .options(List.of(option))
+                .imageUrls(List.of("http://example.com/image.jpg"))
+                .build();
+
+        return ProductResponseDto.builder()
+                .productInfo(productInfo)
+                .products(List.of(product))
+                .build();
+    }
+
+    public static ProductResponseDto createUpdatedProductResponse() {
+        BrandDto brand = BrandDto.builder()
+                .brandId(1L)
+                .name("Test Brand")
+                .logoUrl("http://example.com/logo.png")
+                .build();
+        CategoryDto category = CategoryDto.builder()
+                .categoryId(1L)
+                .name("Test Category")
+                .imageUrl("http://example.com/category.png")
+                .build();
+
+        ProductInfoDto productInfo = ProductInfoDto.builder()
+                .productInfoId(1L)
+                .brand(brand)
+                .category(category)
+                .name("Updated Product")
+                .code("TP001-U")
+                .releasePrice(BigDecimal.valueOf(12000))
+                .releaseDate(LocalDateTime.now())
+                .build();
+
+        ProductOptionDto option = ProductOptionDto.builder()
+                .productOptionValueId(1L)
+                .groupName("Color")
+                .value("Black")
+                .build();
+        ProductDto product = ProductDto.builder()
+                .productId(1L)
+                .inventory(150L)
+                .options(List.of(option))
+                .imageUrls(List.of("http://example.com/updated_image.jpg"))
+                .build();
+
+        return ProductResponseDto.builder()
+                .productInfo(productInfo)
+                .products(List.of(product))
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #27 #28 #29

## 🔎 작업 내용

- **상품(Product) CRUD API 구현**
    - 상품 생성, 수정, 삭제 기능을 위한 API 엔드포인트를 추가했습니다.
    - `ProductFacade`를 중심으로 여러 유스케이스(Brand, Category, Option, ProductInfo, Product)를 오케스트레이션하여 비즈니스 로직을 처리합니다.
- **상품 Variant 모델링 및 관리**
    - 하나의 상품 정보(`ProductInfo`)가 여러 옵션을 가진 상품(`Product`, 이하 Variant)들을 가질 수 있도록 모델링했습니다.
    - 상품 생성 시 여러 Variant를 한 번에 생성할 수 있습니다.
    - 상품 수정 시 각 Variant의 추가, 수정, 삭제를 한 번의 요청으로 처리할 수 있는 로직을 구현했습니다.
        - 요청에 `productId`가 없으면 신규 Variant로 간주하여 생성합니다.
        - 요청에 포함되지 않은 기존 Variant는 삭제(Soft-delete)합니다.
        - 기존 Variant의 옵션, 재고, 이미지 등을 수정합니다.
- **도메인 및 데이터베이스 스키마**
    - `ProductInfo`와 `Product`를 분리하여 상품 공통 정보와 개별 옵션 상품을 관리합니다.
    - `ProductOptionValues`, `ProductImage`를 통해 각 Variant의 옵션과 이미지를 관리합니다.
    - `ProductInfo`에 브랜드와 상품 코드를 기준으로 `UniqueConstraint`를 추가하여 데이터 무결성을 강화했습니다.
- **예외 처리 및 유효성 검사**
    - 상품 생성/수정 시 필요한 `FailureCode`(를 추가했습니다.
    - 각 DTO에 `@Valid`와 관련 어노테이션을 사용하여 유효성 검사를 강화했습니다.
- **테스트 코드 작성**
    - 컨트롤러(`ApiV1ProductControllerTest`), 퍼사드 통합(`ProductFacadeTest`), 유스케이스 단위(`ProductUseCaseTest` 등) 테스트 코드를 작성하여 구현된 기능의 안정성을 검증했습니다.
    <br>

## 📌 참고 사항

- **집중 리뷰**
    - `ProductUseCase`의 `updateMultipleProduct` 메서드 로직이 복잡합니다. Variant의 추가/수정/삭제를 한 번에 처리하는 부분에 대한 리뷰를 부탁드립니다.
- **주의해야 할 점**
    - 상품 삭제는 `ProductInfo`를 기준으로 하위의 모든 `Product`와 관련 데이터(`ProductOptionValues`, `ProductImage`)를 Soft-delete 방식으로 처리합니다.

## 📷 테스트 결과

- Swagger
    - 상품 생성
    <img width="1071" height="1176" alt="image" src="https://github.com/user-attachments/assets/d6d99640-e253-433f-b705-34a14e3a1116" />

    - 상품 수정
    <img width="952" height="1163" alt="image" src="https://github.com/user-attachments/assets/857e0023-3c0f-473e-8399-9a8949bba49d" />

    - 상품 삭제
    <img width="1073" height="717" alt="image" src="https://github.com/user-attachments/assets/f1dcc1cc-0308-4f4a-8d66-0358c459a6cf" />

- 테스트
    - `ApiV1ProductControllerTest` - 단위 테스트
    <img width="463" height="303" alt="image" src="https://github.com/user-attachments/assets/f69e1cc2-96e6-4906-88be-31b082a529ef" />

    - `OptionUseCaseTest` - 단위 테스트
    <img width="469" height="133" alt="image" src="https://github.com/user-attachments/assets/af50a3ee-c1b6-4e60-87de-2e90b0a6b2a0" />

    - `ProductInfoUseCaseTest` - 단위 테스트
    <img width="458" height="227" alt="image" src="https://github.com/user-attachments/assets/11a7b45e-a1b4-4593-9408-3a212066ea91" />

    - `ProductUseCaseTest` - 단위 테스트
    <img width="458" height="194" alt="image" src="https://github.com/user-attachments/assets/1eefe0c4-95dc-4948-b7a5-72a01e08c2ff" />

    - `ProductFacade` - 통합 테스트
    <img width="454" height="193" alt="image" src="https://github.com/user-attachments/assets/62658dc5-a4b1-4c9d-8451-28f8707e18dd" />

---

## ✅ Check List

- [x]  라벨 지정
- [x]  리뷰어 지정
- [x]  담당자 지정
- [x]  테스트 완료
- [x]  이슈 제목 컨벤션 준수
- [x]  PR 제목 및 설명 작성
- [x]  커밋 메시지 컨벤션 준수