### PR TITLE
[FEAT] 정산 상태 관리 (#23, #24)

### DIFF
--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -54,6 +54,8 @@ public enum FailureCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "ENTITY_NOT_FOUND", "대상을 찾을 수 없습니다."),
     SETTLEMENT_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT_ITEM_NOT_FOUND", "정산 상품을 찾을 수 없습니다."),
     SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT_NOT_FOUND", "해당 정산서를 찾을 수 없습니다."),
+    REQUIRED_FAILURE_REASON(HttpStatus.NOT_FOUND, "FAILURE_REASON_REQUIRED", "실패 사유는 필수입니다."),
+    REQUIRED_HOLD_REASON(HttpStatus.NOT_FOUND, "HOLD", "보류 사유는 필수입니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_ROOM_NOT_FOUND", "해당 채팅방을 찾을 수 없습니다."),
     WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "WALLET_NOT_FOUND", "사용자 지갑을 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),

--- a/settlement/src/main/java/com/back/settlement/adapter/in/SettlementLogController.java
+++ b/settlement/src/main/java/com/back/settlement/adapter/in/SettlementLogController.java
@@ -1,0 +1,38 @@
+package com.back.settlement.adapter.in;
+
+import com.back.common.code.SuccessCode;
+import com.back.common.response.CommonResponse;
+import com.back.settlement.app.dto.response.SettlementLogResponse;
+import com.back.settlement.app.facade.SettlementFacade;
+import com.back.settlement.app.usecase.SettlementLogReadUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "정산 로그 관련 API (Admin)", description = "정산 로그 조회 API (관리자 전용)")
+@RestController
+@RequestMapping("/api/v1/admin/settlements")
+@RequiredArgsConstructor
+public class SettlementLogController {
+    private final SettlementFacade settlementFacade;
+
+    @Operation(summary = "정산 로그 조회", description = "특정 정산서의 상태 변경 로그를 조회합니다.")
+    @GetMapping("/{settlementId}/logs")
+    public CommonResponse<List<SettlementLogResponse>> getSettlementLogs() {
+        // TODO: 권한 체크 필요 (인증된 사용자에서 sellerId 추출)
+        Long sellerId = 1L;
+        List<SettlementLogResponse> logs = settlementFacade.getLogsBySettlementId(sellerId);
+        return CommonResponse.success(SuccessCode.OK, logs);
+    }
+
+    @Operation(summary = "전체 로그 조회", description = "모든 정산 상태 변경 로그를 조회합니다.")
+    @GetMapping("/logs")
+    public CommonResponse<List<SettlementLogResponse>> getAllLogs() {
+        List<SettlementLogResponse> logs = settlementFacade.getAllLogs();
+        return CommonResponse.success(SuccessCode.OK, logs);
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/adapter/out/SettlementLogRepository.java
+++ b/settlement/src/main/java/com/back/settlement/adapter/out/SettlementLogRepository.java
@@ -1,0 +1,10 @@
+package com.back.settlement.adapter.out;
+
+import com.back.settlement.domain.SettlementLog;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementLogRepository extends JpaRepository<SettlementLog, Long> {
+    // 특정 정산서의 모든 상태 변경 로그를 조회
+    List<SettlementLog> findBySettlementIdOrderByCreatedAtAsc(Long settlementId);
+}

--- a/settlement/src/main/java/com/back/settlement/app/dto/response/SettlementLogResponse.java
+++ b/settlement/src/main/java/com/back/settlement/app/dto/response/SettlementLogResponse.java
@@ -1,0 +1,19 @@
+package com.back.settlement.app.dto.response;
+
+import com.back.settlement.domain.SettlementLog.ActorType;
+import com.back.settlement.domain.SettlementStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record SettlementLogResponse(
+        Long logId,
+        Long settlementId,
+        SettlementStatus previousStatus,
+        SettlementStatus newStatus,
+        String reason,
+        ActorType actorType,
+        Long actorId,
+        LocalDateTime createdAt
+) {
+}

--- a/settlement/src/main/java/com/back/settlement/app/event/handler/SettlementLogEventHandler.java
+++ b/settlement/src/main/java/com/back/settlement/app/event/handler/SettlementLogEventHandler.java
@@ -1,0 +1,88 @@
+package com.back.settlement.app.event.handler;
+
+import com.back.settlement.adapter.out.SettlementLogRepository;
+import com.back.settlement.adapter.out.SettlementRepository;
+import com.back.settlement.domain.Settlement;
+import com.back.settlement.domain.SettlementLog;
+import com.back.settlement.domain.SettlementLog.ActorType;
+import com.back.settlement.domain.event.SettlementCreatedEvent;
+import com.back.settlement.domain.event.SettlementStatusChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SettlementLogEventHandler {
+    private final SettlementLogRepository settlementLogRepository;
+    private final SettlementRepository settlementRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleCreated(SettlementCreatedEvent event) {
+        log.debug("정산서 생성 이벤트 수신. settlementId={}, sellerId={}", event.settlementId(), event.sellerId());
+
+        Settlement settlement = findSettlementForEvent(event);
+        SettlementLog logEntry = SettlementLog.create(
+                settlement,
+                event.previousStatus(),
+                event.newStatus(),
+                event.reason(),
+                ActorType.BATCH
+        );
+
+        settlementLogRepository.save(logEntry);
+        log.info("정산서 생성 로그 기록 완료. settlementId={}, status={}", settlement.getId(), event.newStatus());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleStatusChanged(SettlementStatusChangedEvent event) {
+        if (event instanceof SettlementCreatedEvent) {
+            return;
+        }
+        log.debug("상태 변경 이벤트 수신. settlementId={}, {} → {}", event.settlementId(), event.previousStatus(), event.newStatus());
+
+        Settlement settlement = settlementRepository.findById(event.settlementId()).orElse(null);
+
+        if (settlement == null) {
+            log.warn("정산서를 찾을 수 없습니다. 로그 기록 생략. settlementId={}", event.settlementId());
+            return;
+        }
+
+        ActorType actorType = determineActorType(event);
+
+        SettlementLog logEntry = SettlementLog.create(
+                settlement,
+                event.previousStatus(),
+                event.newStatus(),
+                event.reason(),
+                actorType
+        );
+
+        settlementLogRepository.save(logEntry);
+        log.info("상태 변경 로그 기록 완료. settlementId={}, {} → {}, reason={}",
+                settlement.getId(),
+                event.previousStatus(),
+                event.newStatus(),
+                event.reason());
+    }
+
+    private Settlement findSettlementForEvent(SettlementCreatedEvent event) {
+        if (event.settlementId() != null) {
+            return settlementRepository.findById(event.settlementId()).orElse(null);
+        }
+
+        return settlementRepository.findBySellerId(event.sellerId())
+                .stream()
+                .filter(s -> s.getStatus() == event.newStatus())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private ActorType determineActorType(SettlementStatusChangedEvent event) {
+        // TODO: 요청 컨텍스트(예: SecurityContext)를 확인하여 ActorType 결정
+        return ActorType.BATCH;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/app/facade/SettlementFacade.java
+++ b/settlement/src/main/java/com/back/settlement/app/facade/SettlementFacade.java
@@ -1,7 +1,9 @@
 package com.back.settlement.app.facade;
 
 import com.back.settlement.app.dto.response.SettlementItemResponse;
+import com.back.settlement.app.dto.response.SettlementLogResponse;
 import com.back.settlement.app.dto.response.SettlementResponse;
+import com.back.settlement.app.usecase.SettlementLogReadUseCase;
 import com.back.settlement.app.usecase.SettlementReadUseCase;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SettlementFacade {
     private final SettlementReadUseCase settlementReadUseCase;
+    private final SettlementLogReadUseCase settlementLogReadUseCase;
 
     public List<SettlementResponse> getSettlements(Long sellerId) {
         return settlementReadUseCase.getSettlements(sellerId);
@@ -18,6 +21,14 @@ public class SettlementFacade {
 
     public SettlementItemResponse getSettlementItem(Long settlementItemId, Long sellerId) {
         return settlementReadUseCase.getSettlementItem(settlementItemId, sellerId);
+    }
+
+    public List<SettlementLogResponse> getLogsBySettlementId(Long settlementId) {
+        return settlementLogReadUseCase.getLogsBySettlementId(settlementId);
+    }
+
+    public List<SettlementLogResponse> getAllLogs() {
+        return settlementLogReadUseCase.getAllLogs();
     }
 
 }

--- a/settlement/src/main/java/com/back/settlement/app/support/DomainEventPublisher.java
+++ b/settlement/src/main/java/com/back/settlement/app/support/DomainEventPublisher.java
@@ -1,0 +1,31 @@
+package com.back.settlement.app.support;
+
+import com.back.settlement.domain.Settlement;
+import com.back.settlement.domain.event.SettlementEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DomainEventPublisher {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publishEvents(Settlement settlement) {
+        if (settlement.getDomainEvents().isEmpty()) {
+            log.debug("발행할 이벤트가 없습니다. settlementId={}", settlement.getId());
+            return;
+        }
+
+        log.debug("도메인 이벤트 발행 시작. settlementId={}, eventCount={}", settlement.getId(), settlement.getDomainEvents().size());
+
+        settlement.getDomainEvents().forEach(event -> {
+            log.debug("이벤트 발행: {}", event.getClass().getSimpleName());
+            eventPublisher.publishEvent(event);
+        });
+        settlement.clearDomainEvents();
+        log.debug("도메인 이벤트 발행 완료. settlementId={}", settlement.getId());
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/app/usecase/SettlementCreateUseCase.java
+++ b/settlement/src/main/java/com/back/settlement/app/usecase/SettlementCreateUseCase.java
@@ -8,6 +8,7 @@ import com.back.settlement.adapter.out.SettlementItemRepository;
 import com.back.settlement.adapter.out.SettlementRepository;
 import com.back.settlement.app.dto.internal.SettlementWithItems;
 import com.back.settlement.app.dto.request.SettlementRequest;
+import com.back.settlement.app.support.DomainEventPublisher;
 import com.back.settlement.app.support.SettlementSupport;
 import com.back.settlement.app.support.YearMonthUtils;
 import com.back.settlement.domain.Settlement;
@@ -31,6 +32,7 @@ public class SettlementCreateUseCase {
     private final SettlementRepository settlementRepository;
     private final SettlementItemRepository settlementItemRepository;
     private final SettlementSupport settlementSupport;
+    private final DomainEventPublisher domainEventPublisher;
     private static final String SYSTEM_NAME = "SYSTEM";
 
     public SettlementWithItems createSettlementForPayee(Long payeeId, YearMonth targetMonth) {
@@ -72,6 +74,7 @@ public class SettlementCreateUseCase {
         Settlement savedSettlement = settlementRepository.save(settlement);
         items.forEach(item -> item.addSettlement(savedSettlement));
         settlementItemRepository.saveAll(items);
+        domainEventPublisher.publishEvents(savedSettlement);
     }
 
     private String extractPayeeName(List<SettlementItem> items) {

--- a/settlement/src/main/java/com/back/settlement/app/usecase/SettlementLogReadUseCase.java
+++ b/settlement/src/main/java/com/back/settlement/app/usecase/SettlementLogReadUseCase.java
@@ -1,0 +1,28 @@
+package com.back.settlement.app.usecase;
+
+import com.back.settlement.adapter.out.SettlementLogRepository;
+import com.back.settlement.app.dto.response.SettlementLogResponse;
+import com.back.settlement.domain.SettlementLog;
+import com.back.settlement.mapper.SettlementMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementLogReadUseCase {
+    private final SettlementLogRepository settlementLogRepository;
+    private final SettlementMapper settlementMapper;
+
+    public List<SettlementLogResponse> getLogsBySettlementId(Long settlementId) {
+        List<SettlementLog> settlementLogs = settlementLogRepository.findBySettlementIdOrderByCreatedAtAsc(settlementId);
+        return settlementMapper.toSettlementLogResponseList(settlementLogs);
+    }
+
+    public List<SettlementLogResponse> getAllLogs() {
+        List<SettlementLog> settlementLogs = settlementLogRepository.findAll();
+        return settlementMapper.toSettlementLogResponseList(settlementLogs);
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/Settlement.java
+++ b/settlement/src/main/java/com/back/settlement/domain/Settlement.java
@@ -1,7 +1,17 @@
 package com.back.settlement.domain;
 
+import static com.back.common.code.FailureCode.*;
+
 import com.back.common.entity.BaseTimeEntity;
+import com.back.common.exception.BadRequestException;
 import com.back.settlement.app.dto.request.SettlementRequest;
+import com.back.settlement.domain.event.SettlementCreatedEvent;
+import com.back.settlement.domain.event.SettlementEvent;
+import com.back.settlement.domain.event.SettlementFailedEvent;
+import com.back.settlement.domain.event.SettlementHoldEvent;
+import com.back.settlement.domain.event.SettlementInternalCompletedEvent;
+import com.back.settlement.domain.event.SettlementStartedEvent;
+import com.back.settlement.domain.exception.InvalidSettlementStateException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,9 +20,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -68,8 +82,11 @@ public class Settlement extends BaseTimeEntity {
     @Column(name = "total_net_amount", precision = 15, scale = 2)
     private BigDecimal totalNetAmount;
 
+    @Transient
+    private final List<SettlementEvent> domainEvents = new ArrayList<>();
+
     public static Settlement createSettlement(SettlementRequest request) {
-        return Settlement.builder()
+        Settlement settlement = Settlement.builder()
                 .sellerId(request.sellerId())
                 .sellerName(request.sellerName())
                 .status(SettlementStatus.PENDING)
@@ -81,6 +98,13 @@ public class Settlement extends BaseTimeEntity {
                 .totalFeeAmount(request.totalFeeAmount())
                 .totalNetAmount(request.totalNetAmount())
                 .build();
+
+        settlement.registerEvent(new SettlementCreatedEvent(
+                settlement.getId(),
+                settlement.getSellerId(),
+                settlement.getTotalNetAmount()
+        ));
+        return settlement;
     }
 
     private static LocalDateTime calculateExpectedDate(LocalDateTime endAt) {
@@ -92,8 +116,78 @@ public class Settlement extends BaseTimeEntity {
                 .withNano(0);
     }
 
+    // 정산 시작 처리
+    public void start() {
+        validateStatusTransition(SettlementStatus.IN_PROGRESS);
+
+        SettlementStatus previousStatus = this.status;
+        this.status = SettlementStatus.IN_PROGRESS;
+
+        registerEvent(new SettlementStartedEvent(this.id, previousStatus));
+    }
+
+    // 정산 완료 처리
     public void complete() {
+        validateStatusTransition(SettlementStatus.COMPLETED);
+
+        SettlementStatus previousStatus = this.status;
         this.status = SettlementStatus.COMPLETED;
         this.completedAt = LocalDateTime.now();
+
+        registerEvent(new SettlementInternalCompletedEvent(
+                this.id,
+                previousStatus,
+                this.totalNetAmount,
+                this.sellerId
+        ));
+    }
+
+    // 정산 보류 처리
+    public void hold(String reason) {
+        // TODO 보류 관련 처리시 reason 수정 예정
+        String actualReason = (reason == null || reason.isBlank()) ? "판매자 계좌 정보 없음" : reason;
+
+        validateStatusTransition(SettlementStatus.HOLD);
+
+        SettlementStatus previousStatus = this.status;
+        this.status = SettlementStatus.HOLD;
+
+        registerEvent(new SettlementHoldEvent(this.id, previousStatus, actualReason));
+    }
+
+    // 정산 실패 처리
+    public void fail(String reason) {
+        if (reason == null || reason.isBlank()) {
+            throw new BadRequestException(REQUIRED_FAILURE_REASON);
+        }
+
+        validateStatusTransition(SettlementStatus.FAILED);
+
+        SettlementStatus previousStatus = this.status;
+        this.status = SettlementStatus.FAILED;
+
+        registerEvent(new SettlementFailedEvent(this.id, previousStatus, reason));
+    }
+
+    // 상태 전이 유효성을 검증
+    private void validateStatusTransition(SettlementStatus targetStatus) {
+        if (!this.status.canTransitionTo(targetStatus)) {
+            throw new InvalidSettlementStateException(this.status, targetStatus);
+        }
+    }
+
+    // 도메인 이벤트 등록
+    private void registerEvent(SettlementEvent event) {
+        this.domainEvents.add(event);
+    }
+
+    // 등록된 도메인 이벤트 목록 조회
+    public List<SettlementEvent> getDomainEvents() {
+        return Collections.unmodifiableList(domainEvents);
+    }
+
+    // 등록된 도메인 이벤트 제거
+    public void clearDomainEvents() {
+        this.domainEvents.clear();
     }
 }

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementLog.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementLog.java
@@ -15,29 +15,70 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 @Table(name = "settlement_log")
 public class SettlementLog extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "settlement_id")
-    @NotNull
     private Settlement settlement;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "previous_status", length = 20)
     private SettlementStatus previousStatus;
 
-    @Enumerated(EnumType.STRING)
     @NotNull
+    @Enumerated(EnumType.STRING)
     @Column(name = "new_status", length = 20)
     private SettlementStatus newStatus;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "actor_type", length = 20)
+    private ActorType actorType;
+
+    @Column(name = "actor_id")
+    private Long actorId;
+
+    public static SettlementLog create(Settlement settlement, SettlementStatus previousStatus, SettlementStatus newStatus, String reason, ActorType actorType) {
+        return SettlementLog.builder()
+                .settlement(settlement)
+                .previousStatus(previousStatus)
+                .newStatus(newStatus)
+                .reason(reason)
+                .actorType(actorType)
+                .actorId(null)
+                .build();
+    }
+
+    public static SettlementLog createByAdmin(Settlement settlement, SettlementStatus previousStatus, SettlementStatus newStatus, String reason, Long adminId) {
+        return SettlementLog.builder()
+                .settlement(settlement)
+                .previousStatus(previousStatus)
+                .newStatus(newStatus)
+                .reason(reason)
+                .actorType(ActorType.ADMIN)
+                .actorId(adminId)
+                .build();
+    }
+
+    public enum ActorType {
+        SYSTEM,
+        ADMIN,
+        BATCH
+    }
 }

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementStatus.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementStatus.java
@@ -1,12 +1,39 @@
 package com.back.settlement.domain;
 
+import java.util.Set;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SettlementStatus {
-    PENDING,      // 정산 대기: 정산 집계 전, 아직 처리 시작 안 함
-    IN_PROGRESS,  // 정산 진행 중: 정산 집계/계산 진행 중
-    HOLD,         // 보류: 관리자가 일시 중단 (문제 발생 등)
-    COMPLETED,    // 정산 완료: 정산 완료, 지급됨
-    FAILED        // 정산 실패: 정산 처리 실패
+    PENDING("정산 대기"),      // 정산 대기: 정산 집계 전, 아직 처리 시작 안 함
+    IN_PROGRESS("정산 진행중"),  // 정산 진행 중: 정산 집계/계산 진행 중
+    HOLD("보류"),         // 보류: 관리자가 일시 중단 (문제 발생 등)
+    COMPLETED("정산 완료"),    // 정산 완료: 정산 완료, 지급됨
+    FAILED("정산 실패");        // 정산 실패: 정산 처리 실패
+
+    private final String value;
+
+    public Set<SettlementStatus> getAllowedTransitions() {
+        return switch (this) {
+            case PENDING -> Set.of(IN_PROGRESS, HOLD, FAILED);
+            case IN_PROGRESS -> Set.of(COMPLETED, HOLD, FAILED);
+            case HOLD -> Set.of(IN_PROGRESS, FAILED);
+            case COMPLETED, FAILED -> Set.of();  // 최종 상태, 전이 불가
+        };
+    }
+
+    public boolean canTransitionTo(SettlementStatus targetStatus) {
+        return getAllowedTransitions().contains(targetStatus);
+    }
+
+    public boolean isTerminal() {
+        return this == COMPLETED || this == FAILED;
+    }
+
+    public boolean isProcessing() {
+        return !isTerminal();
+    }
 }

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementCreatedEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementCreatedEvent.java
@@ -1,0 +1,32 @@
+package com.back.settlement.domain.event;
+
+import com.back.settlement.domain.SettlementStatus;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record SettlementCreatedEvent(
+        Long settlementId,
+        Long sellerId,
+        BigDecimal totalNetAmount,
+        LocalDateTime occurredAt
+) implements SettlementStatusChangedEvent {
+
+    public SettlementCreatedEvent(Long settlementId, Long sellerId, BigDecimal totalNetAmount) {
+        this(settlementId, sellerId, totalNetAmount, LocalDateTime.now());
+    }
+
+    @Override
+    public SettlementStatus previousStatus() {
+        return null;
+    }
+
+    @Override
+    public SettlementStatus newStatus() {
+        return SettlementStatus.PENDING;
+    }
+
+    @Override
+    public String reason() {
+        return "정산서 생성";
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementEvent.java
@@ -1,0 +1,8 @@
+package com.back.settlement.domain.event;
+
+import java.time.LocalDateTime;
+
+public sealed interface SettlementEvent permits SettlementStatusChangedEvent {
+    Long settlementId();
+    LocalDateTime occurredAt();
+}

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementFailedEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementFailedEvent.java
@@ -1,0 +1,21 @@
+package com.back.settlement.domain.event;
+
+import com.back.settlement.domain.SettlementStatus;
+import java.time.LocalDateTime;
+
+public record SettlementFailedEvent(
+        Long settlementId,
+        SettlementStatus previousStatus,
+        String reason,
+        LocalDateTime occurredAt
+) implements SettlementStatusChangedEvent {
+
+    public SettlementFailedEvent(Long settlementId, SettlementStatus previousStatus, String reason) {
+        this(settlementId, previousStatus, reason, LocalDateTime.now());
+    }
+
+    @Override
+    public SettlementStatus newStatus() {
+        return SettlementStatus.FAILED;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementHoldEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementHoldEvent.java
@@ -1,0 +1,21 @@
+package com.back.settlement.domain.event;
+
+import com.back.settlement.domain.SettlementStatus;
+import java.time.LocalDateTime;
+
+public record SettlementHoldEvent(
+        Long settlementId,
+        SettlementStatus previousStatus,
+        String reason,
+        LocalDateTime occurredAt
+) implements SettlementStatusChangedEvent {
+
+    public SettlementHoldEvent(Long settlementId, SettlementStatus previousStatus, String reason) {
+        this(settlementId, previousStatus, reason, LocalDateTime.now());
+    }
+
+    @Override
+    public SettlementStatus newStatus() {
+        return SettlementStatus.HOLD;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementInternalCompletedEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementInternalCompletedEvent.java
@@ -1,0 +1,35 @@
+package com.back.settlement.domain.event;
+
+import com.back.settlement.domain.SettlementStatus;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 정산 완료 이벤트 (모듈 내부용).
+ */
+public record SettlementInternalCompletedEvent(
+        Long settlementId,
+        SettlementStatus previousStatus,
+        BigDecimal totalNetAmount,
+        Long sellerId,
+        LocalDateTime occurredAt
+) implements SettlementStatusChangedEvent {
+
+    public SettlementInternalCompletedEvent(
+            Long settlementId,
+            SettlementStatus previousStatus,
+            BigDecimal totalNetAmount,
+            Long sellerId) {
+        this(settlementId, previousStatus, totalNetAmount, sellerId, LocalDateTime.now());
+    }
+
+    @Override
+    public SettlementStatus newStatus() {
+        return SettlementStatus.COMPLETED;
+    }
+
+    @Override
+    public String reason() {
+        return "정산 완료";
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementStartedEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementStartedEvent.java
@@ -1,0 +1,21 @@
+package com.back.settlement.domain.event;
+
+import com.back.settlement.domain.SettlementStatus;
+import java.time.LocalDateTime;
+
+public record SettlementStartedEvent(
+        Long settlementId,
+        SettlementStatus previousStatus,
+        String reason,
+        LocalDateTime occurredAt
+) implements SettlementStatusChangedEvent {
+
+    public SettlementStartedEvent(Long settlementId, SettlementStatus previousStatus) {
+        this(settlementId, previousStatus, "정산 처리 시작", LocalDateTime.now());
+    }
+
+    @Override
+    public SettlementStatus newStatus() {
+        return SettlementStatus.IN_PROGRESS;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/event/SettlementStatusChangedEvent.java
+++ b/settlement/src/main/java/com/back/settlement/domain/event/SettlementStatusChangedEvent.java
@@ -1,0 +1,9 @@
+package com.back.settlement.domain.event;
+
+import com.back.settlement.domain.SettlementStatus;
+
+public sealed interface SettlementStatusChangedEvent extends SettlementEvent permits SettlementCreatedEvent, SettlementStartedEvent, SettlementInternalCompletedEvent, SettlementFailedEvent, SettlementHoldEvent {
+    SettlementStatus previousStatus();
+    SettlementStatus newStatus();
+    String reason();
+}

--- a/settlement/src/main/java/com/back/settlement/domain/exception/InvalidSettlementStateException.java
+++ b/settlement/src/main/java/com/back/settlement/domain/exception/InvalidSettlementStateException.java
@@ -1,0 +1,28 @@
+package com.back.settlement.domain.exception;
+
+import com.back.settlement.domain.SettlementStatus;
+
+public class InvalidSettlementStateException extends RuntimeException {
+    private final SettlementStatus currentStatus;
+    private final SettlementStatus targetStatus;
+
+    public InvalidSettlementStateException(SettlementStatus currentStatus, SettlementStatus targetStatus) {
+        super(String.format("잘못된 상태 전이: %s → %s (허용된 전이: %s)", currentStatus, targetStatus, currentStatus.getAllowedTransitions()));
+        this.currentStatus = currentStatus;
+        this.targetStatus = targetStatus;
+    }
+
+    public InvalidSettlementStateException(String message) {
+        super(message);
+        this.currentStatus = null;
+        this.targetStatus = null;
+    }
+
+    public SettlementStatus getCurrentStatus() {
+        return currentStatus;
+    }
+
+    public SettlementStatus getTargetStatus() {
+        return targetStatus;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/mapper/SettlementMapper.java
+++ b/settlement/src/main/java/com/back/settlement/mapper/SettlementMapper.java
@@ -1,9 +1,11 @@
 package com.back.settlement.mapper;
 
 import com.back.settlement.app.dto.response.SettlementItemResponse;
+import com.back.settlement.app.dto.response.SettlementLogResponse;
 import com.back.settlement.app.dto.response.SettlementResponse;
 import com.back.settlement.domain.Settlement;
 import com.back.settlement.domain.SettlementItem;
+import com.back.settlement.domain.SettlementLog;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -50,6 +52,25 @@ public class SettlementMapper {
     public List<SettlementItemResponse> toSettlementItemResponseList(List<SettlementItem> settlementItems) {
         return settlementItems.stream()
                 .map(this::toSettlementItemResponse)
+                .toList();
+    }
+
+    public SettlementLogResponse toSettlementLogResponse(SettlementLog settlementLog) {
+        return SettlementLogResponse.builder()
+                .logId(settlementLog.getId())
+                .settlementId(settlementLog.getSettlement().getId())
+                .previousStatus(settlementLog.getPreviousStatus())
+                .newStatus(settlementLog.getNewStatus())
+                .reason(settlementLog.getReason())
+                .actorType(settlementLog.getActorType())
+                .actorId(settlementLog.getActorId())
+                .createdAt(settlementLog.getCreatedAt())
+                .build();
+    }
+
+    public List<SettlementLogResponse> toSettlementLogResponseList(List<SettlementLog> settlementLogs) {
+        return settlementLogs.stream()
+                .map(this::toSettlementLogResponse)
                 .toList();
     }
 }

--- a/settlement/src/test/java/com/back/settlement/domain/SettlementTest.java
+++ b/settlement/src/test/java/com/back/settlement/domain/SettlementTest.java
@@ -1,0 +1,215 @@
+package com.back.settlement.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.back.settlement.domain.event.SettlementFailedEvent;
+import com.back.settlement.domain.event.SettlementHoldEvent;
+import com.back.settlement.domain.event.SettlementInternalCompletedEvent;
+import com.back.settlement.domain.event.SettlementStartedEvent;
+import com.back.settlement.domain.exception.InvalidSettlementStateException;
+import com.back.settlement.fixture.SettlementFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Settlement 도메인 테스트")
+class SettlementTest {
+
+    @Nested
+    @DisplayName("상태 전이 테스트")
+    class StatusTransitionTest {
+
+        @Test
+        @DisplayName("PENDING → IN_PROGRESS 전이 성공")
+        void start_fromPending_success() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+
+            // when
+            settlement.start();
+
+            // then
+            assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("IN_PROGRESS → COMPLETED 전이 성공")
+        void complete_fromInProgress_success() {
+            // given
+            Settlement settlement = SettlementFixture.createSettlement(
+                    1L, 100L, "TestSeller", SettlementStatus.IN_PROGRESS);
+
+            // when
+            settlement.complete();
+
+            // then
+            assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
+            assertThat(settlement.getCompletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PENDING -> COMPLETED 예외 발생")
+        void complete_fromPending_throwsException() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+
+            // when & then
+            assertThatThrownBy(settlement::complete).isInstanceOf(InvalidSettlementStateException.class);
+        }
+
+        @Test
+        @DisplayName("보류 처리 성공")
+        void hold_success() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+
+            // when
+            settlement.hold("판매자 계정 검토 필요");
+
+            // then
+            assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.HOLD);
+        }
+
+        @Test
+        @DisplayName("보류 사유 없이 호출 시 기본 사유 적용")
+        void hold_withoutReason_usesDefaultReason() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+            settlement.clearDomainEvents();
+
+            // when
+            settlement.hold(null);
+
+            // then
+            assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.HOLD);
+            SettlementHoldEvent event = (SettlementHoldEvent) settlement.getDomainEvents().get(0);
+            assertThat(event.reason()).isEqualTo("판매자 계좌 정보 없음");
+        }
+
+        @Test
+        @DisplayName("실패 처리 성공")
+        void fail_success() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+
+            // when
+            settlement.fail("Cash 지급 실패");
+
+            // then
+            assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 발행 테스트")
+    class EventPublishTest {
+
+        @Test
+        @DisplayName("start() 호출 시")
+        void start_registersEvent() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+            settlement.clearDomainEvents();
+
+            // when
+            settlement.start();
+
+            // then
+            assertThat(settlement.getDomainEvents()).hasSize(1);
+            assertThat(settlement.getDomainEvents().get(0)).isInstanceOf(SettlementStartedEvent.class);
+        }
+
+        @Test
+        @DisplayName("complete() 호출 시")
+        void complete_registersEvent() {
+            // given
+            Settlement settlement = SettlementFixture.createSettlement(
+                    1L, 100L, "TestSeller", SettlementStatus.IN_PROGRESS);
+            settlement.clearDomainEvents();
+
+            // when
+            settlement.complete();
+
+            // then
+            assertThat(settlement.getDomainEvents()).hasSize(1);
+            assertThat(settlement.getDomainEvents().get(0))
+                    .isInstanceOf(SettlementInternalCompletedEvent.class);
+        }
+
+        @Test
+        @DisplayName("hold() 호출 시")
+        void hold_registersEvent() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+            settlement.clearDomainEvents();
+
+            // when
+            settlement.hold("테스트 사유");
+
+            // then
+            assertThat(settlement.getDomainEvents()).hasSize(1);
+            SettlementHoldEvent event = (SettlementHoldEvent) settlement.getDomainEvents().get(0);
+            assertThat(event.reason()).isEqualTo("테스트 사유");
+        }
+
+        @Test
+        @DisplayName("fail() 호출 시 ")
+        void fail_registersEvent() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+            settlement.clearDomainEvents();
+
+            // when
+            settlement.fail("실패 사유");
+
+            // then
+            assertThat(settlement.getDomainEvents()).hasSize(1);
+            SettlementFailedEvent event = (SettlementFailedEvent) settlement.getDomainEvents().get(0);
+            assertThat(event.reason()).isEqualTo("실패 사유");
+        }
+
+        @Test
+        @DisplayName("clearDomainEvents() 검증")
+        void clearDomainEvents_clearsAllEvents() {
+            // given
+            Settlement settlement = SettlementFixture.createPendingSettlement(1L, 100L);
+            settlement.start();
+            assertThat(settlement.getDomainEvents()).isNotEmpty();
+
+            // when
+            settlement.clearDomainEvents();
+
+            // then
+            assertThat(settlement.getDomainEvents()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("SettlementStatus 테스트")
+    class SettlementStatusTest {
+
+        @Test
+        @DisplayName("PENDING에서 허용된 전이 상태 검증")
+        void pending_allowedTransitions() {
+            assertThat(SettlementStatus.PENDING.canTransitionTo(SettlementStatus.IN_PROGRESS)).isTrue();
+            assertThat(SettlementStatus.PENDING.canTransitionTo(SettlementStatus.HOLD)).isTrue();
+            assertThat(SettlementStatus.PENDING.canTransitionTo(SettlementStatus.FAILED)).isTrue();
+            assertThat(SettlementStatus.PENDING.canTransitionTo(SettlementStatus.COMPLETED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("COMPLETED는 최종 상태")
+        void completed_isTerminal() {
+            assertThat(SettlementStatus.COMPLETED.isTerminal()).isTrue();
+            assertThat(SettlementStatus.COMPLETED.getAllowedTransitions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("FAILED는 최종 상태")
+        void failed_isTerminal() {
+            assertThat(SettlementStatus.FAILED.isTerminal()).isTrue();
+            assertThat(SettlementStatus.FAILED.getAllowedTransitions()).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #23, #24 

## 🔎 작업 내용
- Settlement 도메인에 상태 전이 규칙 및 도메인 이벤트 발행 기능 추가
- SettlementLog를 통한 상태 변경 이력 자동 기록
- 정산서 변경 이력 조회 API 추가
<br>

## 📌 참고 사항
- 정합성 및 트랜잭션 범위에 대해 고민해볼 시간이 필요하여 세미 프로젝트 이후 최적화 및 고도화 작업 진행할 때 수정 예정입니다.
  Ex) BEFORE COMMIT 으로 설정하여 정산서가 save 되기 직전에 에러가 날 경우 문제 발생


## 📷 테스트 결과
- 상태 변경 이력 자동 기록 결과
  <img width="1238" height="647" alt="스크린샷 2026-01-21 오후 6 13 38" src="https://github.com/user-attachments/assets/89fc3bc6-1563-4d36-905f-dffc8ca6b337" width="50%" height="50%"/> <br>
- 조회 결과
  <img width="1419" height="737" alt="스크린샷 2026-01-21 오후 6 13 46" src="https://github.com/user-attachments/assets/a23895a4-bc80-4adf-8bd6-98d1f0d92c34" width="50%" height="50%"/>


## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
