### PR TITLE
[FEAT] 상품 상세 조회 기능 구현 (#31)

### DIFF
--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductController.java
@@ -43,4 +43,11 @@ public class ApiV1ProductController implements ProductApiController {
         productFacade.deleteProduct(productInfoId);
         return CommonResponse.success(SuccessCode.NO_CONTENT, null);
     }
+
+    @Override
+    @GetMapping("/{productInfoId}")
+    public CommonResponse<ProductResponseDto> getProductDetail(@PathVariable Long productInfoId) {
+        ProductResponseDto response = productFacade.getProductDetail(productInfoId);
+        return CommonResponse.success(SuccessCode.OK, response);
+    }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
@@ -43,6 +43,7 @@ public interface ProductApiController {
             삭제되는 상품에 매칭되는 상품 옵션(ProductOptionValues) 및 이미지(ProductImage)를 삭제합니다.
             모든 삭제는 Soft Delete를 준수합니다.
     """)
+    @ApiResponse(responseCode = "204", description = "상품 삭제 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)

--- a/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductApiController.java
@@ -48,4 +48,15 @@ public interface ProductApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> deleteProduct(Long productInfoId);
+
+    @Operation(summary = "상품 상세 조회", description = """
+            상품의 상세 정보를 조회합니다.
+            상품 기본 정보 (ProductInfo)를 기반으로 이로 파생된 상세 상품(Product)들을 모두 조회합니다.
+            ex. A 상품(ProductInfo)의 색상, 사이즈(ProductOptionValues)에 따른 개별 상품(Product) 조회
+    """)
+    @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> getProductDetail(Long productInfoId);
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -88,6 +88,15 @@ public class ProductFacade {
         productInfoUseCase.deleteProductInfo(productInfoId);
     }
 
+    @Transactional(readOnly = true)
+    public ProductResponseDto getProductDetail(Long productInfoId) {
+        ProductInfo productInfo = productInfoUseCase.findProductInfo(productInfoId);
+
+        List<ProductDto> productDtos = productUseCase.findAllProduct(productInfo);
+
+        return buildProductResponseDto(productInfo, productDtos);
+    }
+
     private ProductResponseDto buildProductResponseDto(ProductInfo productInfo, List<ProductDto> productDtos) {
         return ProductResponseDto.builder()
                 .productInfo(productInfoMapper.toDto(productInfo))

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -60,6 +60,11 @@ public class ProductInfoUseCase {
         productInfoRepository.delete(productInfo);
     }
 
+    @Transactional(readOnly = true)
+    public ProductInfo findProductInfo(Long productInfoId) {
+        return getProductInfoExists(productInfoId);
+    }
+
     private ProductInfo getProductInfoExists(Long productInfoId) {
         return productSupport.findProductInfoById(productInfoId)
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -55,9 +55,13 @@ public class ProductInfoUseCase {
 
     @Transactional
     public void deleteProductInfo(Long productInfoId) {
-        ProductInfo productInfo = productSupport.findProductInfoById(productInfoId)
-                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
+        ProductInfo productInfo = getProductInfoExists(productInfoId);
 
         productInfoRepository.delete(productInfo);
+    }
+
+    private ProductInfo getProductInfoExists(Long productInfoId) {
+        return productSupport.findProductInfoById(productInfoId)
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -84,6 +84,20 @@ public class ProductUseCase {
         deleteProducts(deletedProducts);
     }
 
+    @Transactional(readOnly = true)
+    public List<ProductDto> findAllProduct(ProductInfo productInfo) {
+        List<Product> products = productSupport.getAllProductsByProductInfo(productInfo);
+
+        if (products.isEmpty()) {
+            throw new CustomException(FailureCode.ENTITY_NOT_FOUND);
+        }
+
+        List<ProductOptionValues> productOptionValues = productSupport.getAllProductOptionValuesByProductsIn(products);
+        List<ProductImage> productImages = productSupport.getAllProductImagesByProductsIn(products);
+
+        return convertToDto(products, productOptionValues, productImages);
+    }
+
     private void handleCreations(ProductInfo productInfo, List<ProductVariantUpdateRequestDto> variantsToCreate, Map<Long, OptionValue> optionValueMap) {
         List<Product> createdProducts = new ArrayList<>();
         List<ProductOptionValues> createdProductOptionValues = new ArrayList<>();

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -71,11 +71,7 @@ public class ProductUseCase {
         handleUpdates(productInfo, variantsToUpdate, optionValueMap, existProducts);
         handleCreations(productInfo, variantsToCreate, optionValueMap);
 
-        List<Product> updatedProducts = productSupport.getAllProductsByProductInfo(productInfo);
-        List<ProductOptionValues> updatedProductOptionValues = productSupport.getAllProductOptionValuesByProductsIn(updatedProducts);
-        List<ProductImage> updatedProductImages = productSupport.getAllProductImagesByProductsIn(updatedProducts);
-
-        return convertToDto(updatedProducts, updatedProductOptionValues, updatedProductImages);
+        return findAllProduct(productInfo);
     }
 
     @Transactional

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductControllerTest.java
@@ -214,4 +214,49 @@ class ApiV1ProductControllerTest {
             verify(productFacade).deleteProduct(productInfoId);
         }
     }
+
+    @Nested
+    @DisplayName("GET /api/v1/products/{productInfoId}")
+    class GetProductDetailTest {
+
+        @Test
+        @DisplayName("상품 상세 조회를 성공한다")
+        @WithMockUser
+        void getProductDetail_Success() throws Exception {
+            // given
+            long productInfoId = 1L;
+            ProductResponseDto response = RequestFixture.createProductResponse();
+            given(productFacade.getProductDetail(productInfoId)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/products/{productInfoId}", productInfoId)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("OK"))
+                    .andExpect(jsonPath("$.data.productInfo.productInfoId").value(response.productInfo().productInfoId()))
+                    .andExpect(jsonPath("$.data.products[0].productId").value(response.products().getFirst().productId()));
+
+            verify(productFacade).getProductDetail(productInfoId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 정보 ID로 조회 시 404 Not Found를 반환한다")
+        @WithMockUser
+        void getProductDetail_Fail_NotFound() throws Exception {
+            // given
+            long productInfoId = 999L;
+            given(productFacade.getProductDetail(productInfoId))
+                    .willThrow(new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/products/{productInfoId}", productInfoId)
+                    ).andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("PRODUCT_INFO_NOT_FOUND"));
+
+            verify(productFacade).getProductDetail(productInfoId);
+        }
+    }
 }

--- a/product/src/test/java/com/back/product/app/ProductQueryTest.java
+++ b/product/src/test/java/com/back/product/app/ProductQueryTest.java
@@ -1,0 +1,139 @@
+package com.back.product.app;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.adapter.out.*;
+import com.back.product.domain.*;
+import com.back.product.dto.response.ProductResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+@DisplayName("ProductFacade 조회 통합 테스트")
+class ProductQueryTest {
+
+    @Autowired
+    private ProductFacade productFacade;
+
+    // DB-Setup & Verification
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductInfoRepository productInfoRepository;
+    @Autowired private ProductImageRepository productImageRepository;
+    @Autowired private ProductOptionValuesRepository productOptionValuesRepository;
+    @Autowired private BrandRepository brandRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private OptionGroupRepository optionGroupRepository;
+    @Autowired private OptionValueRepository optionValueRepository;
+
+    private Brand savedBrand;
+    private Category savedCategory;
+    private OptionValue savedOptionValueBlack;
+    private OptionValue savedOptionValue95;
+    private ProductInfo savedProductInfo;
+
+    @BeforeEach
+    void setUp() {
+        // Given: Prerequisite data
+        savedBrand = brandRepository.save(Brand.builder().name("Test Brand").imageUrl("logo.png").build());
+        savedCategory = categoryRepository.save(Category.builder().name("Test Category").imageUrl("img.png").build());
+
+        OptionGroup savedOptionGroupColor = optionGroupRepository.save(OptionGroup.builder().name("Color").build());
+        OptionGroup savedOptionGroupSize = optionGroupRepository.save(OptionGroup.builder().name("Size").build());
+
+        savedOptionValueBlack = optionValueRepository.save(OptionValue.builder().optionGroup(savedOptionGroupColor).value("Black").build());
+        savedOptionValue95 = optionValueRepository.save(OptionValue.builder().optionGroup(savedOptionGroupSize).value("95").build());
+
+        savedProductInfo = productInfoRepository.save(ProductInfo.builder()
+                .brand(savedBrand)
+                .category(savedCategory)
+                .name("Test Product")
+                .productCode("TEST-001")
+                .releasePrice(BigDecimal.valueOf(100000))
+                .releasedDate(LocalDateTime.now())
+                .build());
+
+        Product savedProduct = productRepository.save(Product.builder()
+                .productInfo(savedProductInfo)
+                .inventory(50L)
+                .build());
+
+        productImageRepository.save(ProductImage.builder().product(savedProduct).imageUrl("test_image.jpg").build());
+
+        productOptionValuesRepository.saveAll(List.of(
+                ProductOptionValues.builder().product(savedProduct).optionValue(savedOptionValueBlack).build(),
+                ProductOptionValues.builder().product(savedProduct).optionValue(savedOptionValue95).build()
+        ));
+    }
+
+    @Nested
+    @DisplayName("getProductDetail 메서드")
+    class GetProductDetailTest {
+
+        @Test
+        @DisplayName("성공: 상품 상세 정보를 정상적으로 조회한다")
+        void getProductDetail_Success() {
+            // when
+            ProductResponseDto response = productFacade.getProductDetail(savedProductInfo.getId());
+
+            // then
+            assertThat(response).isNotNull();
+            // ProductInfo 검증
+            assertThat(response.productInfo().productInfoId()).isEqualTo(savedProductInfo.getId());
+            assertThat(response.productInfo().name()).isEqualTo("Test Product");
+            assertThat(response.productInfo().brand().name()).isEqualTo("Test Brand");
+            assertThat(response.productInfo().category().name()).isEqualTo("Test Category");
+
+            // Product(variant) 검증
+            assertThat(response.products().get(0).inventory()).isEqualTo(50L);
+
+            // ProductImage 검증
+            assertThat(response.products().get(0).imageUrls()).containsExactly("test_image.jpg");
+
+            // ProductOption 검증
+            assertThat(response.products().get(0).options()).hasSize(2);
+            assertThat(response.products().get(0).options().stream().map(o -> o.groupName() + ":" + o.value()))
+                    .containsExactlyInAnyOrder("Color:Black", "Size:95");
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 ID로 조회 시 예외를 발생시킨다")
+        void getProductDetail_Fail_ProductInfoNotFound() {
+            // given
+            Long nonExistentId = 999L;
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productFacade.getProductDetail(nonExistentId));
+
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.PRODUCT_INFO_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 상품 정보는 있으나 하위 상품(variant)이 없을 경우 예외를 발생시킨다")
+        void getProductDetail_Fail_ProductsNotFound() {
+            // given
+            productImageRepository.deleteAll();
+            productOptionValuesRepository.deleteAll();
+            productRepository.deleteAll();
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productFacade.getProductDetail(savedProductInfo.getId()));
+
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.ENTITY_NOT_FOUND);
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/usecase/ProductInfoUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductInfoUseCaseTest.java
@@ -196,4 +196,40 @@ class ProductInfoUseCaseTest {
             verify(productInfoRepository, never()).delete(any(ProductInfo.class));
         }
     }
+
+    @Nested
+    @DisplayName("findProductInfo 메서드")
+    class FindProductInfoTest {
+
+        @Test
+        @DisplayName("성공: 상품 정보를 조회한다")
+        void findProductInfo_Success() {
+            // given
+            long productInfoId = 1L;
+            given(productSupport.findProductInfoById(productInfoId)).willReturn(Optional.of(productInfo));
+
+            // when
+            ProductInfo result = productInfoUseCase.findProductInfo(productInfoId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(productInfoId);
+            verify(productSupport).findProductInfoById(productInfoId);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 상품 정보 ID이면 예외를 발생시킨다")
+        void findProductInfo_Fail_NotFound() {
+            // given
+            long productInfoId = 99L;
+            given(productSupport.findProductInfoById(productInfoId)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productInfoUseCase.findProductInfo(productInfoId)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.PRODUCT_INFO_NOT_FOUND);
+            verify(productSupport).findProductInfoById(productInfoId);
+        }
+    }
 }

--- a/product/src/test/java/com/back/product/app/usecase/ProductUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductUseCaseTest.java
@@ -1,5 +1,7 @@
 package com.back.product.app.usecase;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.ProductImageRepository;
 import com.back.product.adapter.out.ProductOptionValuesRepository;
 import com.back.product.adapter.out.ProductRepository;
@@ -23,12 +25,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -235,6 +240,52 @@ class ProductUseCaseTest {
 
             verify(productRepository).deleteAll(deleteCaptor.capture());
             assertThat(deleteCaptor.getValue()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllProduct 메서드")
+    class FindAllProductTest {
+
+        @Test
+        @DisplayName("성공: ProductInfo에 속한 모든 상품(variant)들을 조회한다")
+        void findAllProduct_Success() {
+            // given
+            Product product1 = Product.builder().id(1L).build();
+            Product product2 = Product.builder().id(2L).build();
+            List<Product> products = List.of(product1, product2);
+
+            given(productSupport.getAllProductsByProductInfo(productInfo)).willReturn(products);
+            given(productSupport.getAllProductOptionValuesByProductsIn(products)).willReturn(List.of());
+            given(productSupport.getAllProductImagesByProductsIn(products)).willReturn(List.of());
+            given(productMapper.toDto(any(), any(), any())).willReturn(ProductDto.builder().build());
+
+            // when
+            List<ProductDto> result = productUseCase.findAllProduct(productInfo);
+
+            // then
+            assertThat(result).hasSize(2);
+            verify(productSupport).getAllProductsByProductInfo(productInfo);
+            verify(productSupport).getAllProductOptionValuesByProductsIn(products);
+            verify(productSupport).getAllProductImagesByProductsIn(products);
+            verify(productMapper, times(2)).toDto(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("실패: ProductInfo에 속한 상품이 없으면 예외를 발생시킨다")
+        void findAllProduct_Fail_NoProducts() {
+            // given
+            given(productSupport.getAllProductsByProductInfo(productInfo)).willReturn(Collections.emptyList());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productUseCase.findAllProduct(productInfo)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.ENTITY_NOT_FOUND);
+
+            verify(productSupport).getAllProductsByProductInfo(productInfo);
+            verify(productSupport, never()).getAllProductOptionValuesByProductsIn(any());
+            verify(productSupport, never()).getAllProductImagesByProductsIn(any());
         }
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #29 #31 

## 🔎 작업 내용

- 상품 상세 조회 API 기능 구현 (`GET /api/v1/products/{productInfoId}`)
- 상품 상세 조회 로직 구현 (`ProductFacade`, `ProductUseCase`, `ProductInfoUseCase`)
- 기존 코드 리팩토링 (상품 기본 정보 조회 메소드 분리, 중복 코드 수정)
- 상품 상세 조회 기능에 대한 단위 테스트 및 통합 테스트 코드 작성
- Swagger 문서에 누락된 상품 삭제 응답 추가

## 📷 테스트 결과
- 컨트롤러 단위 테스트
  <img width="457" height="130" alt="image" src="https://github.com/user-attachments/assets/bb947019-b87d-4927-9525-5186d067c297" />

- ProductInfoUseCase 단위 테스트
   <img width="454" height="128" alt="image" src="https://github.com/user-attachments/assets/8c0d2339-c6b9-46a1-bb1b-8dbbed45133c" />

- ProductUseCase 단위 테스트
  <img width="459" height="134" alt="image" src="https://github.com/user-attachments/assets/b9d2a2d1-e775-43a0-a218-2726f7eba74d" />

- ProductQueury 통합 테스트
  <img width="456" height="153" alt="image" src="https://github.com/user-attachments/assets/deaa3f9a-f32d-451e-936d-3524e81e7175" />


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
