### PR TITLE
[FEAT] 결제 취소 (#92)

### DIFF
--- a/cash/src/main/java/com/back/cash/adapter/in/ApiV1InternalCashController.java
+++ b/cash/src/main/java/com/back/cash/adapter/in/ApiV1InternalCashController.java
@@ -1,0 +1,30 @@
+package com.back.cash.adapter.in;
+
+import com.back.cash.app.CashFacade;
+import com.back.cash.dto.request.PaymentCancelRequestDto;
+import com.back.cash.dto.response.PaymentCancelResponseDto;
+import com.back.common.code.SuccessCode;
+import com.back.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/internal/cash/payments")
+@RequiredArgsConstructor
+public class ApiV1InternalCashController {
+
+    private final CashFacade cashFacade;
+
+    @PostMapping("/cancel")
+    public ResponseEntity<CommonResponse<PaymentCancelResponseDto>> cancel(@RequestBody PaymentCancelRequestDto req) {
+        PaymentCancelResponseDto result = cashFacade.cancelPayment(req);
+
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(CommonResponse.success(SuccessCode.OK, result));
+    }
+}

--- a/cash/src/main/java/com/back/cash/adapter/out/PaymentRepository.java
+++ b/cash/src/main/java/com/back/cash/adapter/out/PaymentRepository.java
@@ -12,5 +12,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByRelTypeAndRelId(RelType relType, Long relId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Payment> findWithLockByRelTypeAndRelId(RelType relType, Long relId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Payment> findWithLockByTossOrderId(String tossOrderId);
 }

--- a/cash/src/main/java/com/back/cash/adapter/out/market/MarketPaymentsHttpClient.java
+++ b/cash/src/main/java/com/back/cash/adapter/out/market/MarketPaymentsHttpClient.java
@@ -7,15 +7,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
-@HttpExchange("/api/v1/market/internal")
+@HttpExchange("/api/v1/internal/market")
 @Profile("!local")
 public interface MarketPaymentsHttpClient extends MarketPaymentsClient {
 
     @Override
-    @PostExchange("/payment-confirm")
+    @PostExchange("/payments/confirm")
     void notifyPaymentCompleted(@RequestBody PaymentCompletedRequestDto dto);
 
     @Override
-    @PostExchange("/payment-failed")
+    @PostExchange("/payments/fail")
     void notifyPaymentFailed(@RequestBody PaymentFailedRequestDto dto);
 }

--- a/cash/src/main/java/com/back/cash/app/CancelPaymentUseCase.java
+++ b/cash/src/main/java/com/back/cash/app/CancelPaymentUseCase.java
@@ -1,0 +1,89 @@
+package com.back.cash.app;
+
+import com.back.cash.adapter.out.PaymentRepository;
+import com.back.cash.domain.Payment;
+import com.back.cash.domain.Wallet;
+import com.back.cash.domain.enums.PaymentStatus;
+import com.back.cash.dto.request.PaymentCancelRequestDto;
+import com.back.cash.dto.response.PaymentCancelResponseDto;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.common.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class CancelPaymentUseCase {
+
+    private final PaymentRepository paymentRepository;
+    private final WalletSupport walletSupport;
+    private final CashLogSupport cashLogSupport;
+
+    public PaymentCancelResponseDto execute(PaymentCancelRequestDto req) {
+
+        Payment payment = paymentRepository.findWithLockByRelTypeAndRelId(req.relType(), req.relId())
+                .orElseThrow(() -> new EntityNotFoundException(FailureCode.PAYMENT_NOT_FOUND));
+
+        // 요청자 검증
+        if (!payment.getUserId().equals(req.userId())) {
+            throw new CustomException(FailureCode.OWNER_MISMATCH);
+        }
+
+        BigDecimal expected = refundableAmount(payment);
+
+        // 이미 취소면 그대로 응답
+        if (payment.getStatus() == PaymentStatus.CANCELED) {
+            if (!payment.isReleased()) {
+                throw new CustomException(FailureCode.PAYMENT_STATE_INCONSISTENT);
+            }
+            return PaymentCancelResponseDto.of(payment.getUserId(), expected);
+        }
+
+        // DONE이 아니면 취소 불가
+        if (payment.getStatus() != PaymentStatus.DONE) {
+            throw new CustomException(FailureCode.INVALID_CANCEL);
+        }
+
+        // DONE인데 releasedAt이 있으면 비정상
+        if (payment.isReleased()) {
+            throw new CustomException(FailureCode.PAYMENT_STATE_INCONSISTENT);
+        }
+
+        // 금액 검증
+        if (expected.compareTo(req.amount()) != 0) {
+            throw new CustomException(FailureCode.AMOUNT_MISMATCH);
+        }
+
+        // 환불(홀딩 해제): 시스템 -> 유저
+        Wallet buyerWallet = walletSupport.getUserWallet(payment.getUserId());
+        Wallet systemWallet = walletSupport.getSystemWallet();
+
+        systemWallet.withdraw(expected);
+        buyerWallet.deposit(expected);
+
+        // 로그
+        cashLogSupport.recordCancelRefund(
+                buyerWallet,
+                systemWallet,
+                expected,
+                payment.getRelType(),
+                payment.getRelId()
+        );
+
+        payment.markReleased();
+        payment.markAsCanceled();
+
+        return PaymentCancelResponseDto.of(payment.getUserId(), expected);
+    }
+
+    private BigDecimal refundableAmount(Payment payment) {
+        if (payment.getTotalAmount() == null) {
+            throw new CustomException(FailureCode.PAYMENT_TOTAL_AMOUNT_MISSING);
+        }
+        return payment.getTotalAmount();
+    }
+}
+

--- a/cash/src/main/java/com/back/cash/app/CashFacade.java
+++ b/cash/src/main/java/com/back/cash/app/CashFacade.java
@@ -1,12 +1,10 @@
 package com.back.cash.app;
 
 import com.back.cash.adapter.out.market.MarketPaymentsClient;
-import com.back.cash.dto.request.PayAndHoldRequestDto;
-import com.back.cash.dto.request.PaymentFailedRequestDto;
-import com.back.cash.dto.request.TossConfirmRequest;
-import com.back.cash.dto.request.TossFailRequestDto;
+import com.back.cash.dto.request.*;
 import com.back.cash.dto.response.ConfirmResultResponseDto;
 import com.back.cash.dto.response.PayAndHoldResponseDto;
+import com.back.cash.dto.response.PaymentCancelResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +19,7 @@ public class CashFacade {
     private final ConfirmTossPaymentUseCase confirmTossPaymentUseCase;
     private final MarketPaymentsClient marketPaymentsClient;
     private final FailTossPaymentUseCase failTossPaymentUseCase;
+    private final CancelPaymentUseCase cancelPaymentUseCase;
 
     @Transactional
     public PayAndHoldResponseDto payAndHold(PayAndHoldRequestDto dto) {
@@ -56,5 +55,10 @@ public class CashFacade {
                 marketPaymentsClient.notifyPaymentFailed(failedDto);
             }
         });
+    }
+
+    @Transactional
+    public PaymentCancelResponseDto cancelPayment(PaymentCancelRequestDto req) {
+        return cancelPaymentUseCase.execute(req);
     }
 }

--- a/cash/src/main/java/com/back/cash/app/CashLogSupport.java
+++ b/cash/src/main/java/com/back/cash/app/CashLogSupport.java
@@ -64,12 +64,23 @@ public class CashLogSupport {
         cashLogRepository.save(userTopUp);
     }
 
-    public void recordReleaseLog(Wallet buyerWallet, Wallet systemWallet, BigDecimal amount, RelType relType, Long relId) {
+    public void recordReleaseOnPaymentFail(Wallet buyerWallet, Wallet systemWallet,
+                                           BigDecimal amount, RelType relType, Long relId) {
+        recordRelease(buyerWallet, systemWallet, amount, relType, relId, Type.RELEASE_ON_FAIL);
+    }
+
+    public void recordCancelRefund(Wallet buyerWallet, Wallet systemWallet,
+                                   BigDecimal amount, RelType relType, Long relId) {
+        recordRelease(buyerWallet, systemWallet, amount, relType, relId, Type.REFUND_ON_CANCEL);
+    }
+
+    private void recordRelease(Wallet buyerWallet, Wallet systemWallet,
+                               BigDecimal amount, RelType relType, Long relId, Type type) {
         CashLog buyerLog = CashLog.builder()
                 .wallet(buyerWallet)
                 .amount(amount)
                 .balance(buyerWallet.getBalance())
-                .type(Type.RELEASE)
+                .type(type)
                 .relType(relType)
                 .relId(relId)
                 .build();
@@ -78,7 +89,7 @@ public class CashLogSupport {
                 .wallet(systemWallet)
                 .amount(amount.negate())
                 .balance(systemWallet.getBalance())
-                .type(Type.RELEASE)
+                .type(type)
                 .relType(relType)
                 .relId(relId)
                 .build();

--- a/cash/src/main/java/com/back/cash/app/ConfirmTossPaymentUseCase.java
+++ b/cash/src/main/java/com/back/cash/app/ConfirmTossPaymentUseCase.java
@@ -108,7 +108,7 @@ public class ConfirmTossPaymentUseCase {
         systemWallet.withdraw(held);
         buyerWallet.deposit(held);
 
-        cashLogSupport.recordReleaseLog(buyerWallet, systemWallet, held, payment.getRelType(), payment.getRelId());
+        cashLogSupport.recordReleaseOnPaymentFail(buyerWallet, systemWallet, held, payment.getRelType(), payment.getRelId());
 
         payment.markReleased();
     }

--- a/cash/src/main/java/com/back/cash/app/FailTossPaymentUseCase.java
+++ b/cash/src/main/java/com/back/cash/app/FailTossPaymentUseCase.java
@@ -57,7 +57,7 @@ public class FailTossPaymentUseCase {
         systemWallet.withdraw(held);
         buyerWallet.deposit(held);
 
-        cashLogSupport.recordReleaseLog(
+        cashLogSupport.recordReleaseOnPaymentFail(
                 buyerWallet, systemWallet, held,
                 payment.getRelType(), payment.getRelId()
         );

--- a/cash/src/main/java/com/back/cash/domain/Payment.java
+++ b/cash/src/main/java/com/back/cash/domain/Payment.java
@@ -85,4 +85,8 @@ public class Payment extends BaseTimeEntity {
     public void markReleased() {
         this.releasedAt = LocalDateTime.now();
     }
+
+    public void markAsCanceled() {
+        this.status = PaymentStatus.CANCELED;
+    }
 }

--- a/cash/src/main/java/com/back/cash/domain/enums/Type.java
+++ b/cash/src/main/java/com/back/cash/domain/enums/Type.java
@@ -3,7 +3,8 @@ package com.back.cash.domain.enums;
 public enum Type {
     TOPUP_PG,    // PG 충전
     HOLD,    // 금액 홀딩
-    RELEASE,    // 주문 취소
+    RELEASE_ON_FAIL,    // 결제 실패로 인한 선홀딩 반환
+    REFUND_ON_CANCEL, // 주문 취소로 전액 환불
     SETTLEMENT_PRINCIPAL,    // 정산
     SETTLEMENT_FEE     // 정산 수수료
 }

--- a/cash/src/main/java/com/back/cash/dto/request/PaymentCancelRequestDto.java
+++ b/cash/src/main/java/com/back/cash/dto/request/PaymentCancelRequestDto.java
@@ -1,0 +1,16 @@
+package com.back.cash.dto.request;
+
+import com.back.cash.domain.enums.RelType;
+
+import java.math.BigDecimal;
+
+public record PaymentCancelRequestDto(
+        Long userId,
+        RelType relType,
+        Long relId,
+        BigDecimal amount
+) {
+    public static PaymentCancelRequestDto of(Long userId, RelType relType, Long relId, BigDecimal amount) {
+        return new PaymentCancelRequestDto(userId, relType, relId, amount);
+    }
+}

--- a/cash/src/main/java/com/back/cash/dto/response/PaymentCancelResponseDto.java
+++ b/cash/src/main/java/com/back/cash/dto/response/PaymentCancelResponseDto.java
@@ -1,0 +1,12 @@
+package com.back.cash.dto.response;
+
+import java.math.BigDecimal;
+
+public record PaymentCancelResponseDto(
+        Long userId,
+        BigDecimal refundedAmount
+) {
+    public static PaymentCancelResponseDto of(Long userId, BigDecimal refundedAmount) {
+        return new PaymentCancelResponseDto(userId, refundedAmount);
+    }
+}

--- a/cash/src/test/java/com/back/cash/CancelPaymentUseCaseTest.java
+++ b/cash/src/test/java/com/back/cash/CancelPaymentUseCaseTest.java
@@ -1,0 +1,196 @@
+package com.back.cash;
+
+import com.back.cash.adapter.out.PaymentRepository;
+import com.back.cash.app.CancelPaymentUseCase;
+import com.back.cash.app.CashLogSupport;
+import com.back.cash.app.WalletSupport;
+import com.back.cash.domain.Payment;
+import com.back.cash.domain.Wallet;
+import com.back.cash.domain.enums.PaymentStatus;
+import com.back.cash.domain.enums.RelType;
+import com.back.cash.dto.request.PaymentCancelRequestDto;
+import com.back.cash.dto.response.PaymentCancelResponseDto;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CancelPaymentUseCaseTest {
+
+    @InjectMocks
+    private CancelPaymentUseCase cancelPaymentUseCase;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private WalletSupport walletSupport;
+
+    @Mock
+    private CashLogSupport cashLogSupport;
+
+    private final Long userId = 1L;
+    private final RelType relType = RelType.ORDER;
+    private final Long relId = 100L;
+    private final BigDecimal amount = new BigDecimal("10000.00");
+
+    private PaymentCancelRequestDto req(BigDecimal requestAmount) {
+        return new PaymentCancelRequestDto(userId, relType, relId, requestAmount);
+    }
+
+    private Payment createPayment(PaymentStatus status, boolean isReleased) {
+        return Payment.builder()
+                .id(1L)
+                .userId(userId)
+                .relType(relType)
+                .relId(relId)
+                .totalAmount(amount)
+                .status(status)
+                .releasedAt(isReleased ? LocalDateTime.now() : null)
+                .build();
+    }
+
+    @Test
+    @DisplayName("취소 성공(DONE): 시스템 지갑에서 인출하여 사용자 지갑으로 입금하고 상태를 변경한다")
+    void cancel_success_done() {
+        // given
+        PaymentCancelRequestDto request = req(amount);
+        Payment p = createPayment(PaymentStatus.DONE, false);
+
+        Wallet buyerWallet = mock(Wallet.class);
+        Wallet systemWallet = mock(Wallet.class);
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+        given(walletSupport.getUserWallet(userId)).willReturn(buyerWallet);
+        given(walletSupport.getSystemWallet()).willReturn(systemWallet);
+
+        // when
+        PaymentCancelResponseDto response = cancelPaymentUseCase.execute(request);
+
+        // then
+        assertAll(
+                () -> assertEquals(userId, response.userId()),
+                () -> assertEquals(amount, response.refundedAmount()),
+                () -> assertEquals(PaymentStatus.CANCELED, p.getStatus()),
+                () -> assertTrue(p.isReleased()),
+                () -> verify(systemWallet).withdraw(amount),
+                () -> verify(buyerWallet).deposit(amount),
+                () -> verify(cashLogSupport).recordCancelRefund(any(), any(), eq(amount), eq(relType), eq(relId))
+        );
+    }
+
+    @Test
+    @DisplayName("멱등 응답(CANCELED + releasedAt 존재): 추가 작업 없이 환급액을 반환한다")
+    void cancel_idempotent_already_canceled_with_released() {
+        // given
+        PaymentCancelRequestDto request = req(amount);
+        Payment p = createPayment(PaymentStatus.CANCELED, true); // 이미 취소 및 환불 완료
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+
+        // when
+        PaymentCancelResponseDto response = cancelPaymentUseCase.execute(request);
+
+        // then
+        assertAll(
+                () -> assertEquals(amount, response.refundedAmount()),
+                () -> verifyNoInteractions(walletSupport, cashLogSupport) // 지갑 이동 및 로그 기록 없음 확인
+        );
+    }
+
+    @Test
+    @DisplayName("예외(CANCELED인데 releasedAt 없음): PAYMENT_STATE_INCONSISTENT")
+    void cancel_canceled_without_released_inconsistent() {
+        // given
+        PaymentCancelRequestDto request = req(amount);
+        Payment p = createPayment(PaymentStatus.CANCELED, false); // 상태는 취소인데 환불 기록 없음
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class, () -> cancelPaymentUseCase.execute(request));
+        assertEquals(FailureCode.PAYMENT_STATE_INCONSISTENT, ex.getFailureCode());
+    }
+
+    @Test
+    @DisplayName("예외(DONE이 아닌 상태): INVALID_CANCEL")
+    void cancel_not_done_invalid_cancel() {
+        // given
+        PaymentCancelRequestDto request = req(amount);
+        Payment p = createPayment(PaymentStatus.READY, false); // DONE이 아닌 상태
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class, () -> cancelPaymentUseCase.execute(request));
+        assertEquals(FailureCode.INVALID_CANCEL, ex.getFailureCode());
+    }
+
+    @Test
+    @DisplayName("예외(요청 userId 불일치): OWNER_MISMATCH")
+    void cancel_owner_mismatch() {
+        // given
+        PaymentCancelRequestDto request = new PaymentCancelRequestDto(999L, relType, relId, amount);
+        Payment p = createPayment(PaymentStatus.DONE, false);
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class, () -> cancelPaymentUseCase.execute(request));
+        assertEquals(FailureCode.OWNER_MISMATCH, ex.getFailureCode());
+    }
+
+    @Test
+    @DisplayName("예외(요청 금액 불일치): AMOUNT_MISMATCH")
+    void cancel_amount_mismatch() {
+        // given
+        PaymentCancelRequestDto request = req(new BigDecimal("5000.00")); // 잘못된 금액 요청
+        Payment p = createPayment(PaymentStatus.DONE, false);
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class, () -> cancelPaymentUseCase.execute(request));
+        assertEquals(FailureCode.AMOUNT_MISMATCH, ex.getFailureCode());
+    }
+
+    @Test
+    @DisplayName("예외(totalAmount 없음): PAYMENT_TOTAL_AMOUNT_MISSING")
+    void cancel_total_amount_missing() {
+        // given
+        PaymentCancelRequestDto request = req(amount);
+        Payment p = Payment.builder()
+                .userId(userId)
+                .relType(relType)
+                .relId(relId)
+                .totalAmount(null)
+                .status(PaymentStatus.DONE)
+                .build();
+
+        given(paymentRepository.findWithLockByRelTypeAndRelId(relType, relId))
+                .willReturn(Optional.of(p));
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class, () -> cancelPaymentUseCase.execute(request));
+        assertEquals(FailureCode.PAYMENT_TOTAL_AMOUNT_MISSING, ex.getFailureCode());
+    }
+}

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -18,6 +18,7 @@ public enum FailureCode {
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "INVALID_TYPE_VALUE", "필드가 잘못되었습니다."),
     INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "INSUFFICIENT_BALANCE", "잔액이 부족하여 결제할 수 없습니다."),
     MISSING_SELLER_NAME(HttpStatus.BAD_REQUEST, "MISSING_SELLER_NAME", "판매자 이름이 필요합니다."),
+    INVALID_CANCEL(HttpStatus.BAD_REQUEST, "INVALID_CANCEL", "취소할 수 없는 결제 상태입니다."),
 
     // Market 모듈에서 사용
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "PRODUCT_NOT_FOUND","존재하지 않는 상품입니다."),
@@ -46,7 +47,7 @@ public enum FailureCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
     SETTLEMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "SETTLEMENT_ACCESS_DENIED", "해당 정산 내역에 접근 권한이 없습니다."),
     CHAT_RESTRICTED(HttpStatus.FORBIDDEN, "CHAT_RESTRICTED", "채팅이 제한된 사용자입니다."),
-
+    OWNER_MISMATCH(HttpStatus.FORBIDDEN, "OWNER_MISMATCH", "결제 요청자 정보가 일치하지 않습니다."),
     /**
      * 404 Not Found
      */
@@ -79,13 +80,14 @@ public enum FailureCode {
     PAYMENT_CONFIRM_FAILED(HttpStatus.CONFLICT, "PAYMENT_CONFIRM_FAILED", "결제 승인을 실패했습니다."),
     DUPLICATE_PRODUCT_INFO(HttpStatus.CONFLICT, "DUPLICATE_PRODUCT_INFO", "이미 존재하는 상품 정보입니다."),
     REPORT_DUPLICATE(HttpStatus.CONFLICT, "REPORT_DUPLICATE", "이미 신고한 메시지입니다."),
-
+    PAYMENT_ALREADY_RELEASED(HttpStatus.CONFLICT, "PAYMENT_ALREADY_RELEASED", "이미 환급된 결제입니다."),
     /**
      * 500 Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
-    CASH_MODULE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CASH_MODULE_ERROR", "CASH 모듈과의 통신 중 오류가 발생했습니다.");
-
+    CASH_MODULE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CASH_MODULE_ERROR", "CASH 모듈과의 통신 중 오류가 발생했습니다."),
+    PAYMENT_TOTAL_AMOUNT_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_TOTAL_AMOUNT_MISSING","결제 데이터에 totalAmount가 없습니다."),
+    PAYMENT_STATE_INCONSISTENT(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_STATE_INCONSISTENT", "결제 상태가 일관되지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #92 

## 🔎 작업 내용

- market모듈에서 주문/입찰 취소 요청을 받아서 결제 취소를 처리합니다. 
- 결제 취소시 CashLog에 남기고, 시스템 지갑 -> 사용자 지갑으로 주문/입찰 전체 금액이 환불됩니다. 

<br>


## 📌 참고 사항

- 취소 api 경로 (/api/v1/internal/cash/payments/cancel)

<br>

## 📷 테스트 결과
- 요청
<img width="251" height="128" alt="image" src="https://github.com/user-attachments/assets/406621ed-7388-429f-b6a4-55bb78a6dabf" />

- 성공
<img width="354" height="170" alt="image" src="https://github.com/user-attachments/assets/2b18bb04-105a-4bd0-8057-0a4674db2c57" />

- cashlog에 기록
   
<img width="955" height="329" alt="image" src="https://github.com/user-attachments/assets/49cae953-89b9-4762-9078-05958853361e" />

- payment 테이블에 상태 canceled
 
<img width="1270" height="134" alt="image" src="https://github.com/user-attachments/assets/7f806058-e485-4679-beee-3085d4dbde11" />

    
- 지갑에 반영
    
<img width="708" height="91" alt="image" src="https://github.com/user-attachments/assets/7fe47a3e-7b4d-48ca-9a6e-84bb75e1bd58" />


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
