### PR TITLE
[FEAT] Chat UserClient 연동용 API 구현 (#97)

### DIFF
--- a/user/src/main/java/com/back/user/adapter/in/internal/chat/UserChatController.java
+++ b/user/src/main/java/com/back/user/adapter/in/internal/chat/UserChatController.java
@@ -1,0 +1,36 @@
+package com.back.user.adapter.in.internal.chat;
+
+import com.back.user.app.UserFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/internal/chat/users")
+@Tag(
+        name = "User Internal - Chat",
+        description = "Chat 모듈에서 호출하는 API"
+)
+public class UserChatController {
+
+    private final UserFacade userFacade;
+
+    @Operation(
+            summary = "User blindCount 증가",
+            description = """
+                    Chat 서비스에서 사용자 메시지가 블라인드 처리될 때 호출되는 내부 API입니다.
+                    
+                    - 사용자의 blindCount를 1 증가시킵니다.
+                    - blindCount가 임계치에 도달하면 채팅 제한이 적용됩니다.
+                    """
+    )
+    @PostMapping("/{userId}/blind-count:increase")
+    public void incrementBlindCount (@PathVariable Long userId){
+        userFacade.incrementBlindCount(userId);
+    }
+}

--- a/user/src/main/java/com/back/user/adapter/in/internal/chat/UserChatController.java
+++ b/user/src/main/java/com/back/user/adapter/in/internal/chat/UserChatController.java
@@ -4,10 +4,9 @@ import com.back.user.app.UserFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,4 +32,23 @@ public class UserChatController {
     public void incrementBlindCount (@PathVariable Long userId){
         userFacade.incrementBlindCount(userId);
     }
+
+
+    @Operation(
+            summary = "User 채팅 제한 종료 시각 조회",
+            description = """
+                Chat 서비스에서 사용자 메시지 전송 시
+                채팅 제한 종료 시각을 확인하기 위해 호출하는 내부 API입니다.
+
+                - 채팅 제한이 없는 경우 null을 반환합니다.
+                - 채팅 제한이 존재하는 경우 제한 종료 시각(LocalDateTime)을 반환합니다.
+                """
+    )
+    @GetMapping("{userId}/chat-restricted")
+    public LocalDateTime getChatRestrictedUntil(
+            @PathVariable("userId") Long userId
+    ) {
+        return userFacade.getChatRestrictedUntil(userId);
+    }
+
 }

--- a/user/src/main/java/com/back/user/app/UserFacade.java
+++ b/user/src/main/java/com/back/user/app/UserFacade.java
@@ -25,10 +25,12 @@ public class UserFacade {
         return UserIdResponse.of(user);
     }
 
+    @Transactional
     public void incrementBlindCount(Long userId) {
         userIncrementBlindCountUseCase.incrementBlindCount(userId);
     }
 
+    @Transactional
     public LocalDateTime getChatRestrictedUntil(Long userId){
         User user = userSupport.findById(userId);
         return user.getChatRestrictedUntil();

--- a/user/src/main/java/com/back/user/app/UserFacade.java
+++ b/user/src/main/java/com/back/user/app/UserFacade.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserFacade {
     private final UserSupport userSupport;
     private final UserUpdateUsecase userUpdateUsecase;
+    private final UserIncrementBlindCountUseCase userIncrementBlindCountUseCase;
 
     @Transactional
     public UserIdResponse registerOrUpdateFcmToken(Long userId, UpdateFcmTokenRequest request) {
@@ -20,5 +21,9 @@ public class UserFacade {
         userUpdateUsecase.updateFcmToken(user, request);
 
         return UserIdResponse.of(user);
+    }
+
+    public void incrementBlindCount(Long userId) {
+        userIncrementBlindCountUseCase.incrementBlindCount(userId);
     }
 }

--- a/user/src/main/java/com/back/user/app/UserFacade.java
+++ b/user/src/main/java/com/back/user/app/UserFacade.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class UserFacade {
@@ -26,4 +28,10 @@ public class UserFacade {
     public void incrementBlindCount(Long userId) {
         userIncrementBlindCountUseCase.incrementBlindCount(userId);
     }
+
+    public LocalDateTime getChatRestrictedUntil(Long userId){
+        User user = userSupport.findById(userId);
+        return user.getChatRestrictedUntil();
+    }
+
 }

--- a/user/src/main/java/com/back/user/app/UserIncrementBlindCountUseCase.java
+++ b/user/src/main/java/com/back/user/app/UserIncrementBlindCountUseCase.java
@@ -1,0 +1,24 @@
+package com.back.user.app;
+
+import com.back.user.domain.User;
+import com.back.user.domain.policy.ChatRestrictionPolicy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserIncrementBlindCountUseCase {
+
+    private final UserSupport userSupport;
+
+    public void incrementBlindCount(Long userId){
+        User user = userSupport.findById(userId);
+
+        user.incrementBlindCount();
+
+        if(user.getBlindCount()>= ChatRestrictionPolicy.BLIND_THRESHOLD){
+            user.restrictChatForDays(ChatRestrictionPolicy.RESTRICT_DAYS);
+            user.resetBlindCount();
+        }
+    }
+}

--- a/user/src/main/java/com/back/user/domain/User.java
+++ b/user/src/main/java/com/back/user/domain/User.java
@@ -3,6 +3,7 @@ package com.back.user.domain;
 import com.back.common.entity.BaseTimeEntity;
 import com.back.user.domain.enums.Provider;
 import com.back.user.domain.enums.Role;
+import com.back.user.domain.policy.ChatRestrictionPolicy;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -62,4 +63,22 @@ public class User extends BaseTimeEntity {
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
+    public void incrementBlindCount() {
+        this.blindCount++;
+    }
+
+    public void restrictChatForDays(int days) {
+        if (this.chatRestrictedUntil == null
+                || this.chatRestrictedUntil.isBefore(LocalDateTime.now())) {
+            this.chatRestrictedUntil = LocalDateTime.now().plusDays(days);
+        } else {
+            this.chatRestrictedUntil = this.chatRestrictedUntil.plusDays(days);
+        }
+    }
+
+    public void resetBlindCount(){
+        this.blindCount=0;
+    }
+
 }

--- a/user/src/main/java/com/back/user/domain/policy/ChatRestrictionPolicy.java
+++ b/user/src/main/java/com/back/user/domain/policy/ChatRestrictionPolicy.java
@@ -1,0 +1,6 @@
+package com.back.user.domain.policy;
+
+public class ChatRestrictionPolicy {
+    public static final int BLIND_THRESHOLD = 3;
+    public static final int RESTRICT_DAYS = 3;
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #97 

## 🔎 작업 내용

- Chat UserClient 연동용 API 구현

<br>


## 📷 테스트 결과
- blindCount 3회 요청 시 채팅 제한 및 blindCount 초기화
  <br>
  <img width="199" height="50" alt="캡처" src="https://github.com/user-attachments/assets/18fcc833-3383-4ea6-a695-ec028d00dd68" />


- getChatRestricteduntil 조회 요청
<img width="238" height="95" alt="캡처1" src="https://github.com/user-attachments/assets/44ce5305-2ea8-42b5-93f4-8e6d69eb5c39" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
