### PR TITLE
[CHORE] Swagger 설정에 JWT 관련 내용 추가 (#109)

### DIFF
--- a/common/src/main/java/com/back/common/config/SwaggerConfig.java
+++ b/common/src/main/java/com/back/common/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.back.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,8 +18,19 @@ public class SwaggerConfig {
                 .version("1.0.0")
                 .description("Resello 멀티모듈 프로젝트의 API 명세서입니다.");
 
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt); // 헤더에 토큰 포함 요청
+
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer") // swagger에서 요청 보낼때 Bearer 접두어 붙여줌
+                .bearerFormat("JWT")
+        );
+
         return new OpenAPI()
-                .components(new Components())
-                .info(info);
+                .components(components)
+                .info(info)
+                .addSecurityItem(securityRequirement);
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #109 

## 🔎 작업 내용

- swagger에서 JWT를 포함해 테스트가 가능하도록 config에 설정을 추가했습니다. postman을 사용해 헤더에 넣는 방법도 있지만 번거로울거같아서 추가했습니다.
- 이런 식으로 액세스 토큰을 넣어 테스트가 가능합니다. Bearer 접두어는 swagger에서 알아서 붙여준다고 해서 순수 토큰만 넣어서 테스트하면 됩니다. 로그아웃(토큰 없음)이 기본 상태이며 인증이 필요한 기능 테스트 할때 사용하면 될 것 같습니다.
<img width="640" height="279" alt="image" src="https://github.com/user-attachments/assets/ccaaa239-c784-4002-86a0-224dfe165594" />

<br>

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
