### PR TITLE
[CHORE] FeignClient로 cash 모듈과 market 모듈 통신 검증 (#118)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -4,7 +4,6 @@ import com.back.common.response.CommonResponse;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
-import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
 import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.security.principal.AuthPrincipal;

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -6,6 +6,7 @@ import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,13 +19,13 @@ import org.springframework.web.bind.annotation.*;
 public interface ApiV1Market {
     @Operation(summary = "구매 입찰 등록", description = "구매자가 원하는 가격으로 새로운 구매 입찰을 등록한다.")
     @PostMapping("/bids/buy")
-    CommonResponse<PayAndHoldResponseDto> registerBuyBid(
+    CommonResponse<MarketPaymentResponseDto> registerBuyBid(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
     @Operation(summary = "판매 입찰 등록", description = "판매자가 원하는 가격으로 새로운 판매 입찰을 등록한다.")
     @PostMapping("/bids/sell")
-    CommonResponse<PayAndHoldResponseDto> registerSellBid(
+    CommonResponse<MarketPaymentResponseDto> registerSellBid(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
@@ -38,13 +39,13 @@ public interface ApiV1Market {
 
     @Operation(summary = "즉시 구매 실행", description = "판매 대기 중인 최저가 매물과 매칭하여 즉시 주문을 생성하고 결제를 진행한다.")
     @PostMapping("/buy-now")
-    CommonResponse<PayAndHoldResponseDto> buyNow(
+    CommonResponse<MarketPaymentResponseDto> buyNow(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto);
 
     @Operation(summary = "즉시 판매 실행", description = "구매 대기 중인 최고가 입찰과 매칭하여 즉시 주문을 생성하고 결제를 진행한다.")
     @PostMapping("/sell-now")
-    CommonResponse<PayAndHoldResponseDto> sellNow(
+    CommonResponse<MarketPaymentResponseDto> sellNow(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto);
 

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -6,8 +6,8 @@ import com.back.market.app.MarketFacade;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
-import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,25 +22,25 @@ public class ApiV1MarketController implements ApiV1Market{
     private final MarketFacade marketFacade;
 
     @Override
-    public CommonResponse<PayAndHoldResponseDto> registerBuyBid(
+    public CommonResponse<MarketPaymentResponseDto> registerBuyBid(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto
     ) {
         Long userId = principal.getUserId();
 
-        PayAndHoldResponseDto response = marketFacade.registerBuyBid(userId, requestDto);
+        MarketPaymentResponseDto response = marketFacade.registerBuyBid(userId, requestDto);
 
         return CommonResponse.successWithData(HttpStatus.CREATED, response);
     }
 
     @Override
-    public CommonResponse<PayAndHoldResponseDto> registerSellBid(
+    public CommonResponse<MarketPaymentResponseDto> registerSellBid(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto
     ) {
         Long userId = principal.getUserId();
 
-        PayAndHoldResponseDto response = marketFacade.registerSellBid(userId, requestDto);
+        MarketPaymentResponseDto response = marketFacade.registerSellBid(userId, requestDto);
 
         return CommonResponse.successWithData(HttpStatus.CREATED, response);
     }
@@ -58,24 +58,24 @@ public class ApiV1MarketController implements ApiV1Market{
     }
 
     @Override
-    public CommonResponse<PayAndHoldResponseDto> buyNow(
+    public CommonResponse<MarketPaymentResponseDto> buyNow(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto) {
 
         Long userId = principal.getUserId();
 
-        PayAndHoldResponseDto response = marketFacade.purchaseNow(userId, requestDto);
+        MarketPaymentResponseDto response = marketFacade.purchaseNow(userId, requestDto);
         return CommonResponse.successWithData(HttpStatus.CREATED, response);
     }
 
     @Override
-    public CommonResponse<PayAndHoldResponseDto> sellNow(
+    public CommonResponse<MarketPaymentResponseDto> sellNow(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid BiddingRequestDto requestDto) {
 
         Long userId = principal.getUserId();
 
-        PayAndHoldResponseDto response = marketFacade.sellNow(userId, requestDto);
+        MarketPaymentResponseDto response = marketFacade.sellNow(userId, requestDto);
         return CommonResponse.successWithData(HttpStatus.CREATED, response);
     }
 

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketInternal.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketInternal.java
@@ -15,4 +15,7 @@ public interface ApiV1MarketInternal {
     @Operation(summary = "결제 완료 통지 수신 (Internal Callback)", description = "Cash 모듈로부터 결제 완료(입금 확인) 통지를 수신하여 주문 상태를 확정한다.")
     @PostMapping("/payments/confirm")
     CommonResponse<Void> confirmPayment(@RequestBody PaymentCompletedRequestDto requestDto);
+
+    // TODO 사용자가 결제 도중 실패했을 때 받아주는 컨트롤러 없음
+    // /api/v1/internal/market/payments/fail
 }

--- a/market/src/main/java/com/back/market/adapter/out/cash/CashFeignApi.java
+++ b/market/src/main/java/com/back/market/adapter/out/cash/CashFeignApi.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "cash-client", url = "${feign.cash.url}")
 public interface CashFeignApi {
-    @PostMapping("/api/v1/cash/payments")
+    @PostMapping("/api/v1/internal/cash/payments")
     CommonResponse<PayAndHoldResponseDto> requestBidHold(@RequestBody PayAndHoldRequestDto requestDto);
 
     @PostMapping("/api/v1/internal/cash/payments/cancel")

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -9,6 +9,7 @@ import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +29,7 @@ public class MarketFacade {
      * @return PayAndHoldResponseDto (결제/홀딩 상태 포함)
      */
     @Transactional
-    public PayAndHoldResponseDto registerBuyBid(Long userId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto registerBuyBid(Long userId, BiddingRequestDto requestDto) {
         return registerBidUseCase.registerBuyBid(userId, requestDto);
     }
 
@@ -39,7 +40,7 @@ public class MarketFacade {
      * @return PayAndHoldResponseDto (결제 불필요, PAID 상태)
      */
     @Transactional
-    public PayAndHoldResponseDto registerSellBid(Long userId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto registerSellBid(Long userId, BiddingRequestDto requestDto) {
         return registerBidUseCase.registerSellBid(userId, requestDto);
     }
 
@@ -69,7 +70,7 @@ public class MarketFacade {
      * @param requestDto BiddingRequestDto
      * @return 생성된 주문(Order)의 ID
      */
-    public PayAndHoldResponseDto purchaseNow(Long buyerId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto purchaseNow(Long buyerId, BiddingRequestDto requestDto) {
         return matchInstantTradeUseCase.buyNow(buyerId, requestDto);
     }
 
@@ -79,7 +80,7 @@ public class MarketFacade {
      * @param requestDto BiddingRequestDto
      * @return 생성된 주문(Order)의 ID
      */
-    public PayAndHoldResponseDto sellNow(Long sellerId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto sellNow(Long sellerId, BiddingRequestDto requestDto) {
         return matchInstantTradeUseCase.sellNow(sellerId, requestDto);
     }
 

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -7,7 +7,6 @@ import com.back.market.app.usecase.RegisterBidUseCase;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
-import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
 import com.back.market.dto.response.MarketPaymentResponseDto;
 import lombok.RequiredArgsConstructor;

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -17,6 +17,7 @@ import com.back.common.dto.cash.enums.RelType;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.common.dto.cash.request.PayAndHoldRequestDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.CashRequestMapper;
 import com.back.market.mapper.OrderMapper;
@@ -47,7 +48,7 @@ public class MatchInstantTradeUseCase {
      * @throws BadRequestException 해당 상품의 판매 입찰(매물)이 존재하지 않을 경우 (BIDDING_NOT_FOUND)
      */
     @Transactional
-    public PayAndHoldResponseDto buyNow(Long buyerId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto buyNow(Long buyerId, BiddingRequestDto requestDto) {
         Bidding targetSellBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
         // 정합성 검사 추가: 사용자가 화면에서 본 가격과 실제 조회된 가격이 다르면 예외 처리
@@ -64,7 +65,7 @@ public class MatchInstantTradeUseCase {
      * @throws BadRequestException 해당 상품의 판매 입찰(매물)이 존재하지 않을 경우 (BIDDING_NOT_FOUND)
      */
     @Transactional
-    public PayAndHoldResponseDto sellNow(Long sellerId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto sellNow(Long sellerId, BiddingRequestDto requestDto) {
         Bidding targetBuyBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
                         requestDto.productId(), BiddingPosition.BUY, BiddingStatus.PROCESS)
                 .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
@@ -91,7 +92,7 @@ public class MatchInstantTradeUseCase {
      * 4. 배송지 정보를 포함한 최종 주문(Order) 생성
      * </p>
      */
-    private PayAndHoldResponseDto executeTrade(Long userId, BiddingRequestDto requestDto, Bidding targetBid, BiddingPosition myPosition) {
+    private MarketPaymentResponseDto executeTrade(Long userId, BiddingRequestDto requestDto, Bidding targetBid, BiddingPosition myPosition) {
         // 1. 자전거래 검증
         if(targetBid.getMarketUser().getId().equals(userId)){
             throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
@@ -118,8 +119,8 @@ public class MatchInstantTradeUseCase {
         Order savedOrder = orderRepository.save(order);
 
         // 5. 실제 결제 요청(FeignClient 사용)
-
         if(myPosition == BiddingPosition.BUY) {
+            // Cash 호출
             PayAndHoldRequestDto paymentReq = cashRequestMapper.toPayAndHoldRequestForOrder(savedOrder);
             PayAndHoldResponseDto resultData = marketSupport.getPayAndHoldResult(paymentReq);
 
@@ -133,18 +134,31 @@ public class MatchInstantTradeUseCase {
                 // (Order 생성 시 기본값이 HOLD이므로 별도 상태 변경 불필요)
                 log.info("[MatchInstantTrade] PG 결제 필요 (REQUIRES_PG) - OrderId: {}, TossId: {}", savedOrder.getId(), resultData.tossOrderId());
             }
-            return resultData;
+            return MarketPaymentResponseDto.from(
+                    resultData,
+                    targetBid.getMarketProduct().getName(), // 상품명
+                    me.getNickname(),                       // 구매자 이름
+                    me.getEmail()                           // 구매자 이메일
+            );
         } else {
             // 내가 판매자라면 홀딩할 필요가 없음(이미 구매자가 홀딩한 금액 존재)
             log.info("[MatchTrade] 즉시 판매 체결 (결제 불필요) - OrderId: {}", savedOrder.getId());
             savedOrder.changeStatus(OrderStatus.PAID);
-            return PayAndHoldResponseDto.of(
+
+            PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(
                     PayAndHoldStatus.PAID,
                     RelType.ORDER,
                     savedOrder.getId(),
-                    BigDecimal.ZERO, // 판매자가 내는 돈은 0원
+                    BigDecimal.ZERO,
                     BigDecimal.ZERO,
                     null
+            );
+
+            return MarketPaymentResponseDto.from(
+                    cashResponse,
+                    targetBid.getMarketProduct().getName(),
+                    me.getNickname(),
+                    me.getEmail()
             );
         }
     }

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -16,6 +16,7 @@ import com.back.common.dto.cash.enums.RelType;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.common.dto.cash.request.PayAndHoldRequestDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.CashRequestMapper;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class RegisterBidUseCase {
      * @return 저장된 구매 입찰의 PK
      */
     @Transactional
-    public PayAndHoldResponseDto registerBuyBid(Long userId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto registerBuyBid(Long userId, BiddingRequestDto requestDto) {
         // 가격 유효성 검사(1000원단위인지 아닌지)
         validatePriceUnit(requestDto.price());
 
@@ -79,7 +80,12 @@ public class RegisterBidUseCase {
             log.info("[RegisterBid] PG 결제 필요, HOLD 상태 유지- relId: {}", responseData.relId());
         }
 
-        return responseData;
+        return MarketPaymentResponseDto.from(
+                responseData, // cash에서 보낸 정보
+                product.getName(),
+                user.getNickname(),
+                user.getEmail()
+        );
     }
 
     /**
@@ -89,7 +95,7 @@ public class RegisterBidUseCase {
      * @return 저장된 판매 입찰의 PK
      */
     @Transactional
-    public PayAndHoldResponseDto registerSellBid(Long userId, BiddingRequestDto requestDto) {
+    public MarketPaymentResponseDto registerSellBid(Long userId, BiddingRequestDto requestDto) {
         // 가격 유효성 검사(1000원단위인지 아닌지)
         validatePriceUnit(requestDto.price());
 
@@ -107,13 +113,22 @@ public class RegisterBidUseCase {
         Bidding bidding = biddingMapper.toEntity(requestDto, user, product, BiddingPosition.SELL);
         bidding.changeStatus(BiddingStatus.PROCESS); // 판매 입찰은 결제 과정이 없으므로 즉시 활성화
         Bidding savedBidding = biddingRepository.save(bidding);
-        return PayAndHoldResponseDto.of(
-                PayAndHoldStatus.PAID, // 판매 입찰은 결제가 필요없으므로 완료 상태로 생성
+
+        // 가짜 Cash 응답 생성 (판매는 결제 완료 상태)
+        PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(
+                PayAndHoldStatus.PAID,
                 RelType.BIDDING,
                 savedBidding.getId(),
-                BigDecimal.ZERO, // 사용된 예치금 없음
-                BigDecimal.ZERO, // 필요한 PG 금액 없음
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
                 null
+        );
+
+        return MarketPaymentResponseDto.from(
+                cashResponse,
+                product.getName(),
+                user.getNickname(),
+                user.getEmail()
         );
     }
 

--- a/market/src/main/java/com/back/market/dto/response/MarketPaymentResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/MarketPaymentResponseDto.java
@@ -1,0 +1,39 @@
+package com.back.market.dto.response;
+
+import com.back.common.dto.cash.enums.PayAndHoldStatus;
+import com.back.common.dto.cash.enums.RelType;
+import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+
+import java.math.BigDecimal;
+
+public record MarketPaymentResponseDto(
+        PayAndHoldStatus status,
+        RelType relType,
+        Long relId,
+        BigDecimal walletUsedAmount,
+        BigDecimal pgRequiredAmount,
+        String tossOrderId,
+        String orderName,
+        String customerName,
+        String customerEmail
+) {
+    // 편의 메서드: Cash 응답 + Market 정보 -> 최종 응답 변환
+    public static MarketPaymentResponseDto from(
+            PayAndHoldResponseDto cashDto,
+            String orderName,
+            String customerName,
+            String customerEmail
+    ) {
+        return new MarketPaymentResponseDto(
+                cashDto.status(),
+                cashDto.relType(),
+                cashDto.relId(),
+                cashDto.walletUsedAmount(),
+                cashDto.pgRequiredAmount(),
+                cashDto.tossOrderId(),
+                orderName,
+                customerName,
+                customerEmail
+        );
+    }
+}

--- a/market/src/main/resources/application-prod.yml
+++ b/market/src/main/resources/application-prod.yml
@@ -1,0 +1,44 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  # 1. 데이터베이스 설정 (PostgreSQL)
+  datasource:
+#    driver-class-name: org.postgresql.Driver
+    url: ${DB_URL}             # 예: jdbc:postgresql://rds-endpoint:5432/market_db
+    username: ${DB_USERNAME}   # DB 아이디
+    password: ${DB_PASSWORD}   # DB 비밀번호
+
+  # 2. JPA & Hibernate 설정 (운영 환경 최적화)
+  jpa:
+    hibernate:
+      # 중요: 운영에서는 절대 'create'나 'create-drop'을 쓰면 안 됩니다! (데이터 날아감)
+      # validate: 엔티티와 DB 스키마가 일치하는지 확인만 함 (추천)
+      # update: 변경분만 반영 (편하지만 가끔 꼬일 수 있음)
+      # none: 아무것도 안 함 (Flyway 같은 마이그레이션 툴 쓸 때)
+      ddl-auto: validate
+
+    show-sql: false            # 운영 로그가 너무 지저분해지므로 끔
+    properties:
+      hibernate:
+        format_sql: false      # 로그 포맷팅 끔
+        default_batch_fetch_size: 100 # N+1 문제 완화를 위한 성능 옵션
+
+    open-in-view: false        # DB 커넥션 낭비 방지 (OSIV 종료)
+
+  # 3. JWT 설정
+  jwt:
+    # 운영용 시크릿 키는 절대 코드에 적지 말고 환경변수로 주입받아야 함
+    secret: ${JWT_SECRET}
+
+# 4. Feign Client 설정 (Cash 모듈 연결)
+feign:
+  cash:
+    # AWS 내부 통신 주소 (예: http://cash-service.local:8080 또는 내부 IP)
+    url: ${CASH_MODULE_URL}
+
+logging:
+  level:
+    root: INFO                 # 디버그 로그 끄고 INFO 이상만 출력
+    com.back: INFO

--- a/market/src/main/resources/application.yml
+++ b/market/src/main/resources/application.yml
@@ -2,10 +2,4 @@ spring:
   application:
     name: market
   profiles:
-    active: local
-server:
-  port: 8083
-
-feign:
-  cash:
-    url: http://localhost:8081
+    active: test


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #118 

## 🔎 작업 내용
- 구매 입찰 + cash모듈로 이동해서 홀딩
- 홀딩 이전에 예치금 부족해서 PG사 결제가 필요한 경우도 테스트 완료(happy path만)
- 사용자가 PG사 결제 도중 실패할 경우 market에서 처리하는 컨트롤러 부재로 에러 남
   - 다음 프로젝트 진행 시 추가 필요해서 파일 내에TODO 주석으로 남겨두었음

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 구매 입찰 + cash모듈로 이동해서 홀딩
  
  <img width="1315" height="611" alt="스크린샷 2026-01-23 105741" src="https://github.com/user-attachments/assets/9f01aa40-771c-4baf-97e5-b8d4ebe71ae3" /><br>
  <img width="1027" height="464" alt="스크린샷 2026-01-23 105804" src="https://github.com/user-attachments/assets/ad831fe7-b0c5-4c32-8de1-ef297ed4ea0e" /><br>
  <img width="896" height="387" alt="스크린샷 2026-01-23 105810" src="https://github.com/user-attachments/assets/ed715f99-0f59-4af7-8281-41806cc1525c" />

<br>

- 홀딩 이전에 예치금 부족해서 PG사 결제가 필요한 경우도 테스트 완료(happy path만)

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
