### PR TITLE
[FEAT] 내부 호출용 주문 목록 조회 api 구현 (#115)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketInternal.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketInternal.java
@@ -1,12 +1,15 @@
 package com.back.market.adapter.in;
 
+import com.back.common.dto.settlement.SettlementTargetOrder;
 import com.back.common.response.CommonResponse;
 import com.back.common.dto.cash.request.PaymentCompletedRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
+import java.util.List;
 
 @Tag(name = "Market Internal API", description = "내부 통신용 API")
 @RequestMapping("/api/v1/internal/market")
@@ -18,4 +21,12 @@ public interface ApiV1MarketInternal {
 
     // TODO 사용자가 결제 도중 실패했을 때 받아주는 컨트롤러 없음
     // /api/v1/internal/market/payments/fail
+
+    @Operation(summary = "정산 모듈로 주문 데이터 전송")
+    @GetMapping("/orders/settlement-target")
+    List<SettlementTargetOrder> findSettlementTargetOrders(
+            @RequestParam("targetMonth") @DateTimeFormat(pattern = "yyyy-MM") YearMonth targetMonth,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size
+    );
 }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketInternalController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketInternalController.java
@@ -1,12 +1,16 @@
 package com.back.market.adapter.in;
 
 import com.back.common.code.SuccessCode;
+import com.back.common.dto.settlement.SettlementTargetOrder;
 import com.back.common.response.CommonResponse;
 import com.back.market.app.MarketInternalFacade;
 import com.back.common.dto.cash.request.PaymentCompletedRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.YearMonth;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,5 +25,10 @@ public class ApiV1MarketInternalController implements ApiV1MarketInternal {
             return CommonResponse.success(SuccessCode.ALREADY_PROCESSED, null);
         }
         return CommonResponse.success(SuccessCode.OK, null);
+    }
+
+    @Override
+    public List<SettlementTargetOrder> findSettlementTargetOrders(YearMonth targetMonth, int page, int size) {
+        return marketInternalFacade.getSettlementData(targetMonth, page, size);
     }
 }

--- a/market/src/main/java/com/back/market/adapter/in/MarketDataInit.java
+++ b/market/src/main/java/com/back/market/adapter/in/MarketDataInit.java
@@ -9,12 +9,13 @@ import com.back.market.mapper.MarketProductMapper;
 import com.back.market.mapper.MarketUserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 
 /**
- * 더미 데이터 생성을 위한 클래스(MarketUser, MarketProduct)
+ * 더미 데이터 생성을 위한 클래스(MarketUser, MarketProduct, Bidding, Order)
  * CommandLineRunner를 통해 스프링 application이 시작될 때 run() 메소드도 실행하게끔 구현
  */
 @Component
@@ -26,6 +27,7 @@ public class MarketDataInit implements CommandLineRunner {
     private final MarketProductRepository marketProductRepository;
     private final MarketUserMapper marketUserMapper;
     private final MarketProductMapper marketProductMapper;
+    private final JdbcTemplate jdbcTemplate; //SQL 직접 실행을 위해 추가
 
     @Override
     @Transactional
@@ -49,7 +51,7 @@ public class MarketDataInit implements CommandLineRunner {
                 "https://dummyimage.com/100x100/000/fff&text=Seller"
         );
 
-        marketUserRepository.save(seller);
+        MarketUser savedSeller = marketUserRepository.save(seller);
 
         // 유저 2: 구매자 역할 (ID: 2L)
         MarketUser buyer = marketUserMapper.toEntity(
@@ -61,7 +63,7 @@ public class MarketDataInit implements CommandLineRunner {
                 "010-9876-5432",
                 null
         );
-        marketUserRepository.save(buyer);
+        MarketUser savedBuyer = marketUserRepository.save(buyer);
 
         // 2. MarketProduct 생성 (ID 수동 지정)
         // 상품 1: 나이키 조던 1 - 270 사이즈
@@ -75,7 +77,7 @@ public class MarketDataInit implements CommandLineRunner {
                 "Sneakers",
                 "https://dummyimage.com/600x400/000/fff&text=Jordan1"
         );
-        marketProductRepository.save(product1);
+        MarketProduct savedProduct = marketProductRepository.saveAndFlush(product1);
 
         // 상품 2: 나이키 조던 1 - 280 사이즈 (같은 모델, 다른 사이즈)
         MarketProduct product2 = marketProductMapper.toEntity(
@@ -88,7 +90,7 @@ public class MarketDataInit implements CommandLineRunner {
                 "Sneakers",
                 "https://dummyimage.com/600x400/000/fff&text=Jordan1"
         );
-        marketProductRepository.save(product2);
+        marketProductRepository.saveAndFlush(product2);
 
         // 상품 3: 아디다스 이지 부스트 - 260 사이즈
         MarketProduct product3 = marketProductMapper.toEntity(
@@ -101,8 +103,76 @@ public class MarketDataInit implements CommandLineRunner {
                 "Sneakers",
                 "https://dummyimage.com/600x400/000/fff&text=Yeezy"
         );
-        marketProductRepository.save(product3);
+        marketProductRepository.saveAndFlush(product3);
 
-        System.out.println("======= [Market] 초기 데이터 생성 완료 (User: 2건, Product: 3건) =======");
+        // --------------------------------------------------------
+        // 3. 입찰 및 주문 데이터 생성 (JDBC Template - SQL 직접 실행)
+        // --------------------------------------------------------
+        // JPA Auditing(자동 날짜 설정)을 우회하고 특정 과거/미래 날짜를 넣기 위해 SQL을 직접 실행합니다.
+
+        Long sId = savedSeller.getId();
+        Long bId = savedBuyer.getId();
+        Long pId = savedProduct.getId();
+
+        System.out.println(">> 정산 테스트용 주문 데이터 생성 중...");
+
+        // [Case 0] 초기 수동 생성 예제 (1월 15일)
+        createTestOrder(sId, bId, pId, 209000, "2026-01-15 10:00:00", "2026-01-15 12:00:00");
+
+        // [Case 1] 1월 5일 (정상)
+        createTestOrder(sId, bId, pId, 50000, "2026-01-05 10:00:00", "2026-01-05 12:00:00");
+
+        // [Case 2] 1월 10일 (정상)
+        createTestOrder(sId, bId, pId, 60000, "2026-01-10 10:00:00", "2026-01-10 12:00:00");
+
+        // [Case 3] 1월 20일 (정상)
+        createTestOrder(sId, bId, pId, 70000, "2026-01-20 10:00:00", "2026-01-20 12:00:00");
+
+        // [Case 4] 1월 25일 (정상)
+        createTestOrder(sId, bId, pId, 80000, "2026-01-25 10:00:00", "2026-01-25 12:00:00");
+
+        // [Case 5] 1월 31일 말일 (정상)
+        createTestOrder(sId, bId, pId, 90000, "2026-01-31 23:50:00", "2026-01-31 23:59:59");
+
+        // [Case 6] 12월 31일 (제외 대상 - 과거)
+        createTestOrder(sId, bId, pId, 30000, "2025-12-31 10:00:00", "2025-12-31 23:59:59");
+
+        // [Case 7] 2월 1일 (제외 대상 - 미래)
+        createTestOrder(sId, bId, pId, 40000, "2026-02-01 00:00:01", "2026-02-01 00:00:01");
+
+        System.out.println("======= [Market] 초기 데이터 생성 완료 (User: 2건, Product: 3건, Order: 8건, Bidding: 16건) =======");
+    }
+
+    /**
+     * 입찰(Buy/Sell) 생성 후 주문(Order)까지 한 번에 생성하는 헬퍼 메서드
+     */
+    private void createTestOrder(Long sellerId, Long buyerId, Long productId, long price, String reqDate, String modDate) {
+        // 1. 판매 입찰 생성
+        String sqlSell = "INSERT INTO biddings (user_id, product_id, price, position, status, created_at, last_modified_at) " +
+                "VALUES (?, ?, ?, 'SELL', 'PROCESS', NOW(), NOW())";
+        jdbcTemplate.update(sqlSell, sellerId, productId, price);
+
+        // 2. 구매 입찰 생성
+        String sqlBuy = "INSERT INTO biddings (user_id, product_id, price, position, status, created_at, last_modified_at) " +
+                "VALUES (?, ?, ?, 'BUY', 'PROCESS', NOW(), NOW())";
+        jdbcTemplate.update(sqlBuy, buyerId, productId, price);
+
+        // 3. 주문 생성 (방금 만든 입찰 ID를 서브쿼리로 찾아서 연결)
+        // last_modified_at을 인자로 받은 날짜(modDate)로 강제 주입하는 것이 핵심
+        String sqlOrder = "INSERT INTO orders (buy_bidding_id, sell_bidding_id, price, address, order_status, request_payment_date, created_at, last_modified_at) " +
+                "VALUES (" +
+                "(SELECT id FROM biddings WHERE user_id = ? AND position = 'BUY' AND price = ? ORDER BY id DESC LIMIT 1), " +
+                "(SELECT id FROM biddings WHERE user_id = ? AND position = 'SELL' AND price = ? ORDER BY id DESC LIMIT 1), " +
+                "?, '서울시 테스트구', 'COMPLETED', " +
+                "TO_TIMESTAMP(?, 'YYYY-MM-DD HH24:MI:SS'), " + // request_payment_date
+                "TO_TIMESTAMP(?, 'YYYY-MM-DD HH24:MI:SS'), " + // created_at
+                "TO_TIMESTAMP(?, 'YYYY-MM-DD HH24:MI:SS')" +   // last_modified_at (정산 기준일)
+                ")";
+
+        jdbcTemplate.update(sqlOrder,
+                buyerId, price, // buy bidding 찾기용
+                sellerId, price, // sell bidding 찾기용
+                price,
+                reqDate, reqDate, modDate); // 날짜들
     }
 }

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
@@ -1,7 +1,19 @@
 package com.back.market.adapter.out;
 
 import com.back.market.domain.Order;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    @Query("SELECT o FROM Order o JOIN FETCH o.sellBidding sb JOIN FETCH sb.marketUser s JOIN FETCH o.buyBidding bb WHERE o.lastModifiedAt BETWEEN :startDate and :endDate")
+    List<Order> findSettlementTargetOrders(
+            @Param("startDate") LocalDateTime startDateTime,
+            @Param("endDate") LocalDateTime endDateTime,
+            Pageable pageable
+    );
 }

--- a/market/src/main/java/com/back/market/app/MarketInternalFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketInternalFacade.java
@@ -1,15 +1,21 @@
 package com.back.market.app;
 
+import com.back.common.dto.settlement.SettlementTargetOrder;
 import com.back.market.app.usecase.ConfirmPaymentUseCase;
 import com.back.common.dto.cash.request.PaymentCompletedRequestDto;
+import com.back.market.app.usecase.GetSettlementDataUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MarketInternalFacade {
     private final ConfirmPaymentUseCase confirmPaymentUseCase;
+    private final GetSettlementDataUseCase getSettlementDataUseCase;
 
     /**
      * Cash 모듈로부터 결제 완료(입금 확인) 통지를 수신하여 주문 상태를 확정
@@ -18,5 +24,9 @@ public class MarketInternalFacade {
     @Transactional
     public boolean confirmPayment(PaymentCompletedRequestDto requestDto) {
         return confirmPaymentUseCase.confirmPayment(requestDto);
+    }
+
+    public List<SettlementTargetOrder> getSettlementData(YearMonth targetMonth, int page, int size) {
+        return getSettlementDataUseCase.getSettlementData(targetMonth,  page, size);
     }
 }

--- a/market/src/main/java/com/back/market/app/usecase/GetSettlementDataUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetSettlementDataUseCase.java
@@ -1,0 +1,43 @@
+package com.back.market.app.usecase;
+
+import com.back.common.dto.settlement.SettlementTargetOrder;
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.domain.Order;
+import com.back.market.mapper.OrderMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GetSettlementDataUseCase {
+
+    private final OrderMapper orderMapper;
+    private final OrderRepository orderRepository;
+
+    @Transactional(readOnly = true)
+    public List<SettlementTargetOrder> getSettlementData(YearMonth targetMonth, int page, int size) {
+        // 날짜 범위 계산
+        LocalDateTime startDateTime = targetMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDateTime = targetMonth.atEndOfMonth().atTime(LocalTime.MAX);
+
+        // 페이징
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
+
+        // DB 조회
+        List<Order> orders = orderRepository.findSettlementTargetOrders(startDateTime, endDateTime, pageable);
+
+        return orders.stream()
+                .map(orderMapper::toSettlementTargetOrder)
+                .collect(Collectors.toList());
+    }
+}

--- a/market/src/main/java/com/back/market/mapper/OrderMapper.java
+++ b/market/src/main/java/com/back/market/mapper/OrderMapper.java
@@ -1,5 +1,6 @@
 package com.back.market.mapper;
 
+import com.back.common.dto.settlement.SettlementTargetOrder;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.OrderStatus;
@@ -18,5 +19,19 @@ public class OrderMapper {
                 .orderStatus(OrderStatus.HOLD) //초기 상태 설정
                 .requestPaymentDate(LocalDateTime.now())
                 .build();
+    }
+
+    public SettlementTargetOrder toSettlementTargetOrder(Order order) {
+        Bidding sellBid = order.getSellBidding();
+        Bidding buyBid = order.getBuyBidding();
+        return new SettlementTargetOrder(
+                order.getId(),                          // 주문 ID
+                sellBid.getMarketProduct().getId(),     // 상품 ID(판매입찰 기준)
+                buyBid.getMarketUser().getId(),         // 구매자 ID
+                sellBid.getMarketUser().getId(),        // 판매자 ID
+                sellBid.getMarketUser().getNickname(),  // 판매자 이름(닉네임)
+                order.getPrice(),                       // 주문 가격
+                order.getLastModifiedAt()               // 구매 확정 일시(마지막으로 수정된 날짜)
+        );
     }
 }

--- a/market/src/main/resources/application.yml
+++ b/market/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   application:
     name: market
   profiles:
-    active: test
+    active: local


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #115 

## 🔎 작업 내용

- settlement 모듈과 feign으로 통신하기 위한 api 구현, 주문 조회
- 비즈니스 로직이 구체화되지 않아 주문 상태에 관계없이 조회 가능하도록 구현, 추후 구매확정이나 완료된 주문만 조회 가능하도록 수정 필요할 듯
- 테스트 편의성을 위해 DataInit에 더미 데이터 추가하였음(Order 8건, Bidding 16건)

<br>

## 📷 테스트 결과

 - 노션 참고: [Settlement에서 사용할 Order데이터 조회 API 구현 - Notion](https://www.notion.so/Settlement-Order-API-2f115a01205480388aa1d0c05f1cb461?source=copy_link)

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
