### PR TITLE
[FEAT] 알림 시스템에 Kafka 기반 이벤트 처리 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ subprojects {
         testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
         testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+        // kafka
+        implementation("org.springframework.boot:spring-boot-starter-kafka")
     }
 
     tasks.named('test') {

--- a/common/src/main/java/com/back/common/Settlement/event/SettlementCompletedEvent.java
+++ b/common/src/main/java/com/back/common/Settlement/event/SettlementCompletedEvent.java
@@ -1,5 +1,7 @@
 package com.back.common.Settlement.event;
 
+import com.back.common.event.EventName;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -8,5 +10,5 @@ public record SettlementCompletedEvent(
         LocalDateTime startAt,
         LocalDateTime endAt,
         BigDecimal totalNetAmount
-) {
+) implements EventName {
 }

--- a/common/src/main/java/com/back/common/event/EventName.java
+++ b/common/src/main/java/com/back/common/event/EventName.java
@@ -1,0 +1,10 @@
+package com.back.common.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public interface EventName {
+    @JsonIgnore
+    default String getEventName() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
@@ -1,0 +1,15 @@
+package com.back.common.event;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaEventPublisher {
+    private final KafkaTemplate<String, EventName> kafkaTemplate;
+
+    public void publish(EventName event) {
+        kafkaTemplate.send(event.getEventName(), event);
+    }
+}

--- a/common/src/main/java/com/back/common/market/event/BiddingCompletedEvent.java
+++ b/common/src/main/java/com/back/common/market/event/BiddingCompletedEvent.java
@@ -1,5 +1,7 @@
 package com.back.common.market.event;
 
+import com.back.common.event.EventName;
+
 import java.math.BigDecimal;
 
 public record BiddingCompletedEvent(
@@ -15,5 +17,5 @@ public record BiddingCompletedEvent(
 
         BigDecimal price,
         String biddingPosition  // 판매입찰 / 구매입찰
-) {
+) implements EventName {
 }

--- a/common/src/main/java/com/back/common/market/event/BiddingFailedEvent.java
+++ b/common/src/main/java/com/back/common/market/event/BiddingFailedEvent.java
@@ -1,5 +1,7 @@
 package com.back.common.market.event;
 
+import com.back.common.event.EventName;
+
 import java.math.BigDecimal;
 
 public record BiddingFailedEvent(
@@ -11,5 +13,5 @@ public record BiddingFailedEvent(
 
         BigDecimal price,
         String biddingPosition
-) {
+) implements EventName {
 }

--- a/common/src/main/java/com/back/common/market/event/PurchaseCanceledEvent.java
+++ b/common/src/main/java/com/back/common/market/event/PurchaseCanceledEvent.java
@@ -1,5 +1,7 @@
 package com.back.common.market.event;
 
+import com.back.common.event.EventName;
+
 import java.math.BigDecimal;
 
 public record PurchaseCanceledEvent(
@@ -13,5 +15,5 @@ public record PurchaseCanceledEvent(
 
         BigDecimal price,
         String biddingPosition
-) {
+) implements EventName {
 }

--- a/common/src/main/java/com/back/common/market/event/SellBiddingCreatedEvent.java
+++ b/common/src/main/java/com/back/common/market/event/SellBiddingCreatedEvent.java
@@ -1,9 +1,11 @@
 package com.back.common.market.event;
 
+import com.back.common.event.EventName;
+
 import java.math.BigDecimal;
 
 public record SellBiddingCreatedEvent(
         Long productId,
         BigDecimal currentPrice
-) {
+) implements EventName {
 }

--- a/common/src/main/java/com/back/common/product/event/InspectionCompletedEvent.java
+++ b/common/src/main/java/com/back/common/product/event/InspectionCompletedEvent.java
@@ -1,5 +1,7 @@
 package com.back.common.product.event;
 
+import com.back.common.event.EventName;
+
 import java.time.LocalDateTime;
 
 public record InspectionCompletedEvent(
@@ -12,5 +14,5 @@ public record InspectionCompletedEvent(
         String productSize,
         String productName,
         String productNumber
-) {
+) implements EventName {
 }

--- a/notification/src/main/java/com/back/notification/adapter/in/NotificationEventListener.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/NotificationEventListener.java
@@ -9,51 +9,42 @@ import com.back.common.product.event.InspectionCompletedEvent;
 import com.back.notification.app.NotificationFacade;
 import com.back.notification.domain.enums.Type;
 import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class NotificationEventListener {
     private final NotificationFacade notificationFacade;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KafkaListener(topics = "BiddingCompletedEvent", groupId = "PostEventListener__handle__1")
     public void handle(BiddingCompletedEvent event) {
         notificationFacade.notify(Type.BID_COMPLETED, event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KafkaListener(topics = "PurchaseCanceledEvent", groupId = "PostEventListener__handle__2")
     public void handle(PurchaseCanceledEvent event) {
         notificationFacade.notify(Type.PURCHASE_CANCELED, event);
     }
 
     // 30일 초과되어 입찰에 실패
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KafkaListener(topics = "BiddingFailedEvent", groupId = "PostEventListener__handle__3")
     public void handle(BiddingFailedEvent event) {
         notificationFacade.notify(Type.BID_FAILED, event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KafkaListener(topics = "InspectionCompletedEvent", groupId = "PostEventListener__handle__1")
     public void handle(InspectionCompletedEvent event) {
         notificationFacade.notify(Type.INSPECTION_COMPLETED, event);
     }
 
     // 정산 완료
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KafkaListener(topics = "SettlementCompletedEvent", groupId = "PostEventListener__handle__4")
     public void handle(SettlementCompletedEvent event) {
         notificationFacade.notify(Type.SETTLEMENT_COMPLETED, event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @KafkaListener(topics = "SellBiddingCreatedEvent", groupId = "PostEventListener__handle__5")
     public void handle(SellBiddingCreatedEvent event) {
         notificationFacade.notify(Type.PRICE_DROPPED, event);
     }

--- a/notification/src/main/java/com/back/notification/adapter/in/sqs/NotificationDispatchEventListener.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/sqs/NotificationDispatchEventListener.java
@@ -3,16 +3,15 @@ package com.back.notification.adapter.in.sqs;
 import com.back.notification.adapter.out.sqs.NotificationEventPublisher;
 import com.back.notification.dto.NotificationCreatedEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class NotificationDispatchEventListener {
     private final NotificationEventPublisher publisher;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handle(NotificationCreatedEvent event) {
         publisher.send(event);
     }

--- a/notification/src/main/java/com/back/notification/app/NotificationFacade.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationFacade.java
@@ -4,6 +4,7 @@ import com.back.notification.app.strategy.NotificationStrategyRegistry;
 import com.back.notification.domain.Notification;
 import com.back.notification.app.strategy.NotificationStrategy;
 import com.back.notification.domain.NotificationUser;
+import com.back.notification.dto.NotificationCreatedEvent;
 import com.back.notification.dto.NotificationIdResponseDto;
 import com.back.notification.dto.NotificationMessage;
 import com.back.notification.domain.enums.Type;
@@ -51,7 +52,8 @@ public class NotificationFacade {
 
         notificationSaveUsecase.saveAll(notifications);
 
-        eventPublisher.publishEvent(mapper.toNotificationCreatedEvent(notifications));
+        NotificationCreatedEvent createdEvent = mapper.toNotificationCreatedEvent(notifications);
+        eventPublisher.publishEvent(createdEvent);
     }
 
     @Transactional


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #131 

## 🔎 작업 내용

- 알림 시스템에 Kafka 기반 이벤트 처리 도입
- NotificationDispatchEventListener의 `handle()` 메소드에서 커밋되지 않아 알림이 누락되는 오류를 수정했습니다
<br>


## 📌 참고 사항
- 중간 발표가 끝난 후 kafka는 `config` 클래스로 수정하는게 좋을 거 같습니다
- 다른 도메인에서는 아래처럼 이벤트를 생성하시면 됩니다
```java
private final KafkaEventPublisher kafkaEventPublisher;
kafkaEventPublisher.publish(event);
```

<br>

## 📷 테스트 결과
- 알림 발송 성공
<img width="382" height="186" alt="image" src="https://github.com/user-attachments/assets/26fdabe0-4fa6-4cf3-b5e8-808df8834379" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
