### PR TITLE
[HOTFIX] @query now() 대신 CURRENT_TIMESTAMP로 수정 (#128)

### DIFF
--- a/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductImageRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
     @Modifying
-    @Query("update ProductImage pi set pi.deletedAt = now() where pi.product in :products")
+    @Query("update ProductImage pi set pi.deletedAt = CURRENT_TIMESTAMP where pi.product in :products")
     void deleteAllByProductIn(@Param("products") List<Product> existsProducts);
 
     List<ProductImage> findALlByProductIn(List<Product> products);

--- a/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface ProductOptionValuesRepository extends JpaRepository<ProductOptionValues, Long> {
     @Modifying
-    @Query("update ProductOptionValues pov set pov.deletedAt = now() where pov.product in :products")
+    @Query("update ProductOptionValues pov set pov.deletedAt = CURRENT_TIMESTAMP where pov.product in :products")
     void deleteAllByProductIn(@Param("products") List<Product> products);
 
     List<ProductOptionValues> findAllByProductIn(List<Product> products);

--- a/product/src/main/java/com/back/product/domain/ProductInfo.java
+++ b/product/src/main/java/com/back/product/domain/ProductInfo.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @SQLRestriction("deleted_at IS NULL")
 @Table(name = "product_info",
     uniqueConstraints = {
-        @UniqueConstraint(name = "uk_product_info_brand_code", columnNames = {"brand_id", "productCode"})
+        @UniqueConstraint(name = "uk_product_info_brand_code", columnNames = {"brand_id", "product_code"})
     }
 )
 public class ProductInfo extends BaseTimeEntity {
@@ -38,7 +38,7 @@ public class ProductInfo extends BaseTimeEntity {
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(nullable = false, length = 50)
+    @Column(name = "product_code", nullable = false, length = 50)
     private String productCode;
 
     @Column(nullable = false, precision = 10, scale = 0) // 10자리 정수

--- a/product/src/main/java/com/back/product/domain/ProductInfo.java
+++ b/product/src/main/java/com/back/product/domain/ProductInfo.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @SQLRestriction("deleted_at IS NULL")
 @Table(name = "product_info",
     uniqueConstraints = {
-        @UniqueConstraint(name = "uk_product_info_brand_code", columnNames = {"brand_id", "code"})
+        @UniqueConstraint(name = "uk_product_info_brand_code", columnNames = {"brand_id", "productCode"})
     }
 )
 public class ProductInfo extends BaseTimeEntity {


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #128

## 🔎 작업 내용

- @query now() 대신 CURRENT_TIMESTAMP로 수정

## 📷 테스트 결과
<img width="1120" height="314" alt="image" src="https://github.com/user-attachments/assets/e38a6f5b-a1d6-4156-8680-cd54d6d1b03b" />

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
