### PR TITLE
[FEAT] 구매 입찰 완료 시 알림 이벤트 발행 및 푸시 알림 전송 (#153)

### DIFF
--- a/common/src/main/java/com/back/common/user/event/fcmTokenChangedEvent.java
+++ b/common/src/main/java/com/back/common/user/event/fcmTokenChangedEvent.java
@@ -1,0 +1,9 @@
+package com.back.common.user.event;
+
+import com.back.common.event.EventName;
+
+public record fcmTokenChangedEvent (
+        Long userId,
+        String fcmToken
+) implements EventName {
+}

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -1,7 +1,9 @@
 package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
+import com.back.common.event.KafkaEventPublisher;
 import com.back.common.exception.BadRequestException;
+import com.back.common.market.event.BiddingCompletedEvent;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.adapter.out.OrderRepository;
@@ -39,6 +41,7 @@ public class MatchInstantTradeUseCase {
     private final BiddingMapper biddingMapper;
     private final CashRequestMapper cashRequestMapper;
     private final MarketSupport marketSupport;
+    private final KafkaEventPublisher kafkaEventPublisher;
 
     /**
      * MARKET-009 즉시 구매 실행
@@ -129,6 +132,9 @@ public class MatchInstantTradeUseCase {
                 // 결제 완료 -> 주문 상태 변경
                 log.info("[MatchInstantTrade] 결제 완료 (PAID) - OrderId: {}", savedOrder.getId());
                 savedOrder.changeStatus(OrderStatus.PAID);
+                
+                // 즉시 구매 완료 이벤트 발행
+                publishBiddingCompletedEvent(myBid, targetBid, BiddingPosition.BUY);
             } else if (resultData.status() == PayAndHoldStatus.REQUIRES_PG) {
                 // PG 결제 필요 -> 주문은 대기 상태 유지 (HOLD)
                 // (Order 생성 시 기본값이 HOLD이므로 별도 상태 변경 불필요)
@@ -144,6 +150,9 @@ public class MatchInstantTradeUseCase {
             // 내가 판매자라면 홀딩할 필요가 없음(이미 구매자가 홀딩한 금액 존재)
             log.info("[MatchTrade] 즉시 판매 체결 (결제 불필요) - OrderId: {}", savedOrder.getId());
             savedOrder.changeStatus(OrderStatus.PAID);
+            
+            // 즉시 판매 완료 이벤트 발행
+            publishBiddingCompletedEvent(targetBid, myBid, BiddingPosition.SELL);
 
             PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(
                     PayAndHoldStatus.PAID,
@@ -161,6 +170,29 @@ public class MatchInstantTradeUseCase {
                     me.getEmail()
             );
         }
+    }
+
+    /**
+     * 입찰 체결 완료 이벤트 발행
+     * @param buyBid 구매 입찰
+     * @param sellBid 판매 입찰
+     * @param triggerPosition 어떤 포지션(구매/판매)에서 트리거되었는지
+     */
+    private void publishBiddingCompletedEvent(Bidding buyBid, Bidding sellBid, BiddingPosition triggerPosition) {
+        BiddingCompletedEvent event = new BiddingCompletedEvent(
+                triggerPosition == BiddingPosition.BUY ? buyBid.getId() : sellBid.getId(),
+                buyBid.getMarketUser().getId(),
+                sellBid.getMarketUser().getId(),
+                buyBid.getMarketProduct().getId(),
+                buyBid.getMarketProduct().getName(),
+                buyBid.getMarketProduct().getProductOption(),
+                buyBid.getMarketProduct().getThumbnailImage(),
+                buyBid.getMarketProduct().getBrandName(),
+                buyBid.getPrice(),
+                triggerPosition.name()
+        );
+        
+        kafkaEventPublisher.publish(event);
     }
 
 

--- a/notification/src/main/java/com/back/notification/adapter/in/NotificationEventListener.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/NotificationEventListener.java
@@ -6,7 +6,9 @@ import com.back.common.market.event.SellBiddingCreatedEvent;
 import com.back.common.market.event.PurchaseCanceledEvent;
 import com.back.common.market.event.BiddingCompletedEvent;
 import com.back.common.product.event.InspectionCompletedEvent;
+import com.back.common.user.event.fcmTokenChangedEvent;
 import com.back.notification.app.NotificationFacade;
+import com.back.notification.app.NotificationUserUsecase;
 import com.back.notification.domain.enums.Type;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NotificationEventListener {
     private final NotificationFacade notificationFacade;
+    private final NotificationUserUsecase notificationUserUsecase;
 
     @KafkaListener(topics = "BiddingCompletedEvent", groupId = "PostEventListener__handle__1")
     public void handle(BiddingCompletedEvent event) {
@@ -47,5 +50,10 @@ public class NotificationEventListener {
     @KafkaListener(topics = "SellBiddingCreatedEvent", groupId = "PostEventListener__handle__5")
     public void handle(SellBiddingCreatedEvent event) {
         notificationFacade.notify(Type.PRICE_DROPPED, event);
+    }
+
+    @KafkaListener(topics = "fcmTokenChangedEvent", groupId = "PostEventListener__handle__6")
+    public void handle(fcmTokenChangedEvent event) {
+        notificationUserUsecase.updateFcmToken(event.userId(), event.fcmToken());
     }
 }

--- a/notification/src/main/java/com/back/notification/app/NotificationUserUsecase.java
+++ b/notification/src/main/java/com/back/notification/app/NotificationUserUsecase.java
@@ -4,8 +4,11 @@ import com.back.notification.adapter.out.NotificationUserRepository;
 import com.back.notification.domain.NotificationUser;
 import com.back.notification.exception.NotificationUserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationUserUsecase {
@@ -19,5 +22,18 @@ public class NotificationUserUsecase {
     public NotificationUser findNotificationUserById(Long userId){
         return notificationUserRepository.findById(userId)
                 .orElseThrow(NotificationUserNotFoundException::new);
+    }
+
+    /**
+     * FCM 토큰 업데이트
+     * @param userId 사용자 ID
+     * @param fcmToken 새로운 FCM 토큰
+     */
+    @Transactional
+    public void updateFcmToken(Long userId, String fcmToken) {
+        NotificationUser user = notificationUserRepository.findById(userId)
+                .orElseThrow(NotificationUserNotFoundException::new);
+        
+        user.updateFcmToken(fcmToken);
     }
 }

--- a/notification/src/main/java/com/back/notification/domain/NotificationUser.java
+++ b/notification/src/main/java/com/back/notification/domain/NotificationUser.java
@@ -30,4 +30,8 @@ public class NotificationUser extends BaseTimeEntity {
     private String email;
 
     private String fcmToken;
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/user/src/main/java/com/back/user/app/UserFacade.java
+++ b/user/src/main/java/com/back/user/app/UserFacade.java
@@ -1,27 +1,37 @@
 package com.back.user.app;
 
+import com.back.common.event.KafkaEventPublisher;
+import com.back.common.user.event.fcmTokenChangedEvent;
 import com.back.user.domain.User;
 import com.back.user.dto.request.UpdateFcmTokenRequest;
 import com.back.user.dto.request.UpdateNotificationSettingsRequest;
 import com.back.user.dto.response.UserIdResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserFacade {
     private final UserSupport userSupport;
     private final UserUpdateUsecase userUpdateUsecase;
     private final UserIncrementBlindCountUseCase userIncrementBlindCountUseCase;
+    private final KafkaEventPublisher kafkaEventPublisher;
 
     @Transactional
     public UserIdResponse registerOrUpdateFcmToken(Long userId, UpdateFcmTokenRequest request) {
         User user = userSupport.findById(userId);
 
         userUpdateUsecase.updateFcmToken(user, request);
+
+        // FCM 토큰 변경 이벤트 발행
+        fcmTokenChangedEvent event = new fcmTokenChangedEvent(userId, request.fcmToken());
+        kafkaEventPublisher.publish(event);
+        log.info("[UserFacade] FCM 토큰 변경 이벤트 발행 - UserId: {}", userId);
 
         return UserIdResponse.of(user);
     }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #153 

## 🔎 작업 내용

- 구매 입찰 완료 시 알림 이벤트 발행 및 푸시 알림 전송
- fcm 토큰변경 시 notification_users 테이블에서도 수정

<br>


## 📌 참고 사항

- 실제 테스트시
```java
spring:
  kafka:
    bootstrap-servers: localhost:19092
    producer:
      key-serializer: org.apache.kafka.common.serialization.StringSerializer
      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
    consumer:
      group-id: notification-consumer-group
      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
      properties:
        spring.json.trusted.packages: "*"
      auto-offset-reset: latest
```
을 application-local.yml에 포함하고 있어야 하고, redpanda 도커 컨테이너가 작동 중이어야 합니다.
- redpanda는 실습 때 사용했던 파일입니다

<br>

## 📷 테스트 결과
- 테스트시 fcm 토큰이 변경됩니다

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
