### PR TITLE
[FEAT] 테스트 로그인 API (#158)

### DIFF
--- a/user/src/main/java/com/back/user/adapter/in/auth/TestLoginController.java
+++ b/user/src/main/java/com/back/user/adapter/in/auth/TestLoginController.java
@@ -1,0 +1,42 @@
+package com.back.user.adapter.in.auth;
+
+import com.back.common.code.SuccessCode;
+import com.back.common.response.CommonResponse;
+import com.back.user.app.auth.TestLoginUseCase;
+import com.back.user.dto.request.TestLoginRequestDto;
+import com.back.user.dto.response.TestLoginResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Profile("local")
+@RequestMapping("/api/v1/auth")
+public class TestLoginController {
+    private final TestLoginUseCase testLoginUseCase;
+
+    @PostMapping("/test-login")
+    public CommonResponse<TestLoginResponseDto> testLogin(@RequestBody TestLoginRequestDto req) {
+        TestLoginUseCase.Result r = testLoginUseCase.execute(req.email());
+
+        HttpHeaders headers = new HttpHeaders();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh", r.refreshToken())
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .sameSite("Lax")
+                .maxAge(r.refreshTtl())
+                .build();
+
+        headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        return CommonResponse.success(SuccessCode.OK, new TestLoginResponseDto(r.accessToken()));
+    }
+
+}

--- a/user/src/main/java/com/back/user/adapter/out/UserRepository.java
+++ b/user/src/main/java/com/back/user/adapter/out/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String candidate);
 
     Optional<User> findById(Long id);
+
+    Optional<User> findByEmail(String email);
 }

--- a/user/src/main/java/com/back/user/app/auth/TestLoginUseCase.java
+++ b/user/src/main/java/com/back/user/app/auth/TestLoginUseCase.java
@@ -1,0 +1,50 @@
+package com.back.user.app.auth;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.EntityNotFoundException;
+import com.back.security.jwt.JWTUtil;
+import com.back.user.adapter.out.RefreshStore;
+import com.back.user.adapter.out.UserRepository;
+import com.back.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class TestLoginUseCase {
+
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+    private final RefreshStore refreshStore;
+
+    @Value("${app.jwt.access-ttl}")
+    private Duration accessTtl;
+
+    @Value("${app.jwt.refresh-ttl}")
+    private Duration refreshTtl;
+
+    public record Result(
+            String accessToken,
+            String refreshToken,
+            Duration refreshTtl
+    ) {}
+
+    @Transactional(readOnly = true)
+    public Result execute(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
+
+        String role = user.getRole().name();
+
+        String access = jwtUtil.createJwt("access", user.getId(), role, accessTtl.toMillis());
+        String refresh = jwtUtil.createJwt("refresh", user.getId(), role, refreshTtl.toMillis());
+
+        refreshStore.save(user.getId(), refresh, refreshTtl);
+
+        return new Result(access, refresh, refreshTtl);
+    }
+}

--- a/user/src/main/java/com/back/user/dto/request/TestLoginRequestDto.java
+++ b/user/src/main/java/com/back/user/dto/request/TestLoginRequestDto.java
@@ -1,0 +1,3 @@
+package com.back.user.dto.request;
+
+public record TestLoginRequestDto(String email) {}

--- a/user/src/main/java/com/back/user/dto/response/TestLoginResponseDto.java
+++ b/user/src/main/java/com/back/user/dto/response/TestLoginResponseDto.java
@@ -1,0 +1,4 @@
+package com.back.user.dto.response;
+
+public record TestLoginResponseDto(String access) {
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #158 

## 🔎 작업 내용

- 소셜 로그인시 쿠키값을 가져와서 /reissue로 요청해서 access token을 얻어야 하는 불편함이 있어서 테스트 로그인을 만들었습니다. 

<br>


## 📌 참고 사항

- 테스트 로그인 경로 
  /api/v1/auth/test-login 
- @Profile("local") 로 로컬 환경에서만 실행되도록 하였습니다. 


<br>

## 📷 테스트 결과
- 테스트 로그인 요청
  <br>
  <img width="722" height="505" alt="image" src="https://github.com/user-attachments/assets/92a25c5d-07ed-46aa-b764-969510c9971f" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
