### PR TITLE
[TEST] 캐시 모듈 테스트 코드 import 수정 - (#168)

### DIFF
--- a/cash/src/test/java/com/back/cash/CancelPaymentUseCaseTest.java
+++ b/cash/src/test/java/com/back/cash/CancelPaymentUseCaseTest.java
@@ -1,16 +1,16 @@
 package com.back.cash;
 
 import com.back.cash.adapter.out.PaymentRepository;
-import com.back.cash.app.usecase.CancelPaymentUseCase;
 import com.back.cash.app.CashLogSupport;
 import com.back.cash.app.WalletSupport;
+import com.back.cash.app.usecase.CancelPaymentUseCase;
 import com.back.cash.domain.Payment;
 import com.back.cash.domain.Wallet;
 import com.back.cash.domain.enums.PaymentStatus;
-import com.back.cash.domain.enums.RelType;
-import com.back.cash.dto.request.PaymentCancelRequestDto;
-import com.back.cash.dto.response.PaymentCancelResponseDto;
 import com.back.common.code.FailureCode;
+import com.back.common.dto.cash.enums.RelType;
+import com.back.common.dto.cash.request.PaymentCancelRequestDto;
+import com.back.common.dto.cash.response.PaymentCancelResponseDto;
 import com.back.common.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/cash/src/test/java/com/back/cash/CashLogSupportTest.java
+++ b/cash/src/test/java/com/back/cash/CashLogSupportTest.java
@@ -1,10 +1,10 @@
 package com.back.cash;
 
+import com.back.cash.adapter.out.CashLogRepository;
 import com.back.cash.app.CashLogSupport;
 import com.back.cash.domain.CashLog;
 import com.back.cash.domain.Wallet;
-import com.back.cash.domain.enums.RelType;
-import com.back.cash.adapter.out.CashLogRepository;
+import com.back.common.dto.cash.enums.RelType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/cash/src/test/java/com/back/cash/PayAndHoldUseCaseTest.java
+++ b/cash/src/test/java/com/back/cash/PayAndHoldUseCaseTest.java
@@ -2,17 +2,17 @@ package com.back.cash;
 
 import com.back.cash.adapter.out.PaymentRepository;
 import com.back.cash.app.CashLogSupport;
-import com.back.cash.app.usecase.PayAndHoldUseCase;
 import com.back.cash.app.WalletSupport;
+import com.back.cash.app.usecase.PayAndHoldUseCase;
 import com.back.cash.domain.Payment;
 import com.back.cash.domain.Wallet;
-import com.back.cash.domain.enums.PayAndHoldStatus;
 import com.back.cash.domain.enums.PaymentStatus;
-import com.back.cash.domain.enums.RelType;
 import com.back.cash.domain.enums.WalletType;
-import com.back.cash.dto.request.PayAndHoldRequestDto;
-import com.back.cash.dto.response.PayAndHoldResponseDto;
 import com.back.cash.mapper.PaymentMapper;
+import com.back.common.dto.cash.enums.PayAndHoldStatus;
+import com.back.common.dto.cash.enums.RelType;
+import com.back.common.dto.cash.request.PayAndHoldRequestDto;
+import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.common.exception.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -215,7 +215,7 @@ class PayAndHoldUseCaseTest {
     }
 
     private PayAndHoldRequestDto dto(BigDecimal total) {
-        return new PayAndHoldRequestDto(relType, relId, buyerId, total, orderName);
+        return new PayAndHoldRequestDto(buyerId, total, orderName, relType, relId);
     }
 
     private Payment givenNewPayment(PayAndHoldRequestDto dto) {


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #168 

## 🔎 작업 내용

- 캐시 모듈에서 사용하던 enum, dto를 common 모듈로 옮기게 되면서, 테스트 코드의 import문에 오류가 있어서 변경하였습니다. 

<br>


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
