### PR TITLE
[FEAT] 사용자 알림 정보 조회 기능 추가 (#189)

### DIFF
--- a/notification/src/main/java/com/back/notification/adapter/in/PriceAlertController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/PriceAlertController.java
@@ -31,4 +31,10 @@ public class PriceAlertController {
         List<PriceAlertResponseDto> response = priceAlertFacade.findByUserId(principal.getUserId());
         return CommonResponse.success(SuccessCode.OK, response);
     }
+
+    @DeleteMapping("/{priceAlertId}")
+    public CommonResponse<Void> deletePriceAlert(@PathVariable Long priceAlertId) {
+        priceAlertFacade.delete(priceAlertId);
+        return CommonResponse.success(SuccessCode.OK, null);
+    }
 }

--- a/notification/src/main/java/com/back/notification/adapter/in/PriceAlertController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/PriceAlertController.java
@@ -5,13 +5,13 @@ import com.back.common.response.CommonResponse;
 import com.back.notification.app.pricealert.PriceAlertFacade;
 import com.back.notification.dto.request.PriceAlertSaveRequestDto;
 import com.back.notification.dto.response.PriceAlertIdDto;
+import com.back.notification.dto.response.PriceAlertResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/price-alerts")
@@ -24,5 +24,11 @@ public class PriceAlertController {
                                                           @AuthenticationPrincipal AuthPrincipal principal) {
         PriceAlertIdDto response = priceAlertFacade.save(dto, principal.getUserId());
         return CommonResponse.success(SuccessCode.CREATED, response);
+    }
+
+    @GetMapping
+    public CommonResponse<List<PriceAlertResponseDto>> getPriceAlerts(@AuthenticationPrincipal AuthPrincipal principal) {
+        List<PriceAlertResponseDto> response = priceAlertFacade.findByUserId(principal.getUserId());
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/notification/src/main/java/com/back/notification/adapter/in/PriceAlertController.java
+++ b/notification/src/main/java/com/back/notification/adapter/in/PriceAlertController.java
@@ -33,8 +33,9 @@ public class PriceAlertController {
     }
 
     @DeleteMapping("/{priceAlertId}")
-    public CommonResponse<Void> deletePriceAlert(@PathVariable Long priceAlertId) {
-        priceAlertFacade.delete(priceAlertId);
+    public CommonResponse<Void> deletePriceAlert(@PathVariable Long priceAlertId,
+                                                  @AuthenticationPrincipal AuthPrincipal principal) {
+        priceAlertFacade.delete(priceAlertId, principal.getUserId());
         return CommonResponse.success(SuccessCode.OK, null);
     }
 }

--- a/notification/src/main/java/com/back/notification/adapter/out/PriceAlertRepository.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/PriceAlertRepository.java
@@ -26,4 +26,6 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
             @Param("currentPrice") BigDecimal currentPrice,
             @Param("threshold") LocalDateTime threshold
     );
+
+    List<PriceAlert> findByUserId(Long userId);
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertDeleteUsecase.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertDeleteUsecase.java
@@ -1,0 +1,20 @@
+package com.back.notification.app.pricealert;
+
+import com.back.notification.adapter.out.PriceAlertRepository;
+import com.back.notification.domain.PriceAlert;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PriceAlertDeleteUsecase {
+    private final PriceAlertRepository priceAlertRepository;
+    private final PriceAlertSupport priceAlertSupport;
+
+    public void delete(Long priceAlertId) {
+        PriceAlert priceAlert = priceAlertSupport.findById(priceAlertId);
+        priceAlertRepository.delete(priceAlert);
+    }
+}

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertDeleteUsecase.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertDeleteUsecase.java
@@ -13,8 +13,9 @@ public class PriceAlertDeleteUsecase {
     private final PriceAlertRepository priceAlertRepository;
     private final PriceAlertSupport priceAlertSupport;
 
-    public void delete(Long priceAlertId) {
+    public void delete(Long priceAlertId, Long userId) {
         PriceAlert priceAlert = priceAlertSupport.findById(priceAlertId);
+        priceAlertSupport.validateOwner(priceAlert, userId);
         priceAlertRepository.delete(priceAlert);
     }
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class PriceAlertFacade {
     private final PriceAlertSaveUsecase priceAlertSaveUsecase;
     private final PriceAlertFindUsecase priceAlertFindUsecase;
+    private final PriceAlertDeleteUsecase priceAlertDeleteUsecase;
     private final PriceAlertMapper priceAlertMapper;
 
     public PriceAlertIdDto save(PriceAlertSaveRequestDto dto, Long userId) {
@@ -27,5 +28,9 @@ public class PriceAlertFacade {
         List<PriceAlert> priceAlerts = priceAlertFindUsecase.findByUserId(userId);
 
         return priceAlertMapper.toPriceAlertResponseDtoList(priceAlerts);
+    }
+
+    public void delete(Long priceAlertId) {
+        priceAlertDeleteUsecase.delete(priceAlertId);
     }
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
@@ -30,7 +30,7 @@ public class PriceAlertFacade {
         return priceAlertMapper.toPriceAlertResponseDtoList(priceAlerts);
     }
 
-    public void delete(Long priceAlertId) {
-        priceAlertDeleteUsecase.delete(priceAlertId);
+    public void delete(Long priceAlertId, Long userId) {
+        priceAlertDeleteUsecase.delete(priceAlertId, userId);
     }
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
@@ -1,20 +1,31 @@
 package com.back.notification.app.pricealert;
 
+import com.back.notification.domain.PriceAlert;
 import com.back.notification.dto.request.PriceAlertSaveRequestDto;
 import com.back.notification.dto.response.PriceAlertIdDto;
+import com.back.notification.dto.response.PriceAlertResponseDto;
 import com.back.notification.mapper.PriceAlertMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PriceAlertFacade {
     private final PriceAlertSaveUsecase priceAlertSaveUsecase;
+    private final PriceAlertFindUsecase priceAlertFindUsecase;
     private final PriceAlertMapper priceAlertMapper;
 
     public PriceAlertIdDto save(PriceAlertSaveRequestDto dto, Long userId) {
         Long id = priceAlertSaveUsecase.save(dto, userId);
 
         return priceAlertMapper.toPriceAlertIdDto(id);
+    }
+
+    public List<PriceAlertResponseDto> findByUserId(Long userId) {
+        List<PriceAlert> priceAlerts = priceAlertFindUsecase.findByUserId(userId);
+
+        return priceAlertMapper.toPriceAlertResponseDtoList(priceAlerts);
     }
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFindUsecase.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFindUsecase.java
@@ -1,0 +1,20 @@
+package com.back.notification.app.pricealert;
+
+import com.back.notification.adapter.out.PriceAlertRepository;
+import com.back.notification.domain.PriceAlert;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriceAlertFindUsecase {
+    private final PriceAlertRepository priceAlertRepository;
+
+    public List<PriceAlert> findByUserId(Long userId) {
+        return priceAlertRepository.findByUserId(userId);
+    }
+}

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertSupport.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertSupport.java
@@ -4,6 +4,7 @@ import com.back.common.market.event.SellBiddingCreatedEvent;
 import com.back.notification.adapter.out.PriceAlertRepository;
 import com.back.notification.domain.NotificationUser;
 import com.back.notification.domain.PriceAlert;
+import com.back.notification.exception.PriceAlertNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,5 +30,10 @@ public class PriceAlertSupport {
                 .map(PriceAlert::getUser)
                 .distinct()
                 .toList();
+    }
+
+    public PriceAlert findById(Long priceAlertId) {
+        return priceAlertRepository.findById(priceAlertId)
+                .orElseThrow(PriceAlertNotFoundException::new);
     }
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertSupport.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertSupport.java
@@ -4,6 +4,7 @@ import com.back.common.market.event.SellBiddingCreatedEvent;
 import com.back.notification.adapter.out.PriceAlertRepository;
 import com.back.notification.domain.NotificationUser;
 import com.back.notification.domain.PriceAlert;
+import com.back.notification.exception.PriceAlertAccessDeniedException;
 import com.back.notification.exception.PriceAlertNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -35,5 +36,11 @@ public class PriceAlertSupport {
     public PriceAlert findById(Long priceAlertId) {
         return priceAlertRepository.findById(priceAlertId)
                 .orElseThrow(PriceAlertNotFoundException::new);
+    }
+
+    public void validateOwner(PriceAlert priceAlert, Long userId) {
+        if (!priceAlert.getUser().getId().equals(userId)) {
+            throw new PriceAlertAccessDeniedException();
+        }
     }
 }

--- a/notification/src/main/java/com/back/notification/dto/response/PriceAlertResponseDto.java
+++ b/notification/src/main/java/com/back/notification/dto/response/PriceAlertResponseDto.java
@@ -1,0 +1,21 @@
+package com.back.notification.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PriceAlertResponseDto {
+    private Long id;
+    private Long productId;
+    private BigDecimal targetPrice;
+    private LocalDateTime triggeredAt;
+    private LocalDateTime createdAt;
+}

--- a/notification/src/main/java/com/back/notification/exception/PriceAlertAccessDeniedException.java
+++ b/notification/src/main/java/com/back/notification/exception/PriceAlertAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.back.notification.exception;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+
+public class PriceAlertAccessDeniedException extends CustomException {
+    public PriceAlertAccessDeniedException() {
+        super("해당 가격 알림에 접근할 수 없습니다.", FailureCode.FORBIDDEN);
+    }
+}

--- a/notification/src/main/java/com/back/notification/exception/PriceAlertNotFoundException.java
+++ b/notification/src/main/java/com/back/notification/exception/PriceAlertNotFoundException.java
@@ -1,0 +1,10 @@
+package com.back.notification.exception;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+
+public class PriceAlertNotFoundException extends CustomException {
+    public PriceAlertNotFoundException() {
+        super("존재하지 않는 가격 알림입니다.", FailureCode.ENTITY_NOT_FOUND);
+    }
+}

--- a/notification/src/main/java/com/back/notification/mapper/PriceAlertMapper.java
+++ b/notification/src/main/java/com/back/notification/mapper/PriceAlertMapper.java
@@ -4,7 +4,10 @@ import com.back.notification.domain.NotificationUser;
 import com.back.notification.domain.PriceAlert;
 import com.back.notification.dto.request.PriceAlertSaveRequestDto;
 import com.back.notification.dto.response.PriceAlertIdDto;
+import com.back.notification.dto.response.PriceAlertResponseDto;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class PriceAlertMapper {
@@ -20,5 +23,21 @@ public class PriceAlertMapper {
         return PriceAlertIdDto.builder()
                 .id(id)
                 .build();
+    }
+
+    public PriceAlertResponseDto toPriceAlertResponseDto(PriceAlert priceAlert) {
+        return PriceAlertResponseDto.builder()
+                .id(priceAlert.getId())
+                .productId(priceAlert.getProductId())
+                .targetPrice(priceAlert.getTargetPrice())
+                .triggeredAt(priceAlert.getTriggeredAt())
+                .createdAt(priceAlert.getCreatedAt())
+                .build();
+    }
+
+    public List<PriceAlertResponseDto> toPriceAlertResponseDtoList(List<PriceAlert> priceAlerts) {
+        return priceAlerts.stream()
+                .map(this::toPriceAlertResponseDto)
+                .toList();
     }
 }

--- a/user/src/main/java/com/back/user/adapter/in/ApiV1UserController.java
+++ b/user/src/main/java/com/back/user/adapter/in/ApiV1UserController.java
@@ -6,14 +6,12 @@ import com.back.security.principal.AuthPrincipal;
 import com.back.user.app.UserFacade;
 import com.back.user.dto.request.UpdateFcmTokenRequest;
 import com.back.user.dto.request.UpdateNotificationSettingsRequest;
+import com.back.user.dto.response.NotificationSettingResponse;
 import com.back.user.dto.response.UserIdResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -29,10 +27,17 @@ public class ApiV1UserController implements UserApiV1 {
         return CommonResponse.success(SuccessCode.OK, response);
     }
 
-    @PatchMapping("/me/notifications/setting")
     @Override
+    @GetMapping("/me/notifications/setting")
+    public CommonResponse<NotificationSettingResponse> getNotificationSettings(@AuthenticationPrincipal AuthPrincipal authPrincipal) {
+        NotificationSettingResponse response = userFacade.getNotificationSettings(authPrincipal.getUserId());
+        return CommonResponse.success(SuccessCode.OK, response);
+    }
+
+    @Override
+    @PatchMapping("/me/notifications/setting")
     public CommonResponse<UserIdResponse> updateNotificationSettings(@AuthenticationPrincipal AuthPrincipal authPrincipal,
-                                                                     @RequestBody UpdateNotificationSettingsRequest request) {
+                                                                     @Valid @RequestBody UpdateNotificationSettingsRequest request) {
         UserIdResponse response = userFacade.updateNotificationSettings(authPrincipal.getUserId(), request);
         return CommonResponse.success(SuccessCode.OK, response);
     }

--- a/user/src/main/java/com/back/user/adapter/in/UserApiV1.java
+++ b/user/src/main/java/com/back/user/adapter/in/UserApiV1.java
@@ -4,6 +4,7 @@ import com.back.common.response.CommonResponse;
 import com.back.security.principal.AuthPrincipal;
 import com.back.user.dto.request.UpdateFcmTokenRequest;
 import com.back.user.dto.request.UpdateNotificationSettingsRequest;
+import com.back.user.dto.response.NotificationSettingResponse;
 import com.back.user.dto.response.UserIdResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,6 +29,19 @@ public interface UserApiV1 {
             AuthPrincipal authPrincipal,
             UpdateFcmTokenRequest request
     );
+
+    @Operation(
+            summary = "알림 설정 조회",
+            description = """
+            로그인한 사용자의 알림 설정을 조회합니다.
+            각 알림 항목의 ON/OFF 상태를 확인할 수 있습니다.
+            """
+    )
+    @ApiResponse(responseCode = "200", description = "알림 설정 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "404", description = "알림 설정 찾을 수 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<NotificationSettingResponse> getNotificationSettings(AuthPrincipal authPrincipal);
 
     @Operation(
             summary = "알림 설정 변경",

--- a/user/src/main/java/com/back/user/app/GetNotificationSettingsUseCase.java
+++ b/user/src/main/java/com/back/user/app/GetNotificationSettingsUseCase.java
@@ -1,0 +1,25 @@
+package com.back.user.app;
+
+import com.back.user.domain.UserSetting;
+import com.back.user.dto.response.NotificationSettingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetNotificationSettingsUseCase {
+    private final UserSupport userSupport;
+
+    @Transactional(readOnly = true)
+    public NotificationSettingResponse execute(Long userId) {
+        UserSetting setting = userSupport.findUserSettingById(userId);
+        
+        return new NotificationSettingResponse(
+                setting.isBidStatusEnabled(),
+                setting.isProductStatusEnabled(),
+                setting.isPriceEnabled(),
+                setting.isSettlementEnabled()
+        );
+    }
+}

--- a/user/src/main/java/com/back/user/app/UserFacade.java
+++ b/user/src/main/java/com/back/user/app/UserFacade.java
@@ -5,6 +5,7 @@ import com.back.common.user.event.fcmTokenChangedEvent;
 import com.back.user.domain.User;
 import com.back.user.dto.request.UpdateFcmTokenRequest;
 import com.back.user.dto.request.UpdateNotificationSettingsRequest;
+import com.back.user.dto.response.NotificationSettingResponse;
 import com.back.user.dto.response.UserIdResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ public class UserFacade {
     private final UserSupport userSupport;
     private final UserUpdateUsecase userUpdateUsecase;
     private final UserIncrementBlindCountUseCase userIncrementBlindCountUseCase;
+    private final GetNotificationSettingsUseCase getNotificationSettingsUseCase;
     private final KafkaEventPublisher kafkaEventPublisher;
 
     @Transactional
@@ -36,6 +38,12 @@ public class UserFacade {
         return UserIdResponse.of(user);
     }
 
+    @Transactional(readOnly = true)
+    public NotificationSettingResponse getNotificationSettings(Long userId) {
+        return getNotificationSettingsUseCase.execute(userId);
+    }
+
+    @Transactional
     public UserIdResponse updateNotificationSettings(Long userId, UpdateNotificationSettingsRequest request) {
         User user = userSupport.findById(userId);
 

--- a/user/src/main/java/com/back/user/dto/response/NotificationSettingResponse.java
+++ b/user/src/main/java/com/back/user/dto/response/NotificationSettingResponse.java
@@ -1,0 +1,9 @@
+package com.back.user.dto.response;
+
+public record NotificationSettingResponse(
+        boolean bidStatusEnabled,
+        boolean productStatusEnabled,
+        boolean priceEnabled,
+        boolean settlementEnabled
+) {
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #189 

## 🔎 작업 내용

- 사용자 알림 정보 조회 기능 추가
- 로그인한 유저의 가격 하락 알림 조회 기능 추가
- 가격 하락 알림 삭제 기능 추가

<br>


## 📌 참고 사항

- x

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 알림 정보 조회
```json
{
    "code": "OK",
    "data": {
        "bidStatusEnabled": true,
        "productStatusEnabled": true,
        "priceEnabled": true,
        "settlementEnabled": true
    },
    "message": "요청이 성공했습니다.",
    "status": 200
}
```

- 가격 하락 조회 기능
```json
{
    "code": "OK",
    "data": [
        {
            "id": 1,
            "productId": 1,
            "targetPrice": 10000.00,
            "triggeredAt": null,
            "createdAt": "2026-01-30T14:46:19.311272"
        },
        {
            "id": 2,
            "productId": 1,
            "targetPrice": 10000.00,
            "triggeredAt": null,
            "createdAt": "2026-01-30T14:46:23.788747"
        },
        {
            "id": 3,
            "productId": 1,
            "targetPrice": 1500.00,
            "triggeredAt": null,
            "createdAt": "2026-01-30T14:46:28.458252"
        }
    ],
    "message": "요청이 성공했습니다.",
    "status": 200
}
```

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
