### PR TITLE
[FIX] 소셜 로그인 프론트 콜백 URL 구조 수정 - (#188)

### DIFF
--- a/user/src/main/java/com/back/user/adapter/in/auth/security/config/OAuth2SecurityConfig.java
+++ b/user/src/main/java/com/back/user/adapter/in/auth/security/config/OAuth2SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.back.user.adapter.in.auth.security.config;
 
 
+import com.back.user.adapter.in.auth.security.filter.RedirectUriCookieFilter;
 import com.back.user.adapter.in.auth.security.handler.CustomSuccessHandler;
 import com.back.user.adapter.in.auth.security.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
@@ -21,6 +23,7 @@ public class OAuth2SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
+    private final RedirectUriCookieFilter redirectUriCookieFilter;
 
     @Bean
     @Order(1)
@@ -33,6 +36,7 @@ public class OAuth2SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
+        http.addFilterBefore(redirectUriCookieFilter, OAuth2AuthorizationRequestRedirectFilter.class);
         http.oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                 .successHandler(customSuccessHandler)

--- a/user/src/main/java/com/back/user/adapter/in/auth/security/config/OAuth2UriConfig.java
+++ b/user/src/main/java/com/back/user/adapter/in/auth/security/config/OAuth2UriConfig.java
@@ -1,0 +1,17 @@
+package com.back.user.adapter.in.auth.security.config;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "app.oauth2")
+@Getter
+@Setter
+public class OAuth2UriConfig {
+    private List<String> authorizedRedirectUris;
+}

--- a/user/src/main/java/com/back/user/adapter/in/auth/security/filter/RedirectUriCookieFilter.java
+++ b/user/src/main/java/com/back/user/adapter/in/auth/security/filter/RedirectUriCookieFilter.java
@@ -1,0 +1,34 @@
+package com.back.user.adapter.in.auth.security.filter;
+
+import com.back.user.app.auth.RefreshCookieSupport;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class RedirectUriCookieFilter extends OncePerRequestFilter {
+
+    private final RefreshCookieSupport refreshCookieSupport;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String redirectUri = request.getParameter("redirect_uri");
+        if (StringUtils.hasText(redirectUri)) {
+            response.addHeader(HttpHeaders.SET_COOKIE,
+                    refreshCookieSupport.createRedirectUriCookieHeader(redirectUri));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/user/src/main/java/com/back/user/adapter/in/auth/security/handler/CustomSuccessHandler.java
+++ b/user/src/main/java/com/back/user/adapter/in/auth/security/handler/CustomSuccessHandler.java
@@ -1,10 +1,12 @@
 package com.back.user.adapter.in.auth.security.handler;
 
 import com.back.security.jwt.JWTUtil;
+import com.back.user.adapter.in.auth.security.config.OAuth2UriConfig;
 import com.back.user.adapter.in.auth.security.oauth.principal.CustomOAuth2User;
 import com.back.user.adapter.out.RefreshStore;
 import com.back.user.app.auth.RefreshCookieSupport;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -22,6 +25,8 @@ import java.time.Duration;
 @RequiredArgsConstructor
 @Slf4j
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private static final String REDIRECT_URI_COOKIE = "redirect_uri";
+
     private final JWTUtil jwtUtil;
     private final RefreshStore refreshStore;
     private final RefreshCookieSupport refreshCookieSupport;
@@ -31,6 +36,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     @Value("${app.frontend.callback-url}")
     private String frontendCallbackUrl;
+
+    private final OAuth2UriConfig oauth2UriConfig;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -48,8 +55,33 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 쿠키에 refresh 토큰 저장
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookieSupport.createRefreshSetCookieHeader(refreshToken, refreshTtl));
 
+        // redirect 기본값
+        String targetUrl = frontendCallbackUrl;
+
+        if (request.getCookies() != null) {
+            for (Cookie c : request.getCookies()) {
+                if (REDIRECT_URI_COOKIE.equals(c.getName()) && StringUtils.hasText(c.getValue())) {
+                    String candidate = c.getValue();
+
+                    // 화이트리스트 검증
+                    if (isAllowedRedirect(candidate)) {
+                        targetUrl = candidate;
+                    }
+                    break;
+                }
+            }
+        }
+
+        // redirect_uri 쿠키 삭제
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookieSupport.deleteRedirectUriCookieHeader());
+
         // 프론트 경로로 redirect
-        response.sendRedirect(frontendCallbackUrl);
+        response.sendRedirect(targetUrl);
+    }
+
+    private boolean isAllowedRedirect(String uri) {
+        if (!StringUtils.hasText(uri)) return false;
+        return oauth2UriConfig.getAuthorizedRedirectUris().contains(uri.trim());
     }
 
 }

--- a/user/src/main/java/com/back/user/app/auth/RefreshCookieSupport.java
+++ b/user/src/main/java/com/back/user/app/auth/RefreshCookieSupport.java
@@ -13,7 +13,7 @@ public class RefreshCookieSupport {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .sameSite("Lax")
+                .sameSite("None")
                 .maxAge(ttl)
                 .build()
                 .toString();
@@ -25,7 +25,7 @@ public class RefreshCookieSupport {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .sameSite("Lax")
+                .sameSite("None")
                 .maxAge(0)
                 .build()
                 .toString();

--- a/user/src/main/java/com/back/user/app/auth/RefreshCookieSupport.java
+++ b/user/src/main/java/com/back/user/app/auth/RefreshCookieSupport.java
@@ -30,4 +30,28 @@ public class RefreshCookieSupport {
                 .build()
                 .toString();
     }
+
+    // 리다이렉트 URI 저장을 위한 쿠키 생성
+    public String createRedirectUriCookieHeader(String redirectUri) {
+        return ResponseCookie.from("redirect_uri", redirectUri)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("None")
+                .maxAge(Duration.ofMinutes(5))
+                .build()
+                .toString();
+    }
+
+    // 리다이렉트 URI 쿠키 삭제
+    public String deleteRedirectUriCookieHeader() {
+        return ResponseCookie.from("redirect_uri", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("None")
+                .maxAge(0)
+                .build()
+                .toString();
+    }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #188 

## 🔎 작업 내용

- 로컬 프론트와 배포 백엔드 서버 통신을 위해서 소셜 로그인 콜백 URL을 상황에 따라(localhost:5173, 도메인) 변경하기 위해 추가했습니다. 
- 쿠키 samsite를 None으로 변경했습니다. 
<br>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
