### PR TITLE
[FIX] 웹소켓 브로드캐스트 오류 수정 (#191)

### DIFF
--- a/chat/src/main/java/com/back/chat/ChatApplication.java
+++ b/chat/src/main/java/com/back/chat/ChatApplication.java
@@ -4,10 +4,12 @@ package com.back.chat;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @SpringBootApplication(scanBasePackages = "com.back")
 @EnableFeignClients
+@EnableJpaAuditing
 public class ChatApplication {
     public static void main(String[] args) {
         SpringApplication.run(ChatApplication.class, args);

--- a/chat/src/main/java/com/back/chat/adapter/out/redis/RedisSubscriberConfig.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/redis/RedisSubscriberConfig.java
@@ -12,7 +12,7 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 @RequiredArgsConstructor
 public class RedisSubscriberConfig {
 
-    private static final String CHAT_ROOM_CHANNEL_PATTERN = "chat:room:*";
+    private static final String CHAT_ROOM_CHANNEL_PATTERN = "chatroom:*";
 
     private final RedisConnectionFactory redisConnectionFactory;
     private final RedisChatMessageSubscriber redisChatMessageSubscriber;

--- a/chat/src/test/java/com/back/chat/RedisChatMessageSubscriberTest.java
+++ b/chat/src/test/java/com/back/chat/RedisChatMessageSubscriberTest.java
@@ -1,0 +1,81 @@
+package com.back.chat;
+
+import com.back.chat.adapter.out.redis.RedisChatMessageSubscriber;
+import com.back.chat.event.ChatEventEnvelope;
+import com.back.chat.event.ChatEventType;
+import com.back.chat.event.payload.ChatMessagePayload;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class RedisChatMessageSubscriberTest {
+
+    private ObjectMapper objectMapper;
+    private SimpMessagingTemplate messagingTemplate;
+    private RedisChatMessageSubscriber subscriber;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        // subscriber 내부에서 LocalDateTime을 역직렬화할 수 있게
+        // (너 프로젝트에서는 JacksonConfig 빈이 담당하지만 테스트는 여기서 최소로)
+        messagingTemplate = mock(SimpMessagingTemplate.class);
+        subscriber = new RedisChatMessageSubscriber(objectMapper, messagingTemplate);
+    }
+
+    @Test
+    void onMessage_shouldBroadcastToStompTopic_whenChatMessageEventArrives() throws Exception {
+        // given
+        long roomId = 3L;
+
+        ChatMessagePayload payload = new ChatMessagePayload(
+                101L,        // messageId
+                2L,          // userId
+                roomId,      // roomId
+                "hello",     // content
+                false,       // isBlinded
+                LocalDateTime.of(2026, 1, 30, 14, 50, 0) // createdAt
+        );
+
+        ChatEventEnvelope envelope = new ChatEventEnvelope(
+                ChatEventType.CHAT_MESSAGE,
+                objectMapper.valueToTree(payload)
+        );
+
+        String json = objectMapper.writeValueAsString(envelope);
+
+        byte[] channelBytes = ("chatroom:" + roomId).getBytes(StandardCharsets.UTF_8);
+        byte[] bodyBytes = json.getBytes(StandardCharsets.UTF_8);
+
+        Message redisMessage = new DefaultMessage(channelBytes, bodyBytes);
+
+        // when
+        subscriber.onMessage(redisMessage, null);
+
+        // then
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+
+        verify(messagingTemplate, times(1))
+                .convertAndSend(eq("/topic/chat/room/" + roomId), payloadCaptor.capture());
+
+        assertThat(payloadCaptor.getValue())
+                .isInstanceOf(ChatMessagePayload.class);
+
+        ChatMessagePayload sent = (ChatMessagePayload) payloadCaptor.getValue();
+        assertThat(sent.roomId()).isEqualTo(roomId);
+        assertThat(sent.messageId()).isEqualTo(101L);
+        assertThat(sent.content()).isEqualTo("hello");
+    }
+}
+


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #191 

## 🔎 작업 내용

- Redis 채널 패턴 불일치 수정
- EnableJpaAuditing 어노테이션 적용
- RedisChatMessageSubscriberTest 구현

<br>


## 📷 테스트 결과
- RedisChatMessageSubscriberTest 결과
  <br>
  <img width="220" height="87" alt="캡처" src="https://github.com/user-attachments/assets/466fd7e2-5e8a-42d7-9630-d2f94bfb2745" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
