### PR TITLE
[FEAT] 상품 옵션 CRUD API 기능 구현 (#164)

### DIFF
--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -35,6 +35,7 @@ public enum FailureCode {
     CANNOT_CANCEL_BID(HttpStatus.BAD_REQUEST, "CANNOT_CANCEL_BID", "이미 체결되었거나 취소할 수 없는 상태입니다."),
     WALLET_REFUND_FAILED(HttpStatus.BAD_REQUEST, "WALLET_REFUND_FAILED", "예치금 환불에 실패하였습니다"),
     OPTION_GROUP_IN_USE(HttpStatus.BAD_REQUEST, "OPTION_GROUP_IN_USE", "해당 옵션 그룹을 사용하는 상품이 있어 삭제할 수 없습니다."),
+    OPTION_VALUE_IN_USE(HttpStatus.BAD_REQUEST, "OPTION_VALUE_IN_USE", "해당 옵션 값을 사용하는 상품이 있어 삭제할 수 없습니다."),
 
     /**
      * 401 Unauthorized

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -34,6 +34,7 @@ public enum FailureCode {
     AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),
     CANNOT_CANCEL_BID(HttpStatus.BAD_REQUEST, "CANNOT_CANCEL_BID", "이미 체결되었거나 취소할 수 없는 상태입니다."),
     WALLET_REFUND_FAILED(HttpStatus.BAD_REQUEST, "WALLET_REFUND_FAILED", "예치금 환불에 실패하였습니다"),
+    OPTION_GROUP_IN_USE(HttpStatus.BAD_REQUEST, "OPTION_GROUP_IN_USE", "해당 옵션 그룹을 사용하는 상품이 있어 삭제할 수 없습니다."),
 
     /**
      * 401 Unauthorized

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -71,6 +71,7 @@ public enum FailureCode {
     PRODUCT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_INFO_NOT_FOUND", "존재하지 않는 상품 기본 정보입니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_MESSAGE_NOT_FOUND", "해당 메시지를 찾을 수 없습니다."),
     USER_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_SETTING_NOT_FOUND", "해당 유저의 알림 세팅을 찾을 수 없습니다."),
+    OPTION_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_GROUP_NOT_FOUND", "옵션 그룹이 존재하지 않습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -34,8 +34,6 @@ public enum FailureCode {
     AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),
     CANNOT_CANCEL_BID(HttpStatus.BAD_REQUEST, "CANNOT_CANCEL_BID", "이미 체결되었거나 취소할 수 없는 상태입니다."),
     WALLET_REFUND_FAILED(HttpStatus.BAD_REQUEST, "WALLET_REFUND_FAILED", "예치금 환불에 실패하였습니다"),
-    OPTION_GROUP_IN_USE(HttpStatus.BAD_REQUEST, "OPTION_GROUP_IN_USE", "해당 옵션 그룹을 사용하는 상품이 있어 삭제할 수 없습니다."),
-    OPTION_VALUE_IN_USE(HttpStatus.BAD_REQUEST, "OPTION_VALUE_IN_USE", "해당 옵션 값을 사용하는 상품이 있어 삭제할 수 없습니다."),
 
     /**
      * 401 Unauthorized
@@ -91,6 +89,8 @@ public enum FailureCode {
     DUPLICATE_PRODUCT_INFO(HttpStatus.CONFLICT, "DUPLICATE_PRODUCT_INFO", "이미 존재하는 상품 정보입니다."),
     REPORT_DUPLICATE(HttpStatus.CONFLICT, "REPORT_DUPLICATE", "이미 신고한 메시지입니다."),
     PAYMENT_ALREADY_RELEASED(HttpStatus.CONFLICT, "PAYMENT_ALREADY_RELEASED", "이미 환급된 결제입니다."),
+    OPTION_GROUP_IN_USE(HttpStatus.CONFLICT, "OPTION_GROUP_IN_USE", "해당 옵션 그룹을 사용하는 상품이 있어 삭제할 수 없습니다."),
+    OPTION_VALUE_IN_USE(HttpStatus.CONFLICT, "OPTION_VALUE_IN_USE", "해당 옵션 값을 사용하는 상품이 있어 삭제할 수 없습니다."),
     /**
      * 500 Internal Server Error
      */

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -2,8 +2,11 @@ dependencies {
     implementation project(':common')
     implementation project(':security')
 
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -65,4 +65,12 @@ public class ApiV1OptionController implements OptionApiController {
         OptionValueModifyResponseDto response = productFacade.modifyOptionValue(optionValueId, request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
+
+    @Override
+    @DeleteMapping("/{optionGroupId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public CommonResponse<?> deleteOptionGroup(@PathVariable Long optionGroupId) {
+        productFacade.deleteOptionGroup(optionGroupId);
+        return CommonResponse.success(SuccessCode.NO_CONTENT, null);
+    }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -3,13 +3,13 @@ package com.back.product.adapter.in;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
-import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.response.OptionResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = "/api/v1/products/options", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -25,12 +25,15 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
-    public CommonResponse<?> createOptionGroups(BrandCreateRequestDto request) {
-        return null;
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<OptionResponseDto> createOptions(@Valid @RequestBody OptionCreateRequestDto request) {
+        OptionResponseDto response = productFacade.createOptions(request);
+        return CommonResponse.success(SuccessCode.CREATED, response);
     }
 
     @Override
-    public CommonResponse<?> createOptionValues(BrandCreateRequestDto request) {
+    public CommonResponse<?> appendOptions(OptionCreateRequestDto request) {
         return null;
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -5,6 +5,8 @@ import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import jakarta.validation.Valid;
@@ -42,5 +44,14 @@ public class ApiV1OptionController implements OptionApiController {
             @Valid @RequestBody OptionAppendRequestDto request) {
         OptionResponseDto response = productFacade.appendOptions(optionGroupId, request);
         return CommonResponse.success(SuccessCode.CREATED, response);
+    }
+
+    @Override
+    @PutMapping("/groups/{optionGroupId}")
+    public CommonResponse<OptionGroupModifyResponseDto> modifyOptionGroup(
+            @PathVariable Long optionGroupId,
+            @Valid @RequestBody OptionGroupModifyRequestDto request) {
+        OptionGroupModifyResponseDto response = productFacade.modifyOptionGroup(optionGroupId, request);
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -67,7 +67,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
-    @DeleteMapping("/{optionGroupId}")
+    @DeleteMapping("/groups/{optionGroupId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<?> deleteOptionGroup(@PathVariable Long optionGroupId) {
         productFacade.deleteOptionGroup(optionGroupId);

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -6,9 +6,11 @@ import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.request.OptionValueModifyRequestDto;
 import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.dto.response.OptionValueModifyResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -52,6 +54,15 @@ public class ApiV1OptionController implements OptionApiController {
             @PathVariable Long optionGroupId,
             @Valid @RequestBody OptionGroupModifyRequestDto request) {
         OptionGroupModifyResponseDto response = productFacade.modifyOptionGroup(optionGroupId, request);
+        return CommonResponse.success(SuccessCode.OK, response);
+    }
+
+    @Override
+    @PutMapping("/values/{optionValueId}")
+    public CommonResponse<OptionValueModifyResponseDto> modifyOptionValue(
+            @PathVariable Long optionValueId,
+            @Valid @RequestBody OptionValueModifyRequestDto request) {
+        OptionValueModifyResponseDto response = productFacade.modifyOptionValue(optionValueId, request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -1,21 +1,27 @@
 package com.back.product.adapter.in;
 
+import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.response.OptionResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(path = "/api/v1/products/options")
+@RequestMapping(path = "/api/v1/products/options", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
-public class ApiV1ProductOptionController implements ProductOptionApiController {
+public class ApiV1OptionController implements OptionApiController {
     private final ProductFacade productFacade;
 
     @Override
-    public CommonResponse<?> getOptions() {
-        return null;
+    @GetMapping
+    public CommonResponse<OptionResponseDto> getOptions() {
+        OptionResponseDto response = productFacade.getOptions();
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 
     @Override

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -3,7 +3,9 @@ package com.back.product.adapter.in;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
+import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,21 +21,26 @@ public class ApiV1OptionController implements OptionApiController {
 
     @Override
     @GetMapping
-    public CommonResponse<OptionResponseDto> getOptions() {
-        OptionResponseDto response = productFacade.getOptions();
+    public CommonResponse<OptionListResponseDto> getOptions() {
+        OptionListResponseDto response = productFacade.getOptions();
         return CommonResponse.success(SuccessCode.OK, response);
     }
 
     @Override
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommonResponse<OptionResponseDto> createOptions(@Valid @RequestBody OptionCreateRequestDto request) {
-        OptionResponseDto response = productFacade.createOptions(request);
+    public CommonResponse<OptionListResponseDto> createOptions(@Valid @RequestBody OptionCreateRequestDto request) {
+        OptionListResponseDto response = productFacade.createOptions(request);
         return CommonResponse.success(SuccessCode.CREATED, response);
     }
 
     @Override
-    public CommonResponse<?> appendOptions(OptionCreateRequestDto request) {
-        return null;
+    @PostMapping(path = "/{optionGroupId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<OptionResponseDto> appendOptions(
+            @PathVariable Long optionGroupId,
+            @Valid @RequestBody OptionAppendRequestDto request) {
+        OptionResponseDto response = productFacade.appendOptions(optionGroupId, request);
+        return CommonResponse.success(SuccessCode.CREATED, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1OptionController.java
@@ -73,4 +73,12 @@ public class ApiV1OptionController implements OptionApiController {
         productFacade.deleteOptionGroup(optionGroupId);
         return CommonResponse.success(SuccessCode.NO_CONTENT, null);
     }
+
+    @Override
+    @DeleteMapping("/values/{optionValueId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public CommonResponse<?> deleteOptionValue(@PathVariable Long optionValueId) {
+        productFacade.deleteOptionValue(optionValueId);
+        return CommonResponse.success(SuccessCode.NO_CONTENT, null);
+    }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductOptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductOptionController.java
@@ -1,0 +1,30 @@
+package com.back.product.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.product.app.ProductFacade;
+import com.back.product.dto.request.BrandCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/v1/products/options")
+@RequiredArgsConstructor
+public class ApiV1ProductOptionController implements ProductOptionApiController {
+    private final ProductFacade productFacade;
+
+    @Override
+    public CommonResponse<?> getOptions() {
+        return null;
+    }
+
+    @Override
+    public CommonResponse<?> createOptionGroups(BrandCreateRequestDto request) {
+        return null;
+    }
+
+    @Override
+    public CommonResponse<?> createOptionValues(BrandCreateRequestDto request) {
+        return null;
+    }
+}

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -53,4 +53,14 @@ public interface OptionApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> deleteOptionGroup(Long optionGroupId);
+
+    @Operation(summary = "옵션 값 삭제", description = """
+        기존의 옵션 값을 삭제합니다.
+        삭제 시, 사용되는 상품이 있다면, 삭제를 진행하지 않습니다.
+    """)
+    @ApiResponse(responseCode = "204", description = "옵션 값 삭제 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> deleteOptionValue(Long optionValueId);
 }

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -2,6 +2,7 @@ package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.OptionCreateRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,17 +17,17 @@ public interface OptionApiController {
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> getOptions();
 
-    @Operation(summary = "옵션 그룹 생성", description = "새로운 옵션 그룹을 생성합니다.")
+    @Operation(summary = "옵션 생성", description = "새로운 옵션 그룹을 값을 포함하여 생성합니다.")
     @ApiResponse(responseCode = "201", description = "새로운 옵션 그룹 생성 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> createOptionGroups(BrandCreateRequestDto request);
+    CommonResponse<?> createOptions(OptionCreateRequestDto request);
 
-    @Operation(summary = "옵션 값 생성", description = "새로운 옵션 값을 생성합니다.")
+    @Operation(summary = "옵션 추가", description = "기존의 옵션 그룹에 값을 추가합니다.")
     @ApiResponse(responseCode = "201", description = "새로운 옵션 값 생성 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> createOptionValues(BrandCreateRequestDto request);
+    CommonResponse<?> appendOptions(OptionCreateRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -2,6 +2,7 @@ package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,5 +30,5 @@ public interface OptionApiController {
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> appendOptions(OptionCreateRequestDto request);
+    CommonResponse<?> appendOptions(Long optionGroupId, OptionAppendRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -4,6 +4,7 @@ import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.BrandCreateRequestDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.request.OptionGroupModifyRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,4 +32,13 @@ public interface OptionApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> appendOptions(Long optionGroupId, OptionAppendRequestDto request);
+
+    @Operation(summary = "옵션 그룹 수정", description = "기존의 옵션 그룹의 값을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "옵션 그룹 수정 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> modifyOptionGroup(Long optionGroupId, OptionGroupModifyRequestDto request);
+
+
 }

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -48,7 +48,7 @@ public interface OptionApiController {
         기존의 옵션 그룹을 삭제합니다.
         삭제 시, 그룹 내의 값들을 모두 확인해서 사용되는 상품이 있다면, 삭제를 진행하지 않습니다.
     """)
-    @ApiResponse(responseCode = "204", description = "옵션 값 수정 성공")
+    @ApiResponse(responseCode = "204", description = "옵션 그룹 삭제 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -1,10 +1,7 @@
 package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
-import com.back.product.dto.request.BrandCreateRequestDto;
-import com.back.product.dto.request.OptionAppendRequestDto;
-import com.back.product.dto.request.OptionCreateRequestDto;
-import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.request.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,6 +36,13 @@ public interface OptionApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> modifyOptionGroup(Long optionGroupId, OptionGroupModifyRequestDto request);
+
+    @Operation(summary = "옵션 값 수정", description = "기존의 옵션 값을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "옵션 값 수정 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> modifyOptionValue(Long optionValueId, OptionValueModifyRequestDto request);
 
 
 }

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Product", description = "상품 관련 API")
-public interface ProductOptionApiController {
+public interface OptionApiController {
 
     @Operation(summary = "상품 옵션 목록 조회", description = "상품의 옵션 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "상품 옵션 목록 조회 성공")

--- a/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/OptionApiController.java
@@ -44,5 +44,13 @@ public interface OptionApiController {
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> modifyOptionValue(Long optionValueId, OptionValueModifyRequestDto request);
 
-
+    @Operation(summary = "옵션 그룹 삭제", description = """
+        기존의 옵션 그룹을 삭제합니다.
+        삭제 시, 그룹 내의 값들을 모두 확인해서 사용되는 상품이 있다면, 삭제를 진행하지 않습니다.
+    """)
+    @ApiResponse(responseCode = "204", description = "옵션 값 수정 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> deleteOptionGroup(Long optionGroupId);
 }

--- a/product/src/main/java/com/back/product/adapter/in/ProductOptionApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductOptionApiController.java
@@ -1,0 +1,32 @@
+package com.back.product.adapter.in;
+
+import com.back.common.response.CommonResponse;
+import com.back.product.dto.request.BrandCreateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Product", description = "상품 관련 API")
+public interface ProductOptionApiController {
+
+    @Operation(summary = "상품 옵션 목록 조회", description = "상품의 옵션 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "상품 옵션 목록 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> getOptions();
+
+    @Operation(summary = "옵션 그룹 생성", description = "새로운 옵션 그룹을 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "새로운 옵션 그룹 생성 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> createOptionGroups(BrandCreateRequestDto request);
+
+    @Operation(summary = "옵션 값 생성", description = "새로운 옵션 값을 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "새로운 옵션 값 생성 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> createOptionValues(BrandCreateRequestDto request);
+}

--- a/product/src/main/java/com/back/product/adapter/out/OptionGroupRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/OptionGroupRepository.java
@@ -4,4 +4,5 @@ import com.back.product.domain.OptionGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> {
+    OptionGroup findByName(String name);
 }

--- a/product/src/main/java/com/back/product/adapter/out/OptionValueRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/OptionValueRepository.java
@@ -3,11 +3,16 @@ package com.back.product.adapter.out;
 import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface OptionValueRepository extends JpaRepository<OptionValue, Long>
 {
     List<OptionValue> findAllByOptionGroupIn(List<OptionGroup> optionGroups);
+
+    @Modifying
+    @Query("update OptionValue ov set ov.deletedAt = CURRENT_TIMESTAMP where ov.optionGroup.id = :optionGroupId")
+    void deleteAllByOptionGroup_Id(Long optionGroupId);
 }

--- a/product/src/main/java/com/back/product/adapter/out/OptionValueRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/OptionValueRepository.java
@@ -1,8 +1,13 @@
 package com.back.product.adapter.out;
 
+import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface OptionValueRepository extends JpaRepository<OptionValue, Long>
 {
+    List<OptionValue> findAllByOptionGroupIn(List<OptionGroup> optionGroups);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
@@ -15,4 +15,6 @@ public interface ProductOptionValuesRepository extends JpaRepository<ProductOpti
     void deleteAllByProductIn(@Param("products") List<Product> products);
 
     List<ProductOptionValues> findAllByProductIn(List<Product> products);
+
+    Boolean existsByOptionValue_OptionGroup_Id(Long optionGroupId);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductOptionValuesRepository.java
@@ -17,4 +17,6 @@ public interface ProductOptionValuesRepository extends JpaRepository<ProductOpti
     List<ProductOptionValues> findAllByProductIn(List<Product> products);
 
     Boolean existsByOptionValue_OptionGroup_Id(Long optionGroupId);
+
+    Boolean existsByOptionValue_Id(Long optionValueId);
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -1,5 +1,7 @@
 package com.back.product.app;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.app.usecase.*;
 import com.back.product.domain.*;
 import com.back.product.dto.CategoryDto;
@@ -132,5 +134,16 @@ public class ProductFacade {
     @Transactional
     public OptionValueModifyResponseDto modifyOptionValue(Long optionValueId, @Valid OptionValueModifyRequestDto request) {
         return optionUseCase.modifyOptionValue(optionValueId, request);
+    }
+
+    @Transactional
+    public void deleteOptionGroup(Long optionGroupId) {
+        Boolean isUsed = productUseCase.isOptionGroupInUse(optionGroupId);
+
+        if (isUsed) {
+            throw new CustomException(FailureCode.OPTION_GROUP_IN_USE);
+        }
+
+        optionUseCase.deleteOptions(optionGroupId);
     }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -6,10 +6,7 @@ import com.back.product.dto.CategoryDto;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.request.*;
 import com.back.product.dto.BrandDto;
-import com.back.product.dto.response.OptionListResponseDto;
-import com.back.product.dto.response.OptionResponseDto;
-import com.back.product.dto.response.ProductResponseDto;
-import com.back.product.dto.response.ProductSearchListResponseDto;
+import com.back.product.dto.response.*;
 import com.back.product.mapper.ProductInfoMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -125,5 +122,10 @@ public class ProductFacade {
     @Transactional
     public OptionResponseDto appendOptions(Long optionGroupId, @Valid OptionAppendRequestDto request) {
         return optionUseCase.appendOptions(optionGroupId, request);
+    }
+
+    @Transactional
+    public OptionGroupModifyResponseDto modifyOptionGroup(Long optionGroupId, @Valid OptionGroupModifyRequestDto request) {
+        return optionUseCase.modifyOptionGroup(optionGroupId, request);
     }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -128,4 +128,9 @@ public class ProductFacade {
     public OptionGroupModifyResponseDto modifyOptionGroup(Long optionGroupId, @Valid OptionGroupModifyRequestDto request) {
         return optionUseCase.modifyOptionGroup(optionGroupId, request);
     }
+
+    @Transactional
+    public OptionValueModifyResponseDto modifyOptionValue(Long optionValueId, @Valid OptionValueModifyRequestDto request) {
+        return optionUseCase.modifyOptionValue(optionValueId, request);
+    }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -116,4 +116,8 @@ public class ProductFacade {
                 .build();
     }
 
+    @Transactional
+    public OptionResponseDto createOptions(@Valid OptionCreateRequestDto request) {
+        return optionUseCase.createOptions(request);
+    }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -146,4 +146,15 @@ public class ProductFacade {
 
         optionUseCase.deleteOptions(optionGroupId);
     }
+
+    @Transactional
+    public void deleteOptionValue(Long optionValueId) {
+        Boolean isUsed = productUseCase.isOptionValueInUse(optionValueId);
+
+        if (isUsed) {
+            throw new CustomException(FailureCode.OPTION_VALUE_IN_USE);
+        }
+
+        optionUseCase.deleteOption(optionValueId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -6,6 +6,7 @@ import com.back.product.dto.CategoryDto;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.request.*;
 import com.back.product.dto.BrandDto;
+import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.dto.response.ProductResponseDto;
 import com.back.product.dto.response.ProductSearchListResponseDto;
@@ -105,7 +106,7 @@ public class ProductFacade {
     }
 
     @Transactional(readOnly = true)
-    public OptionResponseDto getOptions() {
+    public OptionListResponseDto getOptions() {
         return optionUseCase.findAllOptions();
     }
 
@@ -117,7 +118,12 @@ public class ProductFacade {
     }
 
     @Transactional
-    public OptionResponseDto createOptions(@Valid OptionCreateRequestDto request) {
+    public OptionListResponseDto createOptions(@Valid OptionCreateRequestDto request) {
         return optionUseCase.createOptions(request);
+    }
+
+    @Transactional
+    public OptionResponseDto appendOptions(Long optionGroupId, @Valid OptionAppendRequestDto request) {
+        return optionUseCase.appendOptions(optionGroupId, request);
     }
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -6,6 +6,7 @@ import com.back.product.dto.CategoryDto;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.request.*;
 import com.back.product.dto.BrandDto;
+import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.dto.response.ProductResponseDto;
 import com.back.product.dto.response.ProductSearchListResponseDto;
 import com.back.product.mapper.ProductInfoMapper;
@@ -103,10 +104,16 @@ public class ProductFacade {
         return productDocumentUseCase.findProductPage(request, page, size);
     }
 
+    @Transactional(readOnly = true)
+    public OptionResponseDto getOptions() {
+        return optionUseCase.findAllOptions();
+    }
+
     private ProductResponseDto buildProductResponseDto(ProductInfo productInfo, List<ProductDto> productDtos) {
         return ProductResponseDto.builder()
                 .productInfo(productInfoMapper.toDto(productInfo))
                 .products(productDtos)
                 .build();
     }
+
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -10,9 +10,11 @@ import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.request.OptionValueModifyRequestDto;
 import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.dto.response.OptionValueModifyResponseDto;
 import com.back.product.mapper.OptionMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -103,6 +105,23 @@ public class OptionUseCase {
 
         return convertToModifyGroupDto(existsGroup);
     }
+
+    @Transactional
+    public OptionValueModifyResponseDto modifyOptionValue(Long optionValueId, @Valid OptionValueModifyRequestDto request) {
+        OptionValue existsValue = productSupport.getOptionValueById(optionValueId)
+                .orElseThrow(() -> new CustomException(FailureCode.OPTION_VALUE_NOT_FOUND));
+
+        existsValue.modifyName(request.name());
+
+        if (existsValue.willChangeGroup(request.optionGroupId())) {
+            OptionGroup changedGroup = productSupport.getOptionGroupById(request.optionGroupId())
+                            .orElseThrow(() -> new CustomException(FailureCode.OPTION_GROUP_NOT_FOUND));
+
+            existsValue.changeGroup(changedGroup);
+        }
+
+        return convertToModifyValueDto(existsValue);
+    }
     
     private OptionGroup createOptionGroup(String name) {
         return optionMapper.toGroupEntity(name);
@@ -139,6 +158,15 @@ public class OptionUseCase {
                 .id(group.getId())
                 .name(group.getName())
                 .updatedAt(group.getLastModifiedAt())
+                .build();
+    }
+
+    private OptionValueModifyResponseDto convertToModifyValueDto(OptionValue value) {
+        return OptionValueModifyResponseDto.builder()
+                .id(value.getId())
+                .optionGroupId(value.getOptionGroup().getId())
+                .value(value.getValue())
+                .updatedAt(value.getLastModifiedAt())
                 .build();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -2,12 +2,18 @@ package com.back.product.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
+import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
+import com.back.product.dto.OptionDto;
+import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.mapper.OptionMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.swing.text.html.Option;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -15,6 +21,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class OptionUseCase {
+    private final OptionMapper optionMapper;
     private final ProductSupport productSupport;
 
     @Transactional(readOnly = true)
@@ -27,5 +34,31 @@ public class OptionUseCase {
 
         return foundValues.stream()
                 .collect(Collectors.toMap(OptionValue::getId, value -> value));
+    }
+
+    @Transactional(readOnly = true)
+    public OptionResponseDto findAllOptions() {
+        List<OptionGroup> optionGroups = productSupport.getAllProductOptionGroups();
+
+        if (optionGroups.isEmpty()) {
+            return OptionResponseDto.builder().build();
+        }
+
+        Map<OptionGroup, List<OptionValue>> optionValueAsMap = productSupport.getAllProductOptionValuesByOptionGroupIn(optionGroups)
+                .stream().collect(Collectors.groupingBy(OptionValue::getOptionGroup));
+
+        return convertToDto(optionGroups, optionValueAsMap);
+    }
+
+    private OptionResponseDto convertToDto(List<OptionGroup> optionGroups, Map<OptionGroup, List<OptionValue>> optionValueAsMap) {
+        List<OptionDto> optionDtos = optionGroups.stream().map(group -> {
+            List<OptionValue> values = optionValueAsMap.get(group);
+
+            if (values == null) values = new ArrayList<>();
+
+            return optionMapper.toDto(group, values);
+        }).toList();
+
+        return OptionResponseDto.builder().options(optionDtos).build();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -7,7 +7,9 @@ import com.back.product.adapter.out.OptionValueRepository;
 import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
+import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.mapper.OptionMapper;
 import jakarta.validation.Valid;
@@ -19,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -42,11 +43,11 @@ public class OptionUseCase {
     }
 
     @Transactional(readOnly = true)
-    public OptionResponseDto findAllOptions() {
+    public OptionListResponseDto findAllOptions() {
         List<OptionGroup> optionGroups = productSupport.getAllProductOptionGroups();
 
         if (optionGroups.isEmpty()) {
-            return OptionResponseDto.builder().build();
+            return OptionListResponseDto.builder().build();
         }
 
         Map<OptionGroup, List<OptionValue>> optionValueAsMap = productSupport.getAllProductOptionValuesByOptionGroupIn(optionGroups)
@@ -56,12 +57,12 @@ public class OptionUseCase {
     }
 
     @Transactional
-    public OptionResponseDto createOptions(@Valid OptionCreateRequestDto request) {
+    public OptionListResponseDto createOptions(@Valid OptionCreateRequestDto request) {
         List<OptionDto> createdOptions = request.options().stream()
                 .map(option -> createOption(option.group(), option.values()))
                 .toList();
 
-        return OptionResponseDto.builder().options(createdOptions).build();
+        return OptionListResponseDto.builder().options(createdOptions).build();
     }
 
     @Transactional
@@ -78,6 +79,18 @@ public class OptionUseCase {
         
         return convertToOptionDto(group, createdValues);
     }
+
+    @Transactional
+    public OptionResponseDto appendOptions(Long optionGroupId, @Valid OptionAppendRequestDto request) {
+        OptionGroup group = productSupport.getOptionGroupById(optionGroupId)
+                .orElseThrow(() -> new CustomException(FailureCode.OPTION_GROUP_NOT_FOUND));
+
+        List<OptionValue> newValues = createOptionValues(group, request.values());
+
+        List<OptionValue> createdValues = optionValueRepository.saveAll(newValues);
+
+        return OptionResponseDto.builder().option(convertToOptionDto(group, createdValues)).build();
+    }
     
     private OptionGroup createOptionGroup(String name) {
         return optionMapper.toGroupEntity(name);
@@ -93,7 +106,7 @@ public class OptionUseCase {
         return optionMapper.toValueEntity(group, valueName);
     }
 
-    private OptionResponseDto convertToOptionResponseDto(List<OptionGroup> optionGroups, Map<OptionGroup, List<OptionValue>> optionValueAsMap) {
+    private OptionListResponseDto convertToOptionResponseDto(List<OptionGroup> optionGroups, Map<OptionGroup, List<OptionValue>> optionValueAsMap) {
         List<OptionDto> optionDtos = optionGroups.stream().map(group -> {
             List<OptionValue> values = optionValueAsMap.get(group);
 
@@ -102,7 +115,7 @@ public class OptionUseCase {
             return convertToOptionDto(group, values);
         }).toList();
 
-        return OptionResponseDto.builder().options(optionDtos).build();
+        return OptionListResponseDto.builder().options(optionDtos).build();
     }
     
     private OptionDto convertToOptionDto(OptionGroup group, List<OptionValue> values) {

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -2,9 +2,12 @@ package com.back.product.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
+import com.back.product.adapter.out.OptionGroupRepository;
+import com.back.product.adapter.out.OptionValueRepository;
 import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
+import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.mapper.OptionMapper;
 import jakarta.validation.Valid;
@@ -12,17 +15,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.Option;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 public class OptionUseCase {
     private final OptionMapper optionMapper;
     private final ProductSupport productSupport;
+    private final OptionGroupRepository optionGroupRepository;
+    private final OptionValueRepository optionValueRepository;
 
     @Transactional(readOnly = true)
     public Map<Long, OptionValue> findOptionValuesAsMap(@Valid List<Long> optionValueIds) {
@@ -47,18 +52,60 @@ public class OptionUseCase {
         Map<OptionGroup, List<OptionValue>> optionValueAsMap = productSupport.getAllProductOptionValuesByOptionGroupIn(optionGroups)
                 .stream().collect(Collectors.groupingBy(OptionValue::getOptionGroup));
 
-        return convertToDto(optionGroups, optionValueAsMap);
+        return convertToOptionResponseDto(optionGroups, optionValueAsMap);
     }
 
-    private OptionResponseDto convertToDto(List<OptionGroup> optionGroups, Map<OptionGroup, List<OptionValue>> optionValueAsMap) {
+    @Transactional
+    public OptionResponseDto createOptions(@Valid OptionCreateRequestDto request) {
+        List<OptionDto> createdOptions = request.options().stream()
+                .map(option -> createOption(option.group(), option.values()))
+                .toList();
+
+        return OptionResponseDto.builder().options(createdOptions).build();
+    }
+
+    @Transactional
+    public OptionDto createOption(String groupName, List<String> valueNames) {
+        OptionGroup group = productSupport.getOptionGroupByName(groupName.toLowerCase());
+        
+        if (group == null) {
+            OptionGroup newGroup = createOptionGroup(groupName);
+            group = optionGroupRepository.save(newGroup);
+        }
+
+        List<OptionValue> newValues = createOptionValues(group, valueNames);
+        List<OptionValue> createdValues = optionValueRepository.saveAll(newValues);
+        
+        return convertToOptionDto(group, createdValues);
+    }
+    
+    private OptionGroup createOptionGroup(String name) {
+        return optionMapper.toGroupEntity(name);
+    }
+    
+    private List<OptionValue> createOptionValues(OptionGroup group, List<String> valueNames) {
+        return valueNames.stream()
+                .map(valueName -> createOptionValue(group, valueName))
+                .toList();
+    }
+    
+    private OptionValue createOptionValue(OptionGroup group, String valueName) {
+        return optionMapper.toValueEntity(group, valueName);
+    }
+
+    private OptionResponseDto convertToOptionResponseDto(List<OptionGroup> optionGroups, Map<OptionGroup, List<OptionValue>> optionValueAsMap) {
         List<OptionDto> optionDtos = optionGroups.stream().map(group -> {
             List<OptionValue> values = optionValueAsMap.get(group);
 
             if (values == null) values = new ArrayList<>();
 
-            return optionMapper.toDto(group, values);
+            return convertToOptionDto(group, values);
         }).toList();
 
         return OptionResponseDto.builder().options(optionDtos).build();
+    }
+    
+    private OptionDto convertToOptionDto(OptionGroup group, List<OptionValue> values) {
+        return optionMapper.toDto(group, values);
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -129,6 +129,11 @@ public class OptionUseCase {
 
         optionGroupRepository.deleteById(optionGroupId);
     }
+
+    @Transactional
+    public void deleteOption(Long optionValueId) {
+        optionValueRepository.deleteById(optionValueId);
+    }
     
     private OptionGroup createOptionGroup(String name) {
         return optionMapper.toGroupEntity(name);

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -167,18 +167,26 @@ public class OptionUseCase {
 
     private OptionGroupModifyResponseDto convertToModifyGroupDto(OptionGroup group) {
         return OptionGroupModifyResponseDto.builder()
-                .id(group.getId())
-                .name(group.getName())
-                .updatedAt(group.getLastModifiedAt())
+                .group(
+                        OptionGroupModifyResponseDto.OptionGroupDto.builder()
+                                .id(group.getId())
+                                .name(group.getName())
+                                .updatedAt(group.getLastModifiedAt())
+                                .build()
+                )
                 .build();
     }
 
     private OptionValueModifyResponseDto convertToModifyValueDto(OptionValue value) {
         return OptionValueModifyResponseDto.builder()
-                .id(value.getId())
-                .optionGroupId(value.getOptionGroup().getId())
-                .value(value.getValue())
-                .updatedAt(value.getLastModifiedAt())
+                .value(
+                        OptionValueModifyResponseDto.OptionValueDto.builder()
+                                .id(value.getId())
+                                .optionGroupId(value.getOptionGroup().getId())
+                                .value(value.getValue())
+                                .updatedAt(value.getLastModifiedAt())
+                                .build()
+                )
                 .build();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -9,6 +9,8 @@ import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.mapper.OptionMapper;
@@ -91,6 +93,16 @@ public class OptionUseCase {
 
         return OptionResponseDto.builder().option(convertToOptionDto(group, createdValues)).build();
     }
+
+    @Transactional
+    public OptionGroupModifyResponseDto modifyOptionGroup(Long optionGroupId, @Valid OptionGroupModifyRequestDto request) {
+        OptionGroup existsGroup = productSupport.getOptionGroupById(optionGroupId)
+                .orElseThrow(() -> new CustomException(FailureCode.OPTION_GROUP_NOT_FOUND));
+
+        existsGroup.modifyName(request.name());
+
+        return convertToModifyGroupDto(existsGroup);
+    }
     
     private OptionGroup createOptionGroup(String name) {
         return optionMapper.toGroupEntity(name);
@@ -120,5 +132,13 @@ public class OptionUseCase {
     
     private OptionDto convertToOptionDto(OptionGroup group, List<OptionValue> values) {
         return optionMapper.toDto(group, values);
+    }
+
+    private OptionGroupModifyResponseDto convertToModifyGroupDto(OptionGroup group) {
+        return OptionGroupModifyResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .updatedAt(group.getLastModifiedAt())
+                .build();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/OptionUseCase.java
@@ -122,6 +122,13 @@ public class OptionUseCase {
 
         return convertToModifyValueDto(existsValue);
     }
+
+    @Transactional
+    public void deleteOptions(Long optionGroupId) {
+        optionValueRepository.deleteAllByOptionGroup_Id(optionGroupId);
+
+        optionGroupRepository.deleteById(optionGroupId);
+    }
     
     private OptionGroup createOptionGroup(String name) {
         return optionMapper.toGroupEntity(name);

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -116,4 +116,8 @@ public class ProductSupport {
         return optionValueRepository.findById(optionValueId);
     }
 
+    @Transactional(readOnly = true)
+    public Boolean existsProductByOptionGroupId(Long optionGroupId) {
+        return productOptionValuesRepository.existsByOptionValue_OptionGroup_Id(optionGroupId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -110,4 +110,10 @@ public class ProductSupport {
     public Optional<OptionGroup> getOptionGroupById(Long optionGroupId) {
         return optionGroupRepository.findById(optionGroupId);
     }
+
+    @Transactional(readOnly = true)
+    public Optional<OptionValue> getOptionValueById(Long optionValueId) {
+        return optionValueRepository.findById(optionValueId);
+    }
+
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -21,6 +21,7 @@ public class ProductSupport {
     private final ProductRepository productRepository;
     private final ProductOptionValuesRepository productOptionValuesRepository;
     private final ProductImageRepository productImageRepository;
+    private final OptionGroupRepository optionGroupRepository;
 
     @Transactional(readOnly = true)
     public List<Brand> getAllBrands() {
@@ -88,5 +89,15 @@ public class ProductSupport {
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
 
         return productRepository.findAllByProductInfo(productInfo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionGroup> getAllProductOptionGroups() {
+        return optionGroupRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionValue> getAllProductOptionValuesByOptionGroupIn(List<OptionGroup> productOptionGroups) {
+        return optionValueRepository.findAllByOptionGroupIn(productOptionGroups);
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -105,4 +105,9 @@ public class ProductSupport {
     public OptionGroup getOptionGroupByName(String name) {
         return optionGroupRepository.findByName(name);
     }
+
+    @Transactional(readOnly = true)
+    public Optional<OptionGroup> getOptionGroupById(Long optionGroupId) {
+        return optionGroupRepository.findById(optionGroupId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -120,4 +120,9 @@ public class ProductSupport {
     public Boolean existsProductByOptionGroupId(Long optionGroupId) {
         return productOptionValuesRepository.existsByOptionValue_OptionGroup_Id(optionGroupId);
     }
+
+    @Transactional(readOnly = true)
+    public Boolean existsProductByOptionValueId(Long optionValueId) {
+        return productOptionValuesRepository.existsByOptionValue_Id(optionValueId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -100,4 +100,9 @@ public class ProductSupport {
     public List<OptionValue> getAllProductOptionValuesByOptionGroupIn(List<OptionGroup> productOptionGroups) {
         return optionValueRepository.findAllByOptionGroupIn(productOptionGroups);
     }
+
+    @Transactional(readOnly = true)
+    public OptionGroup getOptionGroupByName(String name) {
+        return optionGroupRepository.findByName(name);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -212,4 +212,9 @@ public class ProductUseCase {
             )
         ).toList();
     }
+
+    @Transactional
+    public Boolean isOptionGroupInUse(Long optionGroupId) {
+        return productSupport.existsProductByOptionGroupId(optionGroupId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -217,4 +217,9 @@ public class ProductUseCase {
     public Boolean isOptionGroupInUse(Long optionGroupId) {
         return productSupport.existsProductByOptionGroupId(optionGroupId);
     }
+
+    @Transactional
+    public Boolean isOptionValueInUse(Long optionValueId) {
+        return productSupport.existsProductByOptionValueId(optionValueId);
+    }
 }

--- a/product/src/main/java/com/back/product/domain/OptionGroup.java
+++ b/product/src/main/java/com/back/product/domain/OptionGroup.java
@@ -21,4 +21,8 @@ public class OptionGroup extends BaseTimeEntity {
 
     @Column(nullable = false, length = 20, unique = true)
     private String name;
+
+    public void modifyName(String name) {
+        this.name = name;
+    }
 }

--- a/product/src/main/java/com/back/product/domain/OptionGroup.java
+++ b/product/src/main/java/com/back/product/domain/OptionGroup.java
@@ -19,6 +19,6 @@ public class OptionGroup extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 20, unique = true)
     private String name;
 }

--- a/product/src/main/java/com/back/product/domain/OptionValue.java
+++ b/product/src/main/java/com/back/product/domain/OptionValue.java
@@ -23,6 +23,6 @@ public class OptionValue extends BaseTimeEntity {
     @JoinColumn(name = "option_group_id", nullable = false)
     private OptionGroup optionGroup;
 
-    @Column(name="option_value", nullable = false, length = 20)
+    @Column(name="option_value", nullable = false, length = 20, unique = true)
     private String value;
 }

--- a/product/src/main/java/com/back/product/domain/OptionValue.java
+++ b/product/src/main/java/com/back/product/domain/OptionValue.java
@@ -25,4 +25,16 @@ public class OptionValue extends BaseTimeEntity {
 
     @Column(name="option_value", nullable = false, length = 20, unique = true)
     private String value;
+
+    public void modifyName(String value) {
+        this.value = value;
+    }
+
+    public void changeGroup(OptionGroup optionGroup) {
+        this.optionGroup = optionGroup;
+    }
+
+    public Boolean willChangeGroup(Long changedGroupId) {
+        return !changedGroupId.equals(this.getOptionGroup().getId());
+    }
 }

--- a/product/src/main/java/com/back/product/dto/OptionDto.java
+++ b/product/src/main/java/com/back/product/dto/OptionDto.java
@@ -1,0 +1,26 @@
+package com.back.product.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OptionDto(
+        GroupDto group,
+        List<ValueDto> values
+) {
+    @Builder
+    public record GroupDto(
+            Long id,
+            String name
+    ) {
+    }
+
+
+    @Builder
+    public record ValueDto(
+            Long id,
+            String name
+    ) {
+    }
+}

--- a/product/src/main/java/com/back/product/dto/request/OptionAppendRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/OptionAppendRequestDto.java
@@ -1,0 +1,16 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OptionAppendRequestDto(
+        @NotEmpty(message = "Option Values cannot be null")
+        @Valid
+        List<@Pattern(regexp = "[a-zA-Z0-9]{1,20}$", message = "Option values can be only english and number") String> values
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/OptionCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/OptionCreateRequestDto.java
@@ -1,0 +1,28 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OptionCreateRequestDto(
+        @NotEmpty(message = "Options cannot be null")
+        @Valid
+        List<OptionDto> options
+) {
+    @Builder
+    public record OptionDto(
+            @NotBlank(message = "Option Group Name cannot be blank")
+            @Pattern(regexp = "^[a-z]+$", message = "Option Group Name is permitted only lower case english")
+            String group,
+
+            @NotEmpty(message = "Option Values cannot be null")
+            @Valid
+            List<@Pattern(regexp = "[a-zA-Z0-9]+$", message = "Option values are permitted only english and number") String> values
+    ) {
+    }
+}

--- a/product/src/main/java/com/back/product/dto/request/OptionCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/OptionCreateRequestDto.java
@@ -17,12 +17,12 @@ public record OptionCreateRequestDto(
     @Builder
     public record OptionDto(
             @NotBlank(message = "Option Group Name cannot be blank")
-            @Pattern(regexp = "^[a-z]+$", message = "Option Group Name is permitted only lower case english")
+            @Pattern(regexp = "^[a-z]{1,20}$", message = "Option Group Name is permitted only lower case english")
             String group,
 
             @NotEmpty(message = "Option Values cannot be null")
             @Valid
-            List<@Pattern(regexp = "[a-zA-Z0-9]+$", message = "Option values are permitted only english and number") String> values
+            List<@Pattern(regexp = "[a-zA-Z0-9]{1,20}$", message = "Option values are permitted only english and number") String> values
     ) {
     }
 }

--- a/product/src/main/java/com/back/product/dto/request/OptionGroupModifyRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/OptionGroupModifyRequestDto.java
@@ -1,0 +1,13 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record OptionGroupModifyRequestDto(
+        @NotBlank(message = "Option Group Name cannot be blank")
+        @Pattern(regexp = "^[a-z]{1,20}$", message = "Option Group Name is permitted only lower case english")
+        String name
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/OptionValueModifyRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/OptionValueModifyRequestDto.java
@@ -1,0 +1,18 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record OptionValueModifyRequestDto(
+        @NotNull(message = "Option Group ID cannot be null")
+        @Min(value = 1, message = "Option Group Id must be over 1")
+        Long optionGroupId,
+
+        @NotNull(message = "Option Value Name cannot be null")
+        @Pattern(regexp = "[a-zA-Z0-9]{1,20}$", message = "Option values are permitted only english and number")
+        String name
+) {
+}

--- a/product/src/main/java/com/back/product/dto/response/OptionGroupModifyResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/OptionGroupModifyResponseDto.java
@@ -6,8 +6,13 @@ import java.time.LocalDateTime;
 
 @Builder
 public record OptionGroupModifyResponseDto(
-        Long id,
-        String name,
-        LocalDateTime updatedAt
+        OptionGroupDto group
 ) {
+    @Builder
+    public record OptionGroupDto(
+            Long id,
+            String name,
+            LocalDateTime updatedAt
+    ) {
+    }
 }

--- a/product/src/main/java/com/back/product/dto/response/OptionGroupModifyResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/OptionGroupModifyResponseDto.java
@@ -1,0 +1,13 @@
+package com.back.product.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record OptionGroupModifyResponseDto(
+        Long id,
+        String name,
+        LocalDateTime updatedAt
+) {
+}

--- a/product/src/main/java/com/back/product/dto/response/OptionListResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/OptionListResponseDto.java
@@ -3,8 +3,10 @@ package com.back.product.dto.response;
 import com.back.product.dto.OptionDto;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
-public record OptionResponseDto(
-        OptionDto option
+public record OptionListResponseDto(
+        List<OptionDto> options
 ) {
 }

--- a/product/src/main/java/com/back/product/dto/response/OptionResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/OptionResponseDto.java
@@ -1,0 +1,12 @@
+package com.back.product.dto.response;
+
+import com.back.product.dto.OptionDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OptionResponseDto(
+        List<OptionDto> options
+) {
+}

--- a/product/src/main/java/com/back/product/dto/response/OptionValueModifyResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/OptionValueModifyResponseDto.java
@@ -1,0 +1,14 @@
+package com.back.product.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record OptionValueModifyResponseDto(
+        Long id,
+        Long optionGroupId,
+        String value,
+        LocalDateTime updatedAt
+) {
+}

--- a/product/src/main/java/com/back/product/dto/response/OptionValueModifyResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/OptionValueModifyResponseDto.java
@@ -6,9 +6,14 @@ import java.time.LocalDateTime;
 
 @Builder
 public record OptionValueModifyResponseDto(
-        Long id,
-        Long optionGroupId,
-        String value,
-        LocalDateTime updatedAt
+        OptionValueDto value
 ) {
+    @Builder
+    public record OptionValueDto(
+            Long id,
+            Long optionGroupId,
+            String value,
+            LocalDateTime updatedAt
+    ) {
+    }
 }

--- a/product/src/main/java/com/back/product/mapper/OptionMapper.java
+++ b/product/src/main/java/com/back/product/mapper/OptionMapper.java
@@ -9,6 +9,19 @@ import java.util.List;
 
 @Component
 public class OptionMapper {
+    public OptionGroup toGroupEntity(String name) {
+        return OptionGroup.builder().name(name).build();
+    }
+
+    public OptionValue toValueEntity(String group, String value) {
+        OptionGroup groupEntity = toGroupEntity(group);
+        return toValueEntity(groupEntity, value);
+    }
+
+    public OptionValue toValueEntity(OptionGroup group, String value) {
+        return OptionValue.builder().optionGroup(group).value(value).build();
+    }
+
     public OptionDto toDto(OptionGroup group, List<OptionValue> values) {
         OptionDto.GroupDto optionGroup = toDto(group);
         List<OptionDto.ValueDto> optionValues = values.stream().map(this::toDto).toList();

--- a/product/src/main/java/com/back/product/mapper/OptionMapper.java
+++ b/product/src/main/java/com/back/product/mapper/OptionMapper.java
@@ -1,0 +1,35 @@
+package com.back.product.mapper;
+
+import com.back.product.domain.OptionGroup;
+import com.back.product.domain.OptionValue;
+import com.back.product.dto.OptionDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class OptionMapper {
+    public OptionDto toDto(OptionGroup group, List<OptionValue> values) {
+        OptionDto.GroupDto optionGroup = toDto(group);
+        List<OptionDto.ValueDto> optionValues = values.stream().map(this::toDto).toList();
+
+        return OptionDto.builder()
+                .group(optionGroup)
+                .values(optionValues)
+                .build();
+    }
+
+    private OptionDto.GroupDto toDto(OptionGroup group) {
+        return OptionDto.GroupDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .build();
+    }
+
+    private OptionDto.ValueDto toDto(OptionValue value) {
+        return OptionDto.ValueDto.builder()
+                .id(value.getId())
+                .name(value.getValue())
+                .build();
+    }
+}

--- a/product/src/main/java/com/back/product/mapper/ProductOptionMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductOptionMapper.java
@@ -1,5 +1,7 @@
 package com.back.product.mapper;
 
+import com.back.product.domain.OptionGroup;
+import com.back.product.domain.OptionValue;
 import com.back.product.domain.ProductOptionValues;
 import com.back.product.dto.ProductOptionDto;
 import org.springframework.stereotype.Component;
@@ -13,4 +15,5 @@ public class ProductOptionMapper {
                 .value(productOptionValues.getOptionValue().getValue())
                 .build();
     }
+
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -3,7 +3,9 @@ package com.back.product.adapter.in;
 import com.back.common.code.SuccessCode;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.OptionDto;
+import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,6 +22,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -61,7 +65,7 @@ public class ApiV1OptionControllerTest {
                     OptionDto.ValueDto.builder().id(1L).name("L").build(),
                     OptionDto.ValueDto.builder().id(2L).name("M").build()
             );
-            OptionResponseDto response = OptionResponseDto.builder()
+            OptionListResponseDto response = OptionListResponseDto.builder()
                     .options(List.of(
                             OptionDto.builder().group(color).values(colorValues).build(),
                             OptionDto.builder().group(size).values(sizeValues).build()
@@ -112,7 +116,7 @@ public class ApiV1OptionControllerTest {
                     OptionDto.ValueDto.builder().id(201L).name("small").build(),
                     OptionDto.ValueDto.builder().id(202L).name("large").build()
             );
-            OptionResponseDto expectedResponseDto = OptionResponseDto.builder()
+            OptionListResponseDto expectedResponseDto = OptionListResponseDto.builder()
                     .options(List.of(
                             OptionDto.builder().group(responseGroup1).values(responseValues1).build(),
                             OptionDto.builder().group(responseGroup2).values(responseValues2).build()
@@ -202,6 +206,83 @@ public class ApiV1OptionControllerTest {
 
             // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
             verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/products/options/{optionGroupId}")
+    class AppendOptionsTest {
+
+        @Test
+        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 성공")
+        void appendOptions_success() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
+                    .values(List.of("newValue1", "newValue2"))
+                    .build();
+
+            OptionDto.GroupDto responseGroup = OptionDto.GroupDto.builder().id(optionGroupId).name("color").build();
+            List<OptionDto.ValueDto> responseValues = List.of(
+                    OptionDto.ValueDto.builder().id(1L).name("oldValue").build(),
+                    OptionDto.ValueDto.builder().id(2L).name("newValue1").build(),
+                    OptionDto.ValueDto.builder().id(3L).name("newValue2").build()
+            );
+            OptionResponseDto expectedResponseDto = OptionResponseDto.builder()
+                    .option(OptionDto.builder().group(responseGroup).values(responseValues).build())
+                    .build();
+
+            given(productFacade.appendOptions(anyLong(), any(OptionAppendRequestDto.class))).willReturn(expectedResponseDto);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/products/options/{optionGroupId}", optionGroupId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value(SuccessCode.CREATED.name()))
+                    .andExpect(jsonPath("$.data.option.group.name").value("color"))
+                    .andExpect(jsonPath("$.data.option.values.length()").value(3));
+
+            verify(productFacade).appendOptions(eq(optionGroupId), any(OptionAppendRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 유효성 검사 실패 (빈 values 리스트)")
+        void appendOptions_validationFailure_emptyList() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
+                    .values(List.of())
+                    .build();
+
+            // when & then
+            mockMvc.perform(post("/api/v1/products/options/{optionGroupId}", optionGroupId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).appendOptions(anyLong(), any(OptionAppendRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 유효성 검사 실패 (유효하지 않은 패턴)")
+        void appendOptions_validationFailure_invalidPattern() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
+                    .values(List.of("invalid!value"))
+                    .build();
+
+            // when & then
+            mockMvc.perform(post("/api/v1/products/options/{optionGroupId}", optionGroupId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).appendOptions(anyLong(), any(OptionAppendRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -274,7 +274,7 @@ public class ApiV1OptionControllerTest {
     }
 
     @Nested
-    @DisplayName("DELETE /api/v1/products/options/{optionGroupId}")
+    @DisplayName("DELETE /api/v1/products/options/groups/{optionGroupId}")
     class DeleteOptionGroupTest {
 
         @Test
@@ -285,7 +285,7 @@ public class ApiV1OptionControllerTest {
             doNothing().when(productFacade).deleteOptionGroup(anyLong());
 
             // when & then
-            mockMvc.perform(delete("/api/v1/products/options/{optionGroupId}", optionGroupId))
+            mockMvc.perform(delete("/api/v1/products/options/groups/{optionGroupId}", optionGroupId))
                     .andDo(print())
                     .andExpect(status().isNoContent());
 
@@ -302,9 +302,9 @@ public class ApiV1OptionControllerTest {
                     .deleteOptionGroup(anyLong());
 
             // when & then
-            mockMvc.perform(delete("/api/v1/products/options/{optionGroupId}", optionGroupId))
+            mockMvc.perform(delete("/api/v1/products/options/groups/{optionGroupId}", optionGroupId))
                     .andDo(print())
-                    .andExpect(status().isBadRequest())
+                    .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(FailureCode.OPTION_GROUP_IN_USE.name()))
                     .andExpect(jsonPath("$.message").value(FailureCode.OPTION_GROUP_IN_USE.getMessage()));
         }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -1,30 +1,37 @@
 package com.back.product.adapter.in;
 
+import com.back.common.code.SuccessCode;
 import com.back.product.app.ProductFacade;
-import com.back.product.app.usecase.OptionUseCase;
 import com.back.product.dto.OptionDto;
+import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.security.jwt.JWTUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ApiV1OptionController.class)
 @DisplayName("ApiV1OptionController 테스트")
+@ActiveProfiles("test")
 public class ApiV1OptionControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -33,10 +40,9 @@ public class ApiV1OptionControllerTest {
     private JWTUtil jwtUtil;
 
     @MockitoBean
-    private OptionUseCase optionUseCase;
-
-    @MockitoBean
     private ProductFacade productFacade;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Nested
     @DisplayName("GET /api/v1/products/options")
@@ -62,7 +68,7 @@ public class ApiV1OptionControllerTest {
                     ))
                     .build();
 
-            given(optionUseCase.findAllOptions()).willReturn(response);
+            given(productFacade.getOptions()).willReturn(response);
 
             mockMvc.perform(
                             get("/api/v1/products/options")
@@ -71,6 +77,131 @@ public class ApiV1OptionControllerTest {
                     .andExpect(status().isOk());
 
             verify(productFacade).getOptions();
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/products/options")
+    class CreateOptionsTest {
+
+        @Test
+        @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 성공")
+        void createOptions_unit_test_success() throws Exception {
+            // given: 테스트 준비
+            // 1. 요청 DTO 생성
+            OptionCreateRequestDto.OptionDto requestOption1 = OptionCreateRequestDto.OptionDto.builder()
+                    .group("color")
+                    .values(List.of("red", "blue"))
+                    .build();
+            OptionCreateRequestDto.OptionDto requestOption2 = OptionCreateRequestDto.OptionDto.builder()
+                    .group("size")
+                    .values(List.of("small", "large"))
+                    .build();
+            OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
+                    .options(List.of(requestOption1, requestOption2))
+                    .build();
+
+            // 2. 응답 DTO 생성
+            OptionDto.GroupDto responseGroup1 = OptionDto.GroupDto.builder().id(1L).name("color").build();
+            List<OptionDto.ValueDto> responseValues1 = List.of(
+                    OptionDto.ValueDto.builder().id(101L).name("red").build(),
+                    OptionDto.ValueDto.builder().id(102L).name("blue").build()
+            );
+            OptionDto.GroupDto responseGroup2 = OptionDto.GroupDto.builder().id(2L).name("size").build();
+            List<OptionDto.ValueDto> responseValues2 = List.of(
+                    OptionDto.ValueDto.builder().id(201L).name("small").build(),
+                    OptionDto.ValueDto.builder().id(202L).name("large").build()
+            );
+            OptionResponseDto expectedResponseDto = OptionResponseDto.builder()
+                    .options(List.of(
+                            OptionDto.builder().group(responseGroup1).values(responseValues1).build(),
+                            OptionDto.builder().group(responseGroup2).values(responseValues2).build()
+                    ))
+                    .build();
+
+            // 3. ProductFacade 모킹
+            given(productFacade.createOptions(any(OptionCreateRequestDto.class))).willReturn(expectedResponseDto);
+
+            // when & then: 컨트롤러 실행 및 결과 검증
+            mockMvc.perform(post("/api/v1/products/options")
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated()) // 201 Created
+                    .andExpect(jsonPath("$.code").value(SuccessCode.CREATED.name()))
+                    .andExpect(jsonPath("$.message").value(SuccessCode.CREATED.getMessage()))
+                    .andExpect(jsonPath("$.data.options[0].group.name").value("color"))
+                    .andExpect(jsonPath("$.data.options[0].values[0].name").value("red"))
+                    .andExpect(jsonPath("$.data.options[1].group.name").value("size"))
+                    .andExpect(jsonPath("$.data.options[1].values[1].name").value("large"));
+
+            // ProductFacade의 createOptions 메서드가 올바른 인수로 한 번 호출되었는지 검증
+            verify(productFacade).createOptions(any(OptionCreateRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 유효성 검사 실패 (빈 Options 리스트)")
+        void createOptions_unit_test_validation_failure_empty_options() throws Exception {
+            // given: 유효하지 않은 요청 DTO 생성 (options 리스트가 비어 있음)
+            OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
+                    .options(List.of()) // Empty list
+                    .build();
+
+            // when & then: 컨트롤러 실행 및 결과 검증
+            mockMvc.perform(post("/api/v1/products/options")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest()); // 400 Bad Request
+
+            // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
+            verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 유효성 검사 실패 (Option Group Name 공백)")
+        void createOptions_unit_test_validation_failure_blank_group_name() throws Exception {
+            // given: 유효하지 않은 요청 DTO 생성 (group 이름이 공백)
+            OptionCreateRequestDto.OptionDto requestOption = OptionCreateRequestDto.OptionDto.builder()
+                    .group("  ") // Blank group name
+                    .values(List.of("value1"))
+                    .build();
+            OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
+                    .options(List.of(requestOption))
+                    .build();
+
+            // when & then: 컨트롤러 실행 및 결과 검증
+            mockMvc.perform(post("/api/v1/products/options")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest()); // 400 Bad Request
+
+            // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
+            verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 유효성 검사 실패 (Option Values 리스트 공백)")
+        void createOptions_unit_test_validation_failure_empty_values() throws Exception {
+            // given: 유효하지 않은 요청 DTO 생성 (values 리스트가 비어 있음)
+            OptionCreateRequestDto.OptionDto requestOption = OptionCreateRequestDto.OptionDto.builder()
+                    .group("group1")
+                    .values(List.of()) // Empty values list
+                    .build();
+            OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
+                    .options(List.of(requestOption))
+                    .build();
+
+            // when & then: 컨트롤러 실행 및 결과 검증
+            mockMvc.perform(post("/api/v1/products/options")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest()); // 400 Bad Request
+
+            // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
+            verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -6,13 +6,13 @@ import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.request.OptionValueModifyRequestDto;
 import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.dto.response.OptionValueModifyResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,6 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("ApiV1OptionController 테스트")
 @ActiveProfiles("test")
 public class ApiV1OptionControllerTest {
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -51,13 +52,8 @@ public class ApiV1OptionControllerTest {
 
     @MockitoBean
     private ProductFacade productFacade;
-    
-    ObjectMapper objectMapper = new ObjectMapper();
 
-    @BeforeEach
-    void setupObjectMapper() {
-        objectMapper.registerModule(new JavaTimeModule());
-    }
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Nested
     @DisplayName("GET /api/v1/products/options")
@@ -65,7 +61,7 @@ public class ApiV1OptionControllerTest {
         @Test
         @DisplayName("상품 옵션 목록 조회 컨트롤러 단위 테스트")
         void getOptions_unit_test() throws Exception {
-            // given: 테스트 준비
+            // given
             OptionDto.GroupDto color = OptionDto.GroupDto.builder().id(1L).name("색상").build();
             List<OptionDto.ValueDto> colorValues = List.of(
                     OptionDto.ValueDto.builder().id(1L).name("빨강").build(),
@@ -85,9 +81,9 @@ public class ApiV1OptionControllerTest {
 
             given(productFacade.getOptions()).willReturn(response);
 
-            mockMvc.perform(
-                            get("/api/v1/products/options")
-                                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            // when & then
+            mockMvc.perform(get("/api/v1/products/options")
+                            .contentType(MediaType.APPLICATION_JSON_VALUE))
                     .andDo(print())
                     .andExpect(status().isOk());
 
@@ -98,12 +94,10 @@ public class ApiV1OptionControllerTest {
     @Nested
     @DisplayName("POST /api/v1/products/options")
     class CreateOptionsTest {
-
         @Test
         @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 성공")
         void createOptions_unit_test_success() throws Exception {
-            // given: 테스트 준비
-            // 1. 요청 DTO 생성
+            // given
             OptionCreateRequestDto.OptionDto requestOption1 = OptionCreateRequestDto.OptionDto.builder()
                     .group("color")
                     .values(List.of("red", "blue"))
@@ -116,7 +110,6 @@ public class ApiV1OptionControllerTest {
                     .options(List.of(requestOption1, requestOption2))
                     .build();
 
-            // 2. 응답 DTO 생성
             OptionDto.GroupDto responseGroup1 = OptionDto.GroupDto.builder().id(1L).name("color").build();
             List<OptionDto.ValueDto> responseValues1 = List.of(
                     OptionDto.ValueDto.builder().id(101L).name("red").build(),
@@ -134,15 +127,14 @@ public class ApiV1OptionControllerTest {
                     ))
                     .build();
 
-            // 3. ProductFacade 모킹
             given(productFacade.createOptions(any(OptionCreateRequestDto.class))).willReturn(expectedResponseDto);
 
-            // when & then: 컨트롤러 실행 및 결과 검증
+            // when & then
             mockMvc.perform(post("/api/v1/products/options")
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andDo(print())
-                    .andExpect(status().isCreated()) // 201 Created
+                    .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.code").value(SuccessCode.CREATED.name()))
                     .andExpect(jsonPath("$.message").value(SuccessCode.CREATED.getMessage()))
                     .andExpect(jsonPath("$.data.options[0].group.name").value("color"))
@@ -150,72 +142,22 @@ public class ApiV1OptionControllerTest {
                     .andExpect(jsonPath("$.data.options[1].group.name").value("size"))
                     .andExpect(jsonPath("$.data.options[1].values[1].name").value("large"));
 
-            // ProductFacade의 createOptions 메서드가 올바른 인수로 한 번 호출되었는지 검증
             verify(productFacade).createOptions(any(OptionCreateRequestDto.class));
         }
 
         @Test
         @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 유효성 검사 실패 (빈 Options 리스트)")
         void createOptions_unit_test_validation_failure_empty_options() throws Exception {
-            // given: 유효하지 않은 요청 DTO 생성 (options 리스트가 비어 있음)
             OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
-                    .options(List.of()) // Empty list
+                    .options(List.of())
                     .build();
 
-            // when & then: 컨트롤러 실행 및 결과 검증
             mockMvc.perform(post("/api/v1/products/options")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andDo(print())
-                    .andExpect(status().isBadRequest()); // 400 Bad Request
+                    .andExpect(status().isBadRequest());
 
-            // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
-            verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
-        }
-
-        @Test
-        @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 유효성 검사 실패 (Option Group Name 공백)")
-        void createOptions_unit_test_validation_failure_blank_group_name() throws Exception {
-            // given: 유효하지 않은 요청 DTO 생성 (group 이름이 공백)
-            OptionCreateRequestDto.OptionDto requestOption = OptionCreateRequestDto.OptionDto.builder()
-                    .group("  ") // Blank group name
-                    .values(List.of("value1"))
-                    .build();
-            OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
-                    .options(List.of(requestOption))
-                    .build();
-
-            // when & then: 컨트롤러 실행 및 결과 검증
-            mockMvc.perform(post("/api/v1/products/options")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest()); // 400 Bad Request
-
-            // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
-            verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
-        }
-
-        @Test
-        @DisplayName("상품 옵션 생성 컨트롤러 단위 테스트 - 유효성 검사 실패 (Option Values 리스트 공백)")
-        void createOptions_unit_test_validation_failure_empty_values() throws Exception {
-            // given: 유효하지 않은 요청 DTO 생성 (values 리스트가 비어 있음)
-            OptionCreateRequestDto.OptionDto requestOption = OptionCreateRequestDto.OptionDto.builder()
-                    .group("group1")
-                    .values(List.of()) // Empty values list
-                    .build();
-            OptionCreateRequestDto requestDto = OptionCreateRequestDto.builder()
-                    .options(List.of(requestOption))
-                    .build();
-
-            // when & then: 컨트롤러 실행 및 결과 검증
-            mockMvc.perform(post("/api/v1/products/options")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest()); // 400 Bad Request
-
-            // ProductFacade의 createOptions 메서드가 호출되지 않았는지 검증
             verify(productFacade, never()).createOptions(any(OptionCreateRequestDto.class));
         }
     }
@@ -223,7 +165,6 @@ public class ApiV1OptionControllerTest {
     @Nested
     @DisplayName("POST /api/v1/products/options/{optionGroupId}")
     class AppendOptionsTest {
-
         @Test
         @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 성공")
         void appendOptions_success() throws Exception {
@@ -257,50 +198,11 @@ public class ApiV1OptionControllerTest {
 
             verify(productFacade).appendOptions(eq(optionGroupId), any(OptionAppendRequestDto.class));
         }
-
-        @Test
-        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 유효성 검사 실패 (빈 values 리스트)")
-        void appendOptions_validationFailure_emptyList() throws Exception {
-            // given
-            Long optionGroupId = 1L;
-            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
-                    .values(List.of())
-                    .build();
-
-            // when & then
-            mockMvc.perform(post("/api/v1/products/options/{optionGroupId}", optionGroupId)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-
-            verify(productFacade, never()).appendOptions(anyLong(), any(OptionAppendRequestDto.class));
-        }
-
-        @Test
-        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 유효하지 않은 패턴)")
-        void appendOptions_validationFailure_invalidPattern() throws Exception {
-            // given
-            Long optionGroupId = 1L;
-            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
-                    .values(List.of("invalid!value"))
-                    .build();
-
-            // when & then
-            mockMvc.perform(post("/api/v1/products/options/{optionGroupId}", optionGroupId)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-
-            verify(productFacade, never()).appendOptions(anyLong(), any(OptionAppendRequestDto.class));
-        }
     }
 
     @Nested
     @DisplayName("PUT /api/v1/products/options/groups/{optionGroupId}")
     class ModifyOptionGroupTest {
-
         @Test
         @DisplayName("옵션 그룹 이름 수정 컨트롤러 단위 테스트 - 성공")
         void modifyOptionGroup_success() throws Exception {
@@ -326,49 +228,49 @@ public class ApiV1OptionControllerTest {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(SuccessCode.OK.name()))
-                    .andExpect(jsonPath("$.message").value(SuccessCode.OK.getMessage()))
                     .andExpect(jsonPath("$.data.id").value(optionGroupId))
                     .andExpect(jsonPath("$.data.name").value(newGroupName));
 
             verify(productFacade).modifyOptionGroup(eq(optionGroupId), any(OptionGroupModifyRequestDto.class));
         }
+    }
 
+    @Nested
+    @DisplayName("PUT /api/v1/products/options/values/{optionValueId}")
+    class ModifyOptionValueTest {
         @Test
-        @DisplayName("옵션 그룹 이름 수정 컨트롤러 단위 테스트 - 유효성 검사 실패 (공백 이름)")
-        void modifyOptionGroup_validationFailure_blankName() throws Exception {
+        @DisplayName("옵션 값 수정 컨트롤러 단위 테스트 - 성공")
+        void modifyOptionValue_success() throws Exception {
             // given
-            Long optionGroupId = 1L;
-            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
-                    .name("  ") // Blank name
+            Long optionValueId = 1L;
+            Long newOptionGroupId = 2L;
+            String newName = "newvalue";
+            OptionValueModifyRequestDto requestDto = OptionValueModifyRequestDto.builder()
+                    .optionGroupId(newOptionGroupId)
+                    .name(newName)
                     .build();
 
+            OptionValueModifyResponseDto expectedResponseDto = OptionValueModifyResponseDto.builder()
+                    .id(optionValueId)
+                    .optionGroupId(newOptionGroupId)
+                    .value(newName)
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            given(productFacade.modifyOptionValue(eq(optionValueId), any(OptionValueModifyRequestDto.class))).willReturn(expectedResponseDto);
+
             // when & then
-            mockMvc.perform(put("/api/v1/products/options/groups/{optionGroupId}", optionGroupId)
+            mockMvc.perform(put("/api/v1/products/options/values/{optionValueId}", optionValueId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andDo(print())
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessCode.OK.name()))
+                    .andExpect(jsonPath("$.data.id").value(optionValueId))
+                    .andExpect(jsonPath("$.data.optionGroupId").value(newOptionGroupId))
+                    .andExpect(jsonPath("$.data.value").value(newName));
 
-            verify(productFacade, never()).modifyOptionGroup(anyLong(), any(OptionGroupModifyRequestDto.class));
-        }
-
-        @Test
-        @DisplayName("옵션 그룹 이름 수정 컨트롤러 단위 테스트 - 유효성 검사 실패 (유효하지 않은 패턴)")
-        void modifyOptionGroup_validationFailure_invalidPattern() throws Exception {
-            // given
-            Long optionGroupId = 1L;
-            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
-                    .name("InvalidName123") // Invalid pattern (uppercase, numbers)
-                    .build();
-
-            // when & then
-            mockMvc.perform(put("/api/v1/products/options/groups/{optionGroupId}", optionGroupId)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestDto)))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
-
-            verify(productFacade, never()).modifyOptionGroup(anyLong(), any(OptionGroupModifyRequestDto.class));
+            verify(productFacade).modifyOptionValue(eq(optionValueId), any(OptionValueModifyRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -1,6 +1,8 @@
 package com.back.product.adapter.in;
 
+import com.back.common.code.FailureCode;
 import com.back.common.code.SuccessCode;
+import com.back.common.exception.CustomException;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
@@ -30,11 +32,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -271,6 +270,43 @@ public class ApiV1OptionControllerTest {
                     .andExpect(jsonPath("$.data.value").value(newName));
 
             verify(productFacade).modifyOptionValue(eq(optionValueId), any(OptionValueModifyRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/products/options/{optionGroupId}")
+    class DeleteOptionGroupTest {
+
+        @Test
+        @DisplayName("옵션 그룹 삭제 컨트롤러 단위 테스트 - 성공")
+        void deleteOptionGroup_success() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            doNothing().when(productFacade).deleteOptionGroup(anyLong());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/products/options/{optionGroupId}", optionGroupId))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            verify(productFacade).deleteOptionGroup(eq(optionGroupId));
+        }
+
+        @Test
+        @DisplayName("옵션 그룹 삭제 컨트롤러 단위 테스트 - 실패 (옵션 그룹 사용 중)")
+        void deleteOptionGroup_fail_optionGroupInUse() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            doThrow(new CustomException(FailureCode.OPTION_GROUP_IN_USE))
+                    .when(productFacade)
+                    .deleteOptionGroup(anyLong());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/products/options/{optionGroupId}", optionGroupId))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(FailureCode.OPTION_GROUP_IN_USE.name()))
+                    .andExpect(jsonPath("$.message").value(FailureCode.OPTION_GROUP_IN_USE.getMessage()));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -213,9 +213,13 @@ public class ApiV1OptionControllerTest {
                     .build();
 
             OptionGroupModifyResponseDto expectedResponseDto = OptionGroupModifyResponseDto.builder()
-                    .id(optionGroupId)
-                    .name(newGroupName)
-                    .updatedAt(LocalDateTime.now())
+                    .group(
+                            OptionGroupModifyResponseDto.OptionGroupDto.builder()
+                                    .id(optionGroupId)
+                                    .name(newGroupName)
+                                    .updatedAt(LocalDateTime.now())
+                                    .build()
+                    )
                     .build();
 
             given(productFacade.modifyOptionGroup(eq(optionGroupId), any(OptionGroupModifyRequestDto.class))).willReturn(expectedResponseDto);
@@ -227,8 +231,8 @@ public class ApiV1OptionControllerTest {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(SuccessCode.OK.name()))
-                    .andExpect(jsonPath("$.data.id").value(optionGroupId))
-                    .andExpect(jsonPath("$.data.name").value(newGroupName));
+                    .andExpect(jsonPath("$.data.group.id").value(optionGroupId))
+                    .andExpect(jsonPath("$.data.group.name").value(newGroupName));
 
             verify(productFacade).modifyOptionGroup(eq(optionGroupId), any(OptionGroupModifyRequestDto.class));
         }
@@ -250,10 +254,14 @@ public class ApiV1OptionControllerTest {
                     .build();
 
             OptionValueModifyResponseDto expectedResponseDto = OptionValueModifyResponseDto.builder()
-                    .id(optionValueId)
-                    .optionGroupId(newOptionGroupId)
-                    .value(newName)
-                    .updatedAt(LocalDateTime.now())
+                    .value(
+                            OptionValueModifyResponseDto.OptionValueDto.builder()
+                                    .id(optionValueId)
+                                    .optionGroupId(newOptionGroupId)
+                                    .value(newName)
+                                    .updatedAt(LocalDateTime.now())
+                                    .build()
+                    )
                     .build();
 
             given(productFacade.modifyOptionValue(eq(optionValueId), any(OptionValueModifyRequestDto.class))).willReturn(expectedResponseDto);
@@ -265,9 +273,9 @@ public class ApiV1OptionControllerTest {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(SuccessCode.OK.name()))
-                    .andExpect(jsonPath("$.data.id").value(optionValueId))
-                    .andExpect(jsonPath("$.data.optionGroupId").value(newOptionGroupId))
-                    .andExpect(jsonPath("$.data.value").value(newName));
+                    .andExpect(jsonPath("$.data.value.id").value(optionValueId))
+                    .andExpect(jsonPath("$.data.value.optionGroupId").value(newOptionGroupId))
+                    .andExpect(jsonPath("$.data.value.value").value(newName));
 
             verify(productFacade).modifyOptionValue(eq(optionValueId), any(OptionValueModifyRequestDto.class));
         }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -1,0 +1,76 @@
+package com.back.product.adapter.in;
+
+import com.back.product.app.ProductFacade;
+import com.back.product.app.usecase.OptionUseCase;
+import com.back.product.dto.OptionDto;
+import com.back.product.dto.response.OptionResponseDto;
+import com.back.security.jwt.JWTUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApiV1OptionController.class)
+@DisplayName("ApiV1OptionController 테스트")
+public class ApiV1OptionControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JWTUtil jwtUtil;
+
+    @MockitoBean
+    private OptionUseCase optionUseCase;
+
+    @MockitoBean
+    private ProductFacade productFacade;
+
+    @Nested
+    @DisplayName("GET /api/v1/products/options")
+    class GetOptionsTest {
+        @Test
+        @DisplayName("상품 옵션 목록 조회 컨트롤러 단위 테스트")
+        void getOptions_unit_test() throws Exception {
+            // given: 테스트 준비
+            OptionDto.GroupDto color = OptionDto.GroupDto.builder().id(1L).name("색상").build();
+            List<OptionDto.ValueDto> colorValues = List.of(
+                    OptionDto.ValueDto.builder().id(1L).name("빨강").build(),
+                    OptionDto.ValueDto.builder().id(2L).name("파랑").build()
+            );
+            OptionDto.GroupDto size = OptionDto.GroupDto.builder().id(2L).name("사이즈").build();
+            List<OptionDto.ValueDto> sizeValues = List.of(
+                    OptionDto.ValueDto.builder().id(1L).name("L").build(),
+                    OptionDto.ValueDto.builder().id(2L).name("M").build()
+            );
+            OptionResponseDto response = OptionResponseDto.builder()
+                    .options(List.of(
+                            OptionDto.builder().group(color).values(colorValues).build(),
+                            OptionDto.builder().group(size).values(sizeValues).build()
+                    ))
+                    .build();
+
+            given(optionUseCase.findAllOptions()).willReturn(response);
+
+            mockMvc.perform(
+                            get("/api/v1/products/options")
+                                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+
+            verify(productFacade).getOptions();
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -5,10 +5,14 @@ import com.back.product.app.ProductFacade;
 import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +34,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -45,8 +51,13 @@ public class ApiV1OptionControllerTest {
 
     @MockitoBean
     private ProductFacade productFacade;
+    
+    ObjectMapper objectMapper = new ObjectMapper();
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @BeforeEach
+    void setupObjectMapper() {
+        objectMapper.registerModule(new JavaTimeModule());
+    }
 
     @Nested
     @DisplayName("GET /api/v1/products/options")
@@ -267,7 +278,7 @@ public class ApiV1OptionControllerTest {
         }
 
         @Test
-        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 유효성 검사 실패 (유효하지 않은 패턴)")
+        @DisplayName("상품 옵션 값 추가 컨트롤러 단위 테스트 - 유효하지 않은 패턴)")
         void appendOptions_validationFailure_invalidPattern() throws Exception {
             // given
             Long optionGroupId = 1L;
@@ -283,6 +294,81 @@ public class ApiV1OptionControllerTest {
                     .andExpect(status().isBadRequest());
 
             verify(productFacade, never()).appendOptions(anyLong(), any(OptionAppendRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/products/options/groups/{optionGroupId}")
+    class ModifyOptionGroupTest {
+
+        @Test
+        @DisplayName("옵션 그룹 이름 수정 컨트롤러 단위 테스트 - 성공")
+        void modifyOptionGroup_success() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            String newGroupName = "newcolor";
+            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
+                    .name(newGroupName)
+                    .build();
+
+            OptionGroupModifyResponseDto expectedResponseDto = OptionGroupModifyResponseDto.builder()
+                    .id(optionGroupId)
+                    .name(newGroupName)
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            given(productFacade.modifyOptionGroup(eq(optionGroupId), any(OptionGroupModifyRequestDto.class))).willReturn(expectedResponseDto);
+
+            // when & then
+            mockMvc.perform(put("/api/v1/products/options/groups/{optionGroupId}", optionGroupId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessCode.OK.name()))
+                    .andExpect(jsonPath("$.message").value(SuccessCode.OK.getMessage()))
+                    .andExpect(jsonPath("$.data.id").value(optionGroupId))
+                    .andExpect(jsonPath("$.data.name").value(newGroupName));
+
+            verify(productFacade).modifyOptionGroup(eq(optionGroupId), any(OptionGroupModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("옵션 그룹 이름 수정 컨트롤러 단위 테스트 - 유효성 검사 실패 (공백 이름)")
+        void modifyOptionGroup_validationFailure_blankName() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
+                    .name("  ") // Blank name
+                    .build();
+
+            // when & then
+            mockMvc.perform(put("/api/v1/products/options/groups/{optionGroupId}", optionGroupId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).modifyOptionGroup(anyLong(), any(OptionGroupModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("옵션 그룹 이름 수정 컨트롤러 단위 테스트 - 유효성 검사 실패 (유효하지 않은 패턴)")
+        void modifyOptionGroup_validationFailure_invalidPattern() throws Exception {
+            // given
+            Long optionGroupId = 1L;
+            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
+                    .name("InvalidName123") // Invalid pattern (uppercase, numbers)
+                    .build();
+
+            // when & then
+            mockMvc.perform(put("/api/v1/products/options/groups/{optionGroupId}", optionGroupId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).modifyOptionGroup(anyLong(), any(OptionGroupModifyRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1OptionControllerTest.java
@@ -309,4 +309,41 @@ public class ApiV1OptionControllerTest {
                     .andExpect(jsonPath("$.message").value(FailureCode.OPTION_GROUP_IN_USE.getMessage()));
         }
     }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/products/options/values/{optionValueId}")
+    class DeleteOptionValueTest {
+
+        @Test
+        @DisplayName("옵션 값 삭제 컨트롤러 단위 테스트 - 성공")
+        void deleteOptionValue_success() throws Exception {
+            // given
+            Long optionValueId = 1L;
+            doNothing().when(productFacade).deleteOptionValue(anyLong());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/products/options/values/{optionValueId}", optionValueId))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            verify(productFacade).deleteOptionValue(eq(optionValueId));
+        }
+
+        @Test
+        @DisplayName("옵션 값 삭제 컨트롤러 단위 테스트 - 실패 (옵션 값 사용 중)")
+        void deleteValueGroup_fail_optionValueInUse() throws Exception {
+            // given
+            Long optionValueId = 1L;
+            doThrow(new CustomException(FailureCode.OPTION_VALUE_IN_USE))
+                    .when(productFacade)
+                    .deleteOptionValue(anyLong());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/products/options/values/{optionValueId}", optionValueId))
+                    .andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(FailureCode.OPTION_VALUE_IN_USE.name()))
+                    .andExpect(jsonPath("$.message").value(FailureCode.OPTION_VALUE_IN_USE.getMessage()));
+        }
+    }
 }

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -82,44 +82,44 @@ class ProductFacadeTest {
             // 2. 옵션이 사용 중이므로, 삭제 메서드는 호출되지 않았는지 검증
             verify(optionUseCase, never()).deleteOptions(anyLong());
         }
+    }
+    
+    @Nested
+    @DisplayName("deleteOptionValue 메서드")
+    class DeleteOptionValueTest {
 
-        @Nested
-        @DisplayName("deleteOptionValue 메서드")
-        class DeleteOptionValueTest {
+        @Test
+        @DisplayName("성공: 옵션 값이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
+        void deleteOptionValue_success_whenNotInUse() {
+            // given
+            Long optionValueId = 1L;
+            given(productUseCase.isOptionValueInUse(anyLong())).willReturn(false);
 
-            @Test
-            @DisplayName("성공: 옵션 값이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
-            void deleteOptionValue_success_whenNotInUse() {
-                // given
-                Long optionValueId = 1L;
-                given(productUseCase.isOptionValueInUse(anyLong())).willReturn(false);
+            // when & then
+            assertDoesNotThrow(() -> productFacade.deleteOptionValue(optionValueId));
 
-                // when & then
-                assertDoesNotThrow(() -> productFacade.deleteOptionValue(optionValueId));
+            // verify
+            verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
+            verify(optionUseCase, times(1)).deleteOption(eq(optionValueId));
+        }
 
-                // verify
-                verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
-                verify(optionUseCase, times(1)).deleteOption(eq(optionValueId));
-            }
+        @Test
+        @DisplayName("실패: 옵션 값이 사용 중일 때, CustomException을 발생시킨다")
+        void deleteOptionValue_fail_whenInUse() {
+            // given
+            Long optionValueId = 1L;
+            given(productUseCase.isOptionValueInUse(anyLong())).willReturn(true);
 
-            @Test
-            @DisplayName("실패: 옵션 값이 사용 중일 때, CustomException을 발생시킨다")
-            void deleteOptionValue_fail_whenInUse() {
-                // given
-                Long optionValueId = 1L;
-                given(productUseCase.isOptionValueInUse(anyLong())).willReturn(true);
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productFacade.deleteOptionValue(optionValueId)
+            );
 
-                // when & then
-                CustomException exception = assertThrows(CustomException.class, () ->
-                        productFacade.deleteOptionValue(optionValueId)
-                );
+            assertEquals(FailureCode.OPTION_VALUE_IN_USE, exception.getFailureCode());
 
-                assertEquals(FailureCode.OPTION_VALUE_IN_USE, exception.getFailureCode());
-
-                // verify
-                verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
-                verify(optionUseCase, never()).deleteOption(anyLong());
-            }
+            // verify
+            verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
+            verify(optionUseCase, never()).deleteOption(anyLong());
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -31,8 +31,6 @@ class ProductFacadeTest {
     @Mock
     private OptionUseCase optionUseCase;
 
-    // 다른 UseCase Mock들은 이 테스트에 필요하지 않으므로 생략합니다.
-
     @Nested
     @DisplayName("deleteOptionGroup 메서드")
     class DeleteOptionGroupTest {
@@ -83,6 +81,45 @@ class ProductFacadeTest {
             verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
             // 2. 옵션이 사용 중이므로, 삭제 메서드는 호출되지 않았는지 검증
             verify(optionUseCase, never()).deleteOptions(anyLong());
+        }
+
+        @Nested
+        @DisplayName("deleteOptionValue 메서드")
+        class DeleteOptionValueTest {
+
+            @Test
+            @DisplayName("성공: 옵션 값이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
+            void deleteOptionValue_success_whenNotInUse() {
+                // given
+                Long optionValueId = 1L;
+                given(productUseCase.isOptionValueInUse(anyLong())).willReturn(false);
+
+                // when & then
+                assertDoesNotThrow(() -> productFacade.deleteOptionValue(optionValueId));
+
+                // verify
+                verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
+                verify(optionUseCase, times(1)).deleteOption(eq(optionValueId));
+            }
+
+            @Test
+            @DisplayName("실패: 옵션 값이 사용 중일 때, CustomException을 발생시킨다")
+            void deleteOptionValue_fail_whenInUse() {
+                // given
+                Long optionValueId = 1L;
+                given(productUseCase.isOptionValueInUse(anyLong())).willReturn(true);
+
+                // when & then
+                CustomException exception = assertThrows(CustomException.class, () ->
+                        productFacade.deleteOptionValue(optionValueId)
+                );
+
+                assertEquals(FailureCode.OPTION_VALUE_IN_USE, exception.getFailureCode());
+
+                // verify
+                verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
+                verify(optionUseCase, never()).deleteOption(anyLong());
+            }
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -1,0 +1,88 @@
+package com.back.product.app;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.app.usecase.OptionUseCase;
+import com.back.product.app.usecase.ProductUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductFacade 단위 테스트")
+class ProductFacadeTest {
+
+    @InjectMocks
+    private ProductFacade productFacade;
+
+    @Mock
+    private ProductUseCase productUseCase;
+
+    @Mock
+    private OptionUseCase optionUseCase;
+
+    // 다른 UseCase Mock들은 이 테스트에 필요하지 않으므로 생략합니다.
+
+    @Nested
+    @DisplayName("deleteOptionGroup 메서드")
+    class DeleteOptionGroupTest {
+
+        @Test
+        @DisplayName("성공: 옵션 그룹이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
+        void deleteOptionGroup_success_whenNotInUse() {
+            // given
+            Long optionGroupId = 1L;
+
+            // 1. productUseCase가 "사용 중이 아님(false)"을 반환하도록 설정
+            given(productUseCase.isOptionGroupInUse(anyLong())).willReturn(false);
+
+            // 2. optionUseCase.deleteOptions는 void를 반환하므로, 호출되었는지만 검증하면 됨
+            // doNothing().when(optionUseCase).deleteOptions(anyLong()); // 이 코드는 선택 사항
+
+            // when & then
+            // 예외가 발생하지 않는 것을 검증
+            assertDoesNotThrow(() -> productFacade.deleteOptionGroup(optionGroupId));
+
+            // verify
+            // 1. 사용 여부 확인 메서드가 호출되었는지 검증
+            verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
+            // 2. 삭제 메서드가 호출되었는지 검증
+            verify(optionUseCase, times(1)).deleteOptions(eq(optionGroupId));
+        }
+
+        @Test
+        @DisplayName("실패: 옵션 그룹이 사용 중일 때, CustomException을 발생시킨다")
+        void deleteOptionGroup_fail_whenInUse() {
+            // given
+            Long optionGroupId = 1L;
+
+            // 1. productUseCase가 "사용 중(true)"임을 반환하도록 설정
+            given(productUseCase.isOptionGroupInUse(anyLong())).willReturn(true);
+
+            // when & then
+            // 2. CustomException이 발생하는지 검증
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productFacade.deleteOptionGroup(optionGroupId)
+            );
+
+            // 3. 발생한 예외의 코드가 올바른지 확인
+            assertEquals(FailureCode.OPTION_GROUP_IN_USE, exception.getFailureCode());
+
+            // verify
+            // 1. 사용 여부 확인 메서드는 호출되었는지 검증
+            verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
+            // 2. 옵션이 사용 중이므로, 삭제 메서드는 호출되지 않았는지 검증
+            verify(optionUseCase, never()).deleteOptions(anyLong());
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -530,9 +530,9 @@ class OptionUseCaseTest {
 
             // Assert the response DTO
             assertThat(result).isNotNull();
-            assertThat(result.id()).isEqualTo(optionGroupId);
-            assertThat(result.name()).isEqualTo(newName);
-            assertThat(result.updatedAt()).isNotNull();
+            assertThat(result.group().id()).isEqualTo(optionGroupId);
+            assertThat(result.group().name()).isEqualTo(newName);
+            assertThat(result.group().updatedAt()).isNotNull();
         }
 
         @Test
@@ -603,9 +603,9 @@ class OptionUseCaseTest {
 
             // 응답 DTO 검증
             assertThat(result).isNotNull();
-            assertThat(result.id()).isEqualTo(optionValueId);
-            assertThat(result.value()).isEqualTo(newName);
-            assertThat(result.optionGroupId()).isEqualTo(currentGroupId);
+            assertThat(result.value().id()).isEqualTo(optionValueId);
+            assertThat(result.value().value()).isEqualTo(newName);
+            assertThat(result.value().optionGroupId()).isEqualTo(currentGroupId);
         }
 
         @Test
@@ -649,9 +649,9 @@ class OptionUseCaseTest {
             verify(productSupport, times(1)).getOptionGroupById(newGroupId); // 새 그룹을 조회했는지 검증
 
             assertThat(result).isNotNull();
-            assertThat(result.id()).isEqualTo(optionValueId);
-            assertThat(result.value()).isEqualTo(currentName);
-            assertThat(result.optionGroupId()).isEqualTo(newGroupId); // 그룹 ID가 변경되었는지 확인
+            assertThat(result.value().id()).isEqualTo(optionValueId);
+            assertThat(result.value().value()).isEqualTo(currentName);
+            assertThat(result.value().optionGroupId()).isEqualTo(newGroupId); // 그룹 ID가 변경되었는지 확인
         }
 
         @Test

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -9,6 +9,8 @@ import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
+import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.mapper.OptionMapper;
@@ -20,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OptionUseCase 단위 테스트")
@@ -489,6 +490,67 @@ class OptionUseCaseTest {
 
             // verify that no save operation was attempted
             verify(optionValueRepository, never()).saveAll(any(List.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyOptionGroup 메서드")
+    class ModifyOptionGroupTest {
+
+        @Test
+        @DisplayName("성공: 옵션 그룹의 이름을 성공적으로 변경한다")
+        void modifyOptionGroup_success() {
+            // given
+            Long optionGroupId = 1L;
+            String newName = "newcolor";
+            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
+                    .name(newName)
+                    .build();
+
+            // Use a real object for the entity to test the actual state change
+            // but since it's a unit test, we can mock it as well to verify interactions.
+            OptionGroup existingGroup = mock(OptionGroup.class);
+
+            given(productSupport.getOptionGroupById(optionGroupId)).willReturn(Optional.of(existingGroup));
+
+            // Stubbing the getters that will be used in convertToModifyGroupDto
+            given(existingGroup.getId()).willReturn(optionGroupId);
+            given(existingGroup.getName()).willReturn(newName); // Assume name is updated
+            given(existingGroup.getLastModifiedAt()).willReturn(LocalDateTime.now());
+
+
+            // when
+            OptionGroupModifyResponseDto result = optionUseCase.modifyOptionGroup(optionGroupId, requestDto);
+
+            // then
+            // Verify that the entity's state-changing method was called
+            verify(existingGroup, times(1)).modifyName(newName);
+
+            // Assert the response DTO
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(optionGroupId);
+            assertThat(result.name()).isEqualTo(newName);
+            assertThat(result.updatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("실패: 옵션 그룹이 존재하지 않으면 CustomException을 발생시킨다")
+        void modifyOptionGroup_fail_groupNotFound() {
+            // given
+            Long nonExistentGroupId = 99L;
+            String newName = "newcolor";
+            OptionGroupModifyRequestDto requestDto = OptionGroupModifyRequestDto.builder()
+                    .name(newName)
+                    .build();
+
+            given(productSupport.getOptionGroupById(nonExistentGroupId)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    optionUseCase.modifyOptionGroup(nonExistentGroupId, requestDto)
+            );
+
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_GROUP_NOT_FOUND);
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -10,9 +10,11 @@ import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.request.OptionGroupModifyRequestDto;
+import com.back.product.dto.request.OptionValueModifyRequestDto;
 import com.back.product.dto.response.OptionGroupModifyResponseDto;
 import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.dto.response.OptionValueModifyResponseDto;
 import com.back.product.mapper.OptionMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -551,6 +553,153 @@ class OptionUseCaseTest {
             );
 
             assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_GROUP_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyOptionValue 메서드")
+    class ModifyOptionValueTest {
+
+        @Test
+        @DisplayName("성공: 옵션 값의 이름만 변경한다")
+        void modifyOptionValue_success_onlyName() {
+            // given
+            Long optionValueId = 1L;
+            Long currentGroupId = 10L;
+            String newName = "newvalue";
+
+            // DTO에는 현재 그룹 ID와 새 이름이 포함됨
+            OptionValueModifyRequestDto requestDto = OptionValueModifyRequestDto.builder()
+                    .optionGroupId(currentGroupId)
+                    .name(newName)
+                    .build();
+
+            OptionGroup currentGroup = OptionGroup.builder()
+                    .id(currentGroupId)
+                    .name("color")
+                    .build();
+            OptionValue existingValue = mock(OptionValue.class);
+
+            given(productSupport.getOptionValueById(optionValueId)).willReturn(Optional.of(existingValue));
+            // willChangeGroup이 false를 반환하도록 설정 (그룹 변경 없음)
+            given(existingValue.willChangeGroup(currentGroupId)).willReturn(false);
+
+            // DTO 변환을 위한 getter 스터빙
+            given(existingValue.getId()).willReturn(optionValueId);
+            given(existingValue.getValue()).willReturn(newName);
+            given(existingValue.getOptionGroup()).willReturn(currentGroup);
+            given(existingValue.getLastModifiedAt()).willReturn(LocalDateTime.now());
+
+            // when
+            OptionValueModifyResponseDto result = optionUseCase.modifyOptionValue(optionValueId, requestDto);
+
+            // then
+            // 이름 변경 메서드만 호출되었는지 검증
+            verify(existingValue, times(1)).modifyName(newName);
+            // 그룹 변경 메서드는 호출되지 않았는지 검증
+            verify(existingValue, never()).changeGroup(any(OptionGroup.class));
+            // productSupport에서 다른 그룹을 찾는 로직이 호출되지 않았는지 검증
+            verify(productSupport, never()).getOptionGroupById(anyLong());
+
+            // 응답 DTO 검증
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(optionValueId);
+            assertThat(result.value()).isEqualTo(newName);
+            assertThat(result.optionGroupId()).isEqualTo(currentGroupId);
+        }
+
+        @Test
+        @DisplayName("성공: 옵션 값의 그룹만 변경한다")
+        void modifyOptionValue_success_onlyGroup() {
+            // given
+            Long optionValueId = 1L;
+            Long currentGroupId = 10L;
+            Long newGroupId = 20L;
+            String currentName = "currentvalue";
+
+            OptionValueModifyRequestDto requestDto = OptionValueModifyRequestDto.builder()
+                    .optionGroupId(newGroupId)
+                    .name(currentName)
+                    .build();
+
+            OptionGroup newGroup = OptionGroup.builder()
+                    .id(newGroupId)
+                    .name("size")
+                    .build();
+            OptionValue existingValue = mock(OptionValue.class);
+
+            given(productSupport.getOptionValueById(optionValueId)).willReturn(Optional.of(existingValue));
+            // willChangeGroup이 true를 반환하도록 설정 (그룹 변경 필요)
+            given(existingValue.willChangeGroup(newGroupId)).willReturn(true);
+            // 새로운 그룹을 조회하는 로직 모킹
+            given(productSupport.getOptionGroupById(newGroupId)).willReturn(Optional.of(newGroup));
+
+            // DTO 변환을 위한 getter 스터빙
+            given(existingValue.getId()).willReturn(optionValueId);
+            given(existingValue.getValue()).willReturn(currentName);
+            given(existingValue.getOptionGroup()).willReturn(newGroup); // 변경된 그룹을 반환하도록 설정
+            given(existingValue.getLastModifiedAt()).willReturn(LocalDateTime.now());
+
+            // when
+            OptionValueModifyResponseDto result = optionUseCase.modifyOptionValue(optionValueId, requestDto);
+
+            // then
+            verify(existingValue, times(1)).modifyName(currentName);
+            verify(existingValue, times(1)).changeGroup(newGroup); // 새 그룹으로 변경되었는지 검증
+            verify(productSupport, times(1)).getOptionGroupById(newGroupId); // 새 그룹을 조회했는지 검증
+
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(optionValueId);
+            assertThat(result.value()).isEqualTo(currentName);
+            assertThat(result.optionGroupId()).isEqualTo(newGroupId); // 그룹 ID가 변경되었는지 확인
+        }
+
+        @Test
+        @DisplayName("실패: 수정할 옵션 값을 찾지 못하면 예외를 발생시킨다")
+        void modifyOptionValue_fail_valueNotFound() {
+            // given
+            Long nonExistentValueId = 99L;
+            OptionValueModifyRequestDto requestDto = OptionValueModifyRequestDto.builder()
+                    .optionGroupId(1L)
+                    .name("anyname")
+                    .build();
+
+            given(productSupport.getOptionValueById(nonExistentValueId)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    optionUseCase.modifyOptionValue(nonExistentValueId, requestDto)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_VALUE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 이동할 새로운 옵션 그룹을 찾지 못하면 예외를 발생시킨다")
+        void modifyOptionValue_fail_newGroupNotFound() {
+            // given
+            Long optionValueId = 1L;
+            Long nonExistentGroupId = 99L;
+
+            OptionValueModifyRequestDto requestDto = OptionValueModifyRequestDto.builder()
+                    .optionGroupId(nonExistentGroupId)
+                    .name("anyname")
+                    .build();
+
+            OptionValue existingValue = mock(OptionValue.class);
+
+            given(productSupport.getOptionValueById(optionValueId)).willReturn(Optional.of(existingValue));
+            given(existingValue.willChangeGroup(nonExistentGroupId)).willReturn(true);
+            // 새로운 그룹 조회 시 empty 반환
+            given(productSupport.getOptionGroupById(nonExistentGroupId)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    optionUseCase.modifyOptionValue(optionValueId, requestDto)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_GROUP_NOT_FOUND);
+
+            // 그룹 변경 메서드가 호출되지 않았는지 검증
+            verify(existingValue, never()).changeGroup(any(OptionGroup.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -2,9 +2,12 @@ package com.back.product.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
+import com.back.product.adapter.out.OptionGroupRepository;
+import com.back.product.adapter.out.OptionValueRepository;
 import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
+import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.mapper.OptionMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -18,12 +21,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OptionUseCase 단위 테스트")
@@ -37,6 +44,12 @@ class OptionUseCaseTest {
 
     @Mock
     private OptionMapper optionMapper;
+
+    @Mock
+    private OptionGroupRepository optionGroupRepository;
+
+    @Mock
+    private OptionValueRepository optionValueRepository;
 
     @Nested
     @DisplayName("findOptionValuesAsMap 메서드")
@@ -164,6 +177,226 @@ class OptionUseCaseTest {
             assertThat(result.options()).hasSize(1);
             assertThat(result.options().get(0).group().name()).isEqualTo("Color");
             assertThat(result.options().get(0).values()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("createOptions 메서드")
+    class CreateOptionsTest {
+
+        @Test
+        @DisplayName("성공: 새로운 옵션 그룹과 값들을 생성한다")
+        void createOptions_success_newGroupAndValues() {
+            // given
+            // 1. 요청 DTO 생성
+            OptionCreateRequestDto.OptionDto requestOption1 = new OptionCreateRequestDto.OptionDto("color", List.of("red", "blue"));
+            OptionCreateRequestDto.OptionDto requestOption2 = new OptionCreateRequestDto.OptionDto("size", List.of("small", "large"));
+            OptionCreateRequestDto requestDto = new OptionCreateRequestDto(List.of(requestOption1, requestOption2));
+
+            // 2. Mocking ProductSupport for group lookup (returns null for new groups)
+            given(productSupport.getOptionGroupByName(eq("color"))).willReturn(null);
+            given(productSupport.getOptionGroupByName(eq("size"))).willReturn(null);
+
+            // 3. Mocking OptionMapper for group and value entity conversion
+            OptionGroup newGroup1 = OptionGroup.builder().id(1L).name("color").build();
+            OptionGroup newGroup2 = OptionGroup.builder().id(2L).name("size").build();
+            given(optionMapper.toGroupEntity(eq("color"))).willReturn(newGroup1);
+            given(optionMapper.toGroupEntity(eq("size"))).willReturn(newGroup2);
+
+            OptionValue newValue1_1 = OptionValue.builder().id(101L).optionGroup(newGroup1).value("red").build();
+            OptionValue newValue1_2 = OptionValue.builder().id(102L).optionGroup(newGroup1).value("blue").build();
+            OptionValue newValue2_1 = OptionValue.builder().id(201L).optionGroup(newGroup2).value("small").build();
+            OptionValue newValue2_2 = OptionValue.builder().id(202L).optionGroup(newGroup2).value("large").build();
+
+            given(optionMapper.toValueEntity(eq(newGroup1), eq("red"))).willReturn(newValue1_1);
+            given(optionMapper.toValueEntity(eq(newGroup1), eq("blue"))).willReturn(newValue1_2);
+            given(optionMapper.toValueEntity(eq(newGroup2), eq("small"))).willReturn(newValue2_1);
+            given(optionMapper.toValueEntity(eq(newGroup2), eq("large"))).willReturn(newValue2_2);
+
+            // 4. Mocking OptionGroupRepository save
+            given(optionGroupRepository.save(eq(newGroup1))).willReturn(newGroup1);
+            given(optionGroupRepository.save(eq(newGroup2))).willReturn(newGroup2);
+
+            // 5. Mocking OptionValueRepository saveAll
+            given(optionValueRepository.saveAll(any(List.class))).willAnswer(invocation -> {
+                List<OptionValue> values = invocation.getArgument(0);
+                // Assign IDs or perform other mock operations if needed
+                return values;
+            });
+
+            // 6. Mocking OptionMapper toDto for final response conversion
+            OptionDto.GroupDto responseGroup1 = OptionDto.GroupDto.builder().id(1L).name("color").build();
+            List<OptionDto.ValueDto> responseValues1 = List.of(
+                    OptionDto.ValueDto.builder().id(101L).name("red").build(),
+                    OptionDto.ValueDto.builder().id(102L).name("blue").build()
+            );
+            OptionDto responseOptionDto1 = OptionDto.builder().group(responseGroup1).values(responseValues1).build();
+
+            OptionDto.GroupDto responseGroup2 = OptionDto.GroupDto.builder().id(2L).name("size").build();
+            List<OptionDto.ValueDto> responseValues2 = List.of(
+                    OptionDto.ValueDto.builder().id(201L).name("small").build(),
+                    OptionDto.ValueDto.builder().id(202L).name("large").build()
+            );
+            OptionDto responseOptionDto2 = OptionDto.builder().group(responseGroup2).values(responseValues2).build();
+
+            given(optionMapper.toDto(eq(newGroup1), any(List.class))).willReturn(responseOptionDto1);
+            given(optionMapper.toDto(eq(newGroup2), any(List.class))).willReturn(responseOptionDto2);
+
+
+            // when
+            OptionResponseDto result = optionUseCase.createOptions(requestDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.options()).hasSize(2);
+            assertThat(result.options().get(0).group().name()).isEqualTo("color");
+            assertThat(result.options().get(0).values()).hasSize(2);
+            assertThat(result.options().get(1).group().name()).isEqualTo("size");
+            assertThat(result.options().get(1).values()).hasSize(2);
+
+            // Verify interactions
+            verify(productSupport, times(1)).getOptionGroupByName(eq("color"));
+            verify(productSupport, times(1)).getOptionGroupByName(eq("size"));
+            verify(optionMapper, times(1)).toGroupEntity(eq("color"));
+            verify(optionMapper, times(1)).toGroupEntity(eq("size"));
+            verify(optionGroupRepository, times(1)).save(eq(newGroup1));
+            verify(optionGroupRepository, times(1)).save(eq(newGroup2));
+            verify(optionValueRepository, times(2)).saveAll(any(List.class)); // saveAll is called twice, once for each option
+            verify(optionMapper, times(1)).toDto(eq(newGroup1), any(List.class));
+            verify(optionMapper, times(1)).toDto(eq(newGroup2), any(List.class));
+        }
+
+        @Test
+        @DisplayName("성공: 기존 옵션 그룹을 사용하고 새로운 값들을 생성한다")
+        void createOptions_success_existingGroupAndNewValues() {
+            // given
+            // 1. 요청 DTO 생성
+            OptionCreateRequestDto.OptionDto requestOption1 = new OptionCreateRequestDto.OptionDto("color", List.of("red", "blue"));
+            OptionCreateRequestDto requestDto = new OptionCreateRequestDto(List.of(requestOption1));
+
+            // 2. Mocking ProductSupport for group lookup (returns existing group)
+            OptionGroup existingGroup1 = OptionGroup.builder().id(1L).name("color").build();
+            given(productSupport.getOptionGroupByName(eq("color"))).willReturn(existingGroup1);
+
+            // 3. Mocking OptionMapper for value entity conversion
+            OptionValue newValue1_1 = OptionValue.builder().id(101L).optionGroup(existingGroup1).value("red").build();
+            OptionValue newValue1_2 = OptionValue.builder().id(102L).optionGroup(existingGroup1).value("blue").build();
+
+            given(optionMapper.toValueEntity(eq(existingGroup1), eq("red"))).willReturn(newValue1_1);
+            given(optionMapper.toValueEntity(eq(existingGroup1), eq("blue"))).willReturn(newValue1_2);
+
+            // 4. OptionGroupRepository save should not be called
+            verify(optionGroupRepository, never()).save(any(OptionGroup.class));
+
+            // 5. Mocking OptionValueRepository saveAll
+            given(optionValueRepository.saveAll(any(List.class))).willAnswer(invocation -> {
+                List<OptionValue> values = invocation.getArgument(0);
+                return values;
+            });
+
+            // 6. Mocking OptionMapper toDto for final response conversion
+            OptionDto.GroupDto responseGroup1 = OptionDto.GroupDto.builder().id(1L).name("color").build();
+            List<OptionDto.ValueDto> responseValues1 = List.of(
+                    OptionDto.ValueDto.builder().id(101L).name("red").build(),
+                    OptionDto.ValueDto.builder().id(102L).name("blue").build()
+            );
+            OptionDto responseOptionDto1 = OptionDto.builder().group(responseGroup1).values(responseValues1).build();
+
+            given(optionMapper.toDto(eq(existingGroup1), any(List.class))).willReturn(responseOptionDto1);
+
+            // when
+            OptionResponseDto result = optionUseCase.createOptions(requestDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.options()).hasSize(1);
+            assertThat(result.options().get(0).group().name()).isEqualTo("color");
+            assertThat(result.options().get(0).values()).hasSize(2);
+
+            // Verify interactions
+            verify(productSupport, times(1)).getOptionGroupByName(eq("color"));
+            verify(optionMapper, never()).toGroupEntity(any(String.class)); // Not called for existing group
+            verify(optionGroupRepository, never()).save(any(OptionGroup.class)); // Not called for existing group
+            verify(optionValueRepository, times(1)).saveAll(any(List.class));
+            verify(optionMapper, times(1)).toDto(eq(existingGroup1), any(List.class));
+        }
+
+        @Test
+        @DisplayName("성공: 기존 그룹과 새로운 그룹이 혼합된 경우에도 정상적으로 생성한다")
+        void createOptions_success_mixedGroupsAndValues() {
+            // given
+            // 1. 요청 DTO 생성
+            OptionCreateRequestDto.OptionDto requestOption1 = new OptionCreateRequestDto.OptionDto("color", List.of("red", "blue")); // Existing group
+            OptionCreateRequestDto.OptionDto requestOption2 = new OptionCreateRequestDto.OptionDto("pattern", List.of("stripe", "dot")); // New group
+            OptionCreateRequestDto requestDto = new OptionCreateRequestDto(List.of(requestOption1, requestOption2));
+
+            // 2. Mocking ProductSupport for group lookup
+            OptionGroup existingGroup1 = OptionGroup.builder().id(1L).name("color").build();
+            given(productSupport.getOptionGroupByName(eq("color"))).willReturn(existingGroup1); // Existing
+            given(productSupport.getOptionGroupByName(eq("pattern"))).willReturn(null); // New
+
+            // 3. Mocking OptionMapper for group and value entity conversion
+            OptionGroup newGroup2 = OptionGroup.builder().id(2L).name("pattern").build();
+            given(optionMapper.toGroupEntity(eq("pattern"))).willReturn(newGroup2); // Only for new group
+
+            OptionValue newValue1_1 = OptionValue.builder().id(101L).optionGroup(existingGroup1).value("red").build();
+            OptionValue newValue1_2 = OptionValue.builder().id(102L).optionGroup(existingGroup1).value("blue").build();
+            OptionValue newValue2_1 = OptionValue.builder().id(201L).optionGroup(newGroup2).value("stripe").build();
+            OptionValue newValue2_2 = OptionValue.builder().id(202L).optionGroup(newGroup2).value("dot").build();
+
+            given(optionMapper.toValueEntity(eq(existingGroup1), eq("red"))).willReturn(newValue1_1);
+            given(optionMapper.toValueEntity(eq(existingGroup1), eq("blue"))).willReturn(newValue1_2);
+            given(optionMapper.toValueEntity(eq(newGroup2), eq("stripe"))).willReturn(newValue2_1);
+            given(optionMapper.toValueEntity(eq(newGroup2), eq("dot"))).willReturn(newValue2_2);
+
+            // 4. Mocking OptionGroupRepository save
+            given(optionGroupRepository.save(eq(newGroup2))).willReturn(newGroup2); // Only for new group
+
+            // 5. Mocking OptionValueRepository saveAll
+            given(optionValueRepository.saveAll(any(List.class))).willAnswer(invocation -> {
+                List<OptionValue> values = invocation.getArgument(0);
+                return values;
+            });
+
+            // 6. Mocking OptionMapper toDto for final response conversion
+            OptionDto.GroupDto responseGroup1 = OptionDto.GroupDto.builder().id(1L).name("color").build();
+            List<OptionDto.ValueDto> responseValues1 = List.of(
+                    OptionDto.ValueDto.builder().id(101L).name("red").build(),
+                    OptionDto.ValueDto.builder().id(102L).name("blue").build()
+            );
+            OptionDto responseOptionDto1 = OptionDto.builder().group(responseGroup1).values(responseValues1).build();
+
+            OptionDto.GroupDto responseGroup2 = OptionDto.GroupDto.builder().id(2L).name("pattern").build();
+            List<OptionDto.ValueDto> responseValues2 = List.of(
+                    OptionDto.ValueDto.builder().id(201L).name("stripe").build(),
+                    OptionDto.ValueDto.builder().id(202L).name("dot").build()
+            );
+            OptionDto responseOptionDto2 = OptionDto.builder().group(responseGroup2).values(responseValues2).build();
+
+            given(optionMapper.toDto(eq(existingGroup1), any(List.class))).willReturn(responseOptionDto1);
+            given(optionMapper.toDto(eq(newGroup2), any(List.class))).willReturn(responseOptionDto2);
+
+            // when
+            OptionResponseDto result = optionUseCase.createOptions(requestDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.options()).hasSize(2);
+            assertThat(result.options().get(0).group().name()).isEqualTo("color");
+            assertThat(result.options().get(0).values()).hasSize(2);
+            assertThat(result.options().get(1).group().name()).isEqualTo("pattern");
+            assertThat(result.options().get(1).values()).hasSize(2);
+
+            // Verify interactions
+            verify(productSupport, times(1)).getOptionGroupByName(eq("color"));
+            verify(productSupport, times(1)).getOptionGroupByName(eq("pattern"));
+            verify(optionMapper, never()).toGroupEntity(eq("color")); // Not called for existing group
+            verify(optionMapper, times(1)).toGroupEntity(eq("pattern")); // Called for new group
+            verify(optionGroupRepository, never()).save(eq(existingGroup1)); // Not called for existing group
+            verify(optionGroupRepository, times(1)).save(eq(newGroup2)); // Called for new group
+            verify(optionValueRepository, times(2)).saveAll(any(List.class));
+            verify(optionMapper, times(1)).toDto(eq(existingGroup1), any(List.class));
+            verify(optionMapper, times(1)).toDto(eq(newGroup2), any(List.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -7,8 +7,10 @@ import com.back.product.adapter.out.OptionValueRepository;
 import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
+import com.back.product.dto.request.OptionAppendRequestDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
 import com.back.product.dto.response.OptionListResponseDto;
+import com.back.product.dto.response.OptionResponseDto;
 import com.back.product.mapper.OptionMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -396,6 +399,96 @@ class OptionUseCaseTest {
             verify(optionValueRepository, times(2)).saveAll(any(List.class));
             verify(optionMapper, times(1)).toDto(eq(existingGroup1), any(List.class));
             verify(optionMapper, times(1)).toDto(eq(newGroup2), any(List.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("appendOptions 메서드")
+    class AppendOptionsTest {
+
+        @Test
+        @DisplayName("성공: 기존 옵션 그룹에 새로운 값들을 추가한다")
+        void appendOptions_success() {
+            // given
+            Long optionGroupId = 1L;
+            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
+                    .values(List.of("새로운값1", "새로운값2"))
+                    .build();
+
+            OptionGroup existingGroup = OptionGroup.builder()
+                    .id(optionGroupId)
+                    .name("색상")
+                    .build();
+
+            // Mocking for dependencies
+            given(productSupport.getOptionGroupById(optionGroupId)).willReturn(Optional.of(existingGroup));
+
+            OptionValue newValue1 = OptionValue.builder()
+                    .id(101L)
+                    .optionGroup(existingGroup)
+                    .value("새로운값1")
+                    .build();
+            OptionValue newValue2 = OptionValue.builder()
+                    .id(102L)
+                    .optionGroup(existingGroup)
+                    .value("새로운값2")
+                    .build();
+            List<OptionValue> createdValues = List.of(newValue1, newValue2);
+
+            given(optionMapper.toValueEntity(existingGroup, "새로운값1")).willReturn(newValue1);
+            given(optionMapper.toValueEntity(existingGroup, "새로운값2")).willReturn(newValue2);
+            given(optionValueRepository.saveAll(any(List.class))).willReturn(createdValues);
+
+            OptionDto.GroupDto responseGroupDto = OptionDto.GroupDto.builder()
+                    .id(optionGroupId)
+                    .name("색상")
+                    .build();
+            List<OptionDto.ValueDto> responseValueDtos = List.of(
+                    OptionDto.ValueDto.builder().id(101L).name("새로운값1").build(),
+                    OptionDto.ValueDto.builder().id(102L).name("새로운값2").build()
+            );
+            OptionDto finalOptionDto = OptionDto.builder()
+                    .group(responseGroupDto)
+                    .values(responseValueDtos)
+                    .build();
+
+            given(optionMapper.toDto(existingGroup, createdValues)).willReturn(finalOptionDto);
+
+            // when
+            OptionResponseDto result = optionUseCase.appendOptions(optionGroupId, requestDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.option().group().name()).isEqualTo("색상");
+            assertThat(result.option().values()).hasSize(2);
+            assertThat(result.option().values().get(0).name()).isEqualTo("새로운값1");
+
+            // verify interactions
+            verify(productSupport, times(1)).getOptionGroupById(optionGroupId);
+            verify(optionValueRepository, times(1)).saveAll(any(List.class));
+            verify(optionMapper, times(1)).toDto(any(OptionGroup.class), any(List.class));
+        }
+
+        @Test
+        @DisplayName("실패: 옵션 그룹이 존재하지 않으면 CustomException을 발생시킨다")
+        void appendOptions_fail_groupNotFound() {
+            // given
+            Long nonExistentGroupId = 99L;
+            OptionAppendRequestDto requestDto = OptionAppendRequestDto.builder()
+                    .values(List.of("새로운값"))
+                    .build();
+
+            given(productSupport.getOptionGroupById(nonExistentGroupId)).willReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    optionUseCase.appendOptions(nonExistentGroupId, requestDto)
+            );
+
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_GROUP_NOT_FOUND);
+
+            // verify that no save operation was attempted
+            verify(optionValueRepository, never()).saveAll(any(List.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -2,7 +2,11 @@ package com.back.product.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
+import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
+import com.back.product.dto.OptionDto;
+import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.mapper.OptionMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,12 +15,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OptionUseCase 단위 테스트")
@@ -27,6 +34,9 @@ class OptionUseCaseTest {
 
     @Mock
     private ProductSupport productSupport;
+
+    @Mock
+    private OptionMapper optionMapper;
 
     @Nested
     @DisplayName("findOptionValuesAsMap 메서드")
@@ -68,6 +78,92 @@ class OptionUseCaseTest {
                     optionUseCase.findOptionValuesAsMap(ids)
             );
             assertThat(exception.getFailureCode()).isEqualTo(FailureCode.OPTION_VALUE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllOptions 메서드")
+    class FindAllOptionsTest {
+
+        @Test
+        @DisplayName("성공: 모든 옵션 그룹과 값을 조회하여 DTO로 반환한다")
+        void findAllOptions_Success_WithOptionGroupsAndValues() {
+            // given
+            OptionGroup group1 = OptionGroup.builder().id(1L).name("Color").build();
+            OptionGroup group2 = OptionGroup.builder().id(2L).name("Size").build();
+            List<OptionGroup> optionGroups = List.of(group1, group2);
+
+            OptionValue value1 = OptionValue.builder().id(10L).value("Red").optionGroup(group1).build();
+            OptionValue value2 = OptionValue.builder().id(11L).value("Blue").optionGroup(group1).build();
+            OptionValue value3 = OptionValue.builder().id(20L).value("Small").optionGroup(group2).build();
+            List<OptionValue> optionValues = List.of(value1, value2, value3);
+
+            given(productSupport.getAllProductOptionGroups()).willReturn(optionGroups);
+            given(productSupport.getAllProductOptionValuesByOptionGroupIn(any(List.class))).willReturn(optionValues);
+
+            // Mock OptionMapper behavior
+            OptionDto.GroupDto groupDto1 = OptionDto.GroupDto.builder().id(1L).name("Color").build();
+            OptionDto.ValueDto valueDto1 = OptionDto.ValueDto.builder().id(10L).name("Red").build();
+            OptionDto.ValueDto valueDto2 = OptionDto.ValueDto.builder().id(11L).name("Blue").build();
+            OptionDto optionDto1 = OptionDto.builder().group(groupDto1).values(List.of(valueDto1, valueDto2)).build();
+            given(optionMapper.toDto(eq(group1), any(List.class))).willReturn(optionDto1);
+
+
+            OptionDto.GroupDto groupDto2 = OptionDto.GroupDto.builder().id(2L).name("Size").build();
+            OptionDto.ValueDto valueDto3 = OptionDto.ValueDto.builder().id(20L).name("Small").build();
+            OptionDto optionDto2 = OptionDto.builder().group(groupDto2).values(List.of(valueDto3)).build();
+            given(optionMapper.toDto(eq(group2), any(List.class))).willReturn(optionDto2);
+
+
+            // when
+            OptionResponseDto result = optionUseCase.findAllOptions();
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.options()).hasSize(2);
+            assertThat(result.options().get(0).group().name()).isEqualTo("Color");
+            assertThat(result.options().get(0).values()).hasSize(2);
+            assertThat(result.options().get(1).group().name()).isEqualTo("Size");
+            assertThat(result.options().get(1).values()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("성공: 옵션 그룹이 없을 경우 빈 응답 DTO를 반환한다")
+        void findAllOptions_Success_NoOptionGroups() {
+            // given
+            given(productSupport.getAllProductOptionGroups()).willReturn(new ArrayList<>());
+
+            // when
+            OptionResponseDto result = optionUseCase.findAllOptions();
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.options()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공: 옵션 그룹은 존재하지만 해당 그룹에 속하는 옵션 값이 없을 경우 빈 옵션 값 리스트를 포함한 DTO를 반환한다")
+        void findAllOptions_Success_OptionGroupsButNoValues() {
+            // given
+            OptionGroup group1 = OptionGroup.builder().id(1L).name("Color").build();
+            List<OptionGroup> optionGroups = List.of(group1);
+
+            given(productSupport.getAllProductOptionGroups()).willReturn(optionGroups);
+            given(productSupport.getAllProductOptionValuesByOptionGroupIn(any(List.class))).willReturn(new ArrayList<>());
+
+            // Mock OptionMapper behavior for a group with no values
+            OptionDto.GroupDto groupDto1 = OptionDto.GroupDto.builder().id(1L).name("Color").build();
+            OptionDto optionDto1 = OptionDto.builder().group(groupDto1).values(new ArrayList<>()).build();
+            given(optionMapper.toDto(eq(group1), any(List.class))).willReturn(optionDto1);
+
+            // when
+            OptionResponseDto result = optionUseCase.findAllOptions();
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.options()).hasSize(1);
+            assertThat(result.options().get(0).group().name()).isEqualTo("Color");
+            assertThat(result.options().get(0).values()).isEmpty();
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/OptionUseCaseTest.java
@@ -8,7 +8,7 @@ import com.back.product.domain.OptionGroup;
 import com.back.product.domain.OptionValue;
 import com.back.product.dto.OptionDto;
 import com.back.product.dto.request.OptionCreateRequestDto;
-import com.back.product.dto.response.OptionResponseDto;
+import com.back.product.dto.response.OptionListResponseDto;
 import com.back.product.mapper.OptionMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -129,7 +128,7 @@ class OptionUseCaseTest {
 
 
             // when
-            OptionResponseDto result = optionUseCase.findAllOptions();
+            OptionListResponseDto result = optionUseCase.findAllOptions();
 
             // then
             assertThat(result).isNotNull();
@@ -147,7 +146,7 @@ class OptionUseCaseTest {
             given(productSupport.getAllProductOptionGroups()).willReturn(new ArrayList<>());
 
             // when
-            OptionResponseDto result = optionUseCase.findAllOptions();
+            OptionListResponseDto result = optionUseCase.findAllOptions();
 
             // then
             assertThat(result).isNotNull();
@@ -170,7 +169,7 @@ class OptionUseCaseTest {
             given(optionMapper.toDto(eq(group1), any(List.class))).willReturn(optionDto1);
 
             // when
-            OptionResponseDto result = optionUseCase.findAllOptions();
+            OptionListResponseDto result = optionUseCase.findAllOptions();
 
             // then
             assertThat(result).isNotNull();
@@ -244,7 +243,7 @@ class OptionUseCaseTest {
 
 
             // when
-            OptionResponseDto result = optionUseCase.createOptions(requestDto);
+            OptionListResponseDto result = optionUseCase.createOptions(requestDto);
 
             // then
             assertThat(result).isNotNull();
@@ -305,7 +304,7 @@ class OptionUseCaseTest {
             given(optionMapper.toDto(eq(existingGroup1), any(List.class))).willReturn(responseOptionDto1);
 
             // when
-            OptionResponseDto result = optionUseCase.createOptions(requestDto);
+            OptionListResponseDto result = optionUseCase.createOptions(requestDto);
 
             // then
             assertThat(result).isNotNull();
@@ -377,7 +376,7 @@ class OptionUseCaseTest {
             given(optionMapper.toDto(eq(newGroup2), any(List.class))).willReturn(responseOptionDto2);
 
             // when
-            OptionResponseDto result = optionUseCase.createOptions(requestDto);
+            OptionListResponseDto result = optionUseCase.createOptions(requestDto);
 
             // then
             assertThat(result).isNotNull();


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #164 

## 🔎 작업 내용

- 상품 옵션 관련 API 구현
  - 옵션 생성, 조회, 수정, 삭제 기능
  - 옵션 그룹 수정, 삭제 기능
  - 옵션 값 추가, 수정, 삭제 기능
-  기능 구현에 따른 단위 테스트 코드 작성
- Swagger API 문서 구성
- 데이터 중복 방지를 위한 `UNIQUE` 속성 추가

## 📷 테스트 결과
- Controller 단위 테스트
  <img width="590" height="460" alt="image" src="https://github.com/user-attachments/assets/1d0d3e53-3abf-4fc0-93af-9868a3071c33" />

- UseCase 단위 테스트
  <img width="582" height="585" alt="image" src="https://github.com/user-attachments/assets/b9d6a7a8-bc5a-44d8-ae11-7bfcdecd7a89" />

- Facade 단위 테스트 (for Delete Test)
  <img width="582" height="200" alt="image" src="https://github.com/user-attachments/assets/1c652760-3e74-4d00-85f4-9d8ab0c5c04f" />


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
