### PR TITLE
[FEAT] Brand/Category 관련 CRUD API 기능 구현 (#196)

### DIFF
--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -91,6 +91,7 @@ public enum FailureCode {
     OPTION_GROUP_IN_USE(HttpStatus.CONFLICT, "OPTION_GROUP_IN_USE", "해당 옵션 그룹을 사용하는 상품이 있어 삭제할 수 없습니다."),
     OPTION_VALUE_IN_USE(HttpStatus.CONFLICT, "OPTION_VALUE_IN_USE", "해당 옵션 값을 사용하는 상품이 있어 삭제할 수 없습니다."),
     BRAND_IN_USE(HttpStatus.CONFLICT, "BRAND_IN_USE", "해당 브랜드를 사용하는 상품이 있어 삭제할 수 없습니다."),
+    CATEGORY_IN_USE(HttpStatus.CONFLICT, "CATEGORY_IN_USE", "해당 카테고리를 사용하는 상품이 있어 삭제할 수 없습니다."),
     /**
      * 500 Internal Server Error
      */

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -88,6 +88,9 @@ public enum FailureCode {
     DUPLICATE_PRODUCT_INFO(HttpStatus.CONFLICT, "DUPLICATE_PRODUCT_INFO", "이미 존재하는 상품 정보입니다."),
     REPORT_DUPLICATE(HttpStatus.CONFLICT, "REPORT_DUPLICATE", "이미 신고한 메시지입니다."),
     PAYMENT_ALREADY_RELEASED(HttpStatus.CONFLICT, "PAYMENT_ALREADY_RELEASED", "이미 환급된 결제입니다."),
+    OPTION_GROUP_IN_USE(HttpStatus.CONFLICT, "OPTION_GROUP_IN_USE", "해당 옵션 그룹을 사용하는 상품이 있어 삭제할 수 없습니다."),
+    OPTION_VALUE_IN_USE(HttpStatus.CONFLICT, "OPTION_VALUE_IN_USE", "해당 옵션 값을 사용하는 상품이 있어 삭제할 수 없습니다."),
+    BRAND_IN_USE(HttpStatus.CONFLICT, "BRAND_IN_USE", "해당 브랜드를 사용하는 상품이 있어 삭제할 수 없습니다."),
     /**
      * 500 Internal Server Error
      */

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -2,8 +2,11 @@ dependencies {
     implementation project(':common')
     implementation project(':security')
 
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1BrandController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1BrandController.java
@@ -4,7 +4,9 @@ import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.BrandModifyRequestDto;
 import com.back.product.dto.response.BrandListResponseDto;
+import com.back.product.dto.response.BrandResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,5 +34,14 @@ public class ApiV1BrandController implements BrandApiController {
     public CommonResponse<BrandListResponseDto> createBrands(@RequestBody @Valid BrandCreateRequestDto request) {
         BrandListResponseDto response = productFacade.createBrands(request);
         return CommonResponse.success(SuccessCode.CREATED, response);
+    }
+
+    @Override
+    @PutMapping("/{brandId}")
+    public CommonResponse<BrandResponseDto> modifyBrand(
+            @PathVariable Long brandId,
+            @Valid @RequestBody BrandModifyRequestDto request) {
+        BrandResponseDto response = productFacade.modifyBrand(brandId, request);
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1BrandController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1BrandController.java
@@ -5,7 +5,6 @@ import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.BrandCreateRequestDto;
 import com.back.product.dto.response.BrandListResponseDto;
-import com.back.product.dto.response.BrandResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,13 +15,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping(path = "/api/v1/products/brands", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 public class ApiV1BrandController implements BrandApiController {
-    private final ProductFacade ProductFacade;
+    private final ProductFacade productFacade;
 
     @Override
     @GetMapping
     public CommonResponse<BrandListResponseDto> getBrands() {
         BrandListResponseDto response = BrandListResponseDto.builder()
-                .brands(ProductFacade.getBrands())
+                .brands(productFacade.getBrands())
                 .build();
         return CommonResponse.success(SuccessCode.OK, response);
     }
@@ -30,10 +29,8 @@ public class ApiV1BrandController implements BrandApiController {
     @Override
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommonResponse<BrandResponseDto> createBrand(@RequestBody @Valid BrandCreateRequestDto request) {
-        BrandResponseDto response = BrandResponseDto.builder()
-                .brand(ProductFacade.createBrand(request))
-                .build();
+    public CommonResponse<BrandListResponseDto> createBrands(@RequestBody @Valid BrandCreateRequestDto request) {
+        BrandListResponseDto response = productFacade.createBrands(request);
         return CommonResponse.success(SuccessCode.CREATED, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1BrandController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1BrandController.java
@@ -44,4 +44,12 @@ public class ApiV1BrandController implements BrandApiController {
         BrandResponseDto response = productFacade.modifyBrand(brandId, request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
+
+    @Override
+    @DeleteMapping("/{brandId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public CommonResponse<?> deleteBrand(@PathVariable Long brandId) {
+        productFacade.deleteBrand(brandId);
+        return CommonResponse.success(SuccessCode.NO_CONTENT, null);
+    }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1CategoryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1CategoryController.java
@@ -44,4 +44,12 @@ public class ApiV1CategoryController implements CategoryApiController {
         CategoryResponseDto response = productFacade.modifyCategory(categoryId, request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
+
+    @Override
+    @DeleteMapping("/{categoryId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public CommonResponse<?> deleteCategory(@PathVariable Long categoryId) {
+        productFacade.deleteCategory(categoryId);
+        return CommonResponse.success(SuccessCode.NO_CONTENT, null);
+    }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1CategoryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1CategoryController.java
@@ -4,6 +4,7 @@ import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.request.CategoryModifyRequestDto;
 import com.back.product.dto.response.CategoryListResponseDto;
 import com.back.product.dto.response.CategoryResponseDto;
 import jakarta.validation.Valid;
@@ -33,5 +34,14 @@ public class ApiV1CategoryController implements CategoryApiController {
     public CommonResponse<CategoryListResponseDto> createCategories(@RequestBody @Valid CategoryCreateRequestDto request) {
         CategoryListResponseDto response = productFacade.createCategories(request);
         return CommonResponse.success(SuccessCode.CREATED, response);
+    }
+
+    @Override
+    @PutMapping("/{categoryId}")
+    public CommonResponse<CategoryResponseDto> modifyCategory(
+            @PathVariable Long categoryId,
+            @Valid @RequestBody CategoryModifyRequestDto request) {
+        CategoryResponseDto response = productFacade.modifyCategory(categoryId, request);
+        return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1CategoryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1CategoryController.java
@@ -30,10 +30,8 @@ public class ApiV1CategoryController implements CategoryApiController {
     @Override
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommonResponse<CategoryResponseDto> createCategory(@RequestBody @Valid CategoryCreateRequestDto request) {
-        CategoryResponseDto response = CategoryResponseDto.builder()
-                .category(productFacade.createCategory(request))
-                .build();
+    public CommonResponse<CategoryListResponseDto> createCategories(@RequestBody @Valid CategoryCreateRequestDto request) {
+        CategoryListResponseDto response = productFacade.createCategories(request);
         return CommonResponse.success(SuccessCode.CREATED, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/BrandApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/BrandApiController.java
@@ -16,10 +16,10 @@ public interface BrandApiController {
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> getBrands();
 
-    @Operation(summary = "브랜드 생성", description = "새로운 브랜드를 생성합니다.")
+    @Operation(summary = "브랜드 생성", description = "새로운 브랜드를 생성합니다. 다중 생성이 가능합니다.")
     @ApiResponse(responseCode = "201", description = "브랜드 생성 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> createBrand(BrandCreateRequestDto request);
+    CommonResponse<?> createBrands(BrandCreateRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/BrandApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/BrandApiController.java
@@ -2,6 +2,7 @@ package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.BrandModifyRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -22,4 +23,11 @@ public interface BrandApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> createBrands(BrandCreateRequestDto request);
+
+    @Operation(summary = "브랜드 수정", description = "기존의 브랜드를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "브랜드 수정 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> modifyBrand(Long brandId, BrandModifyRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/BrandApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/BrandApiController.java
@@ -30,4 +30,11 @@ public interface BrandApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> modifyBrand(Long brandId, BrandModifyRequestDto request);
+
+    @Operation(summary = "브랜드 삭제", description = "기존의 브랜드를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "브랜드 삭제 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> deleteBrand(Long brandId);
 }

--- a/product/src/main/java/com/back/product/adapter/in/CategoryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/CategoryApiController.java
@@ -20,5 +20,5 @@ public interface CategoryApiController {
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> createCategory(CategoryCreateRequestDto request);
+    CommonResponse<?> createCategories(CategoryCreateRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/CategoryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/CategoryApiController.java
@@ -29,4 +29,11 @@ public interface CategoryApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> modifyCategory(Long categoryId, CategoryModifyRequestDto request);
+
+    @Operation(summary = "카테고리 삭제", description = "기존의 상품 카테고리를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "카테고리 삭제 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> deleteCategory(Long categoryId);
 }

--- a/product/src/main/java/com/back/product/adapter/in/CategoryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/CategoryApiController.java
@@ -2,6 +2,7 @@ package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.request.CategoryModifyRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,10 +16,17 @@ public interface CategoryApiController {
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> getCategories();
 
-    @Operation(summary = "카테고리 생성", description = "새로운 상품 카테고리를 생성합니다.")
+    @Operation(summary = "카테고리 생성", description = "새로운 상품 카테고리를 생성합니다. 다중 생성이 가능합니다.")
     @ApiResponse(responseCode = "201", description = "카테고리 생성 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> createCategories(CategoryCreateRequestDto request);
+
+    @Operation(summary = "카테고리 수정", description = "기존의 상품 카테고리를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "카테고리 수정 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> modifyCategory(Long categoryId, CategoryModifyRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductInfoRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductInfoRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductInfoRepository extends JpaRepository<ProductInfo, Long> {
     boolean existsProductInfoByBrandAndProductCodeIgnoreCase(Brand brand, String code);
+
+    Boolean existsByBrand_Id(Long brandId);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductInfoRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductInfoRepository.java
@@ -8,4 +8,6 @@ public interface ProductInfoRepository extends JpaRepository<ProductInfo, Long> 
     boolean existsProductInfoByBrandAndProductCodeIgnoreCase(Brand brand, String code);
 
     Boolean existsByBrand_Id(Long brandId);
+
+    Boolean existsByCategory_Id(Long categoryId);
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -34,8 +34,9 @@ public class ProductFacade {
     }
 
     @Transactional
-    public BrandDto createBrand(@Valid BrandCreateRequestDto request) {
-        return brandUseCase.createBrand(request);
+    public BrandListResponseDto createBrands(@Valid BrandCreateRequestDto request) {
+        List<BrandDto> brandDtos = brandUseCase.createBrands(request);
+        return BrandListResponseDto.builder().brands(brandDtos).build();
     }
 
     @Transactional(readOnly = true)

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -75,6 +75,17 @@ public class ProductFacade {
     }
 
     @Transactional
+    public void deleteCategory(Long categoryId) {
+        Boolean isUsed = productInfoUseCase.isCategoryInUse(categoryId);
+
+        if (isUsed) {
+            throw new CustomException(FailureCode.CATEGORY_IN_USE);
+        }
+
+        categoryUseCase.deleteCategory(categoryId);
+    }
+
+    @Transactional
     public ProductResponseDto createProduct(@Valid ProductCreateRequestDto request) {
         Brand brand = brandUseCase.findBrandExists(request.productInfo().brandId());
 

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -39,6 +39,12 @@ public class ProductFacade {
         return BrandListResponseDto.builder().brands(brandDtos).build();
     }
 
+    @Transactional
+    public BrandResponseDto modifyBrand(Long brandId, @Valid BrandModifyRequestDto request) {
+        BrandDto brandDto = brandUseCase.modifyBrand(brandId, request);
+        return BrandResponseDto.builder().brand(brandDto).build();
+    }
+
     @Transactional(readOnly = true)
     public List<CategoryDto> getCategories() {
         return categoryUseCase.getCategories();

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -1,13 +1,14 @@
 package com.back.product.app;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.app.usecase.*;
 import com.back.product.domain.*;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.request.*;
 import com.back.product.dto.BrandDto;
-import com.back.product.dto.response.ProductResponseDto;
-import com.back.product.dto.response.ProductSearchListResponseDto;
+import com.back.product.dto.response.*;
 import com.back.product.mapper.ProductInfoMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -45,8 +45,9 @@ public class ProductFacade {
     }
 
     @Transactional
-    public CategoryDto createCategory(@Valid CategoryCreateRequestDto request) {
-        return categoryUseCase.createCategory(request);
+    public CategoryListResponseDto createCategories(@Valid CategoryCreateRequestDto request) {
+        List<CategoryDto> categoryDtos =  categoryUseCase.createCategories(request);
+        return CategoryListResponseDto.builder().categories(categoryDtos).build();
     }
 
     @Transactional

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -57,6 +57,12 @@ public class ProductFacade {
     }
 
     @Transactional
+    public CategoryResponseDto modifyCategory(Long categoryId, @Valid CategoryModifyRequestDto request) {
+        CategoryDto categoryDto = categoryUseCase.modifyCategory(categoryId, request);
+        return CategoryResponseDto.builder().category(categoryDto).build();
+    }
+
+    @Transactional
     public ProductResponseDto createProduct(@Valid ProductCreateRequestDto request) {
         Brand brand = brandUseCase.findBrandExists(request.productInfo().brandId());
 

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -45,6 +45,17 @@ public class ProductFacade {
         return BrandResponseDto.builder().brand(brandDto).build();
     }
 
+    @Transactional
+    public void deleteBrand(Long brandId) {
+        Boolean isUsed = productInfoUseCase.isBrandInUse(brandId);
+
+        if (isUsed) {
+            throw new CustomException(FailureCode.BRAND_IN_USE);
+        }
+
+        brandUseCase.deleteBrand(brandId);
+    }
+
     @Transactional(readOnly = true)
     public List<CategoryDto> getCategories() {
         return categoryUseCase.getCategories();

--- a/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
@@ -81,6 +81,11 @@ public class BrandUseCase {
         return brandMapper.toDto(brandToModify);
     }
 
+    @Transactional
+    public void deleteBrand(Long brandId) {
+        brandRepository.deleteById(brandId);
+    }
+
     private String toPlainText(String text) {
         if (text == null) {
             throw new InvalidValueException();

--- a/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
@@ -61,6 +61,27 @@ public class BrandUseCase {
                 .orElseThrow(() -> new CustomException(FailureCode.BRAND_NOT_FOUND));
     }
 
+    @Transactional
+    public BrandDto modifyBrand(Long brandId, @Valid BrandModifyRequestDto request) {
+        Brand brandToModify = productSupport.findBrandById(brandId)
+                .orElseThrow(() -> new CustomException(FailureCode.BRAND_NOT_FOUND));
+
+        String newName = toPlainText(request.name());
+
+        productSupport.getAllBrands().stream()
+                .filter(existsBrand -> !existsBrand.getId().equals(brandId))
+                .map(existsBrand -> toPlainText(existsBrand.getName()))
+                .filter(existsBrandPlainName -> existsBrandPlainName.equals(newName))
+                .findFirst()
+                .ifPresent(_ -> { throw new CustomException(FailureCode.BRAND_NAME_DUPLICATE); });
+
+        brandToModify.modifyName(request.name());
+
+        brandToModify.modifyImageUrl(request.imageUrl());
+
+        return brandMapper.toDto(brandToModify);
+    }
+
     private String toPlainText(String text) {
         if (text == null) {
             throw new InvalidValueException();

--- a/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
@@ -2,15 +2,18 @@ package com.back.product.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
+import com.back.common.exception.InvalidValueException;
 import com.back.product.adapter.out.BrandRepository;
 import com.back.product.domain.Brand;
 import com.back.product.dto.request.BrandCreateRequestDto;
 import com.back.product.dto.BrandDto;
+import com.back.product.dto.request.BrandModifyRequestDto;
 import com.back.product.dto.response.BrandListResponseDto;
 import com.back.product.mapper.BrandMapper;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,10 +37,17 @@ public class BrandUseCase {
 
     @Transactional
     public List<BrandDto> createBrands(@Valid BrandCreateRequestDto request) {
-        Map<String, Brand> existsBrands = productSupport.getAllBrands().stream().collect(Collectors.toMap(Brand::getName, brand -> brand));
+        Map<String, Brand> existsBrands = productSupport.getAllBrands().stream()
+                .collect(Collectors.toMap(
+                        brand -> toPlainText(brand.getName()),
+                        brand -> brand)
+                );
 
         List<Brand> brandsToCreate = request.brands().stream()
-                .filter(newBrand -> !existsBrands.containsKey(newBrand.name()))
+                .filter(newBrand -> {
+                    String newName = toPlainText(newBrand.name());
+                    return !existsBrands.containsKey(newName);
+                })
                 .map(brandMapper::toEntity).toList();
 
         List<Brand> createdBrands = brandRepository.saveAll(brandsToCreate);
@@ -49,5 +59,13 @@ public class BrandUseCase {
     public Brand findBrandExists(Long brandId) {
         return productSupport.findBrandById(brandId)
                 .orElseThrow(() -> new CustomException(FailureCode.BRAND_NOT_FOUND));
+    }
+
+    private String toPlainText(String text) {
+        if (text == null) {
+            throw new InvalidValueException();
+        }
+
+        return  text.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
@@ -63,8 +63,7 @@ public class BrandUseCase {
 
     @Transactional
     public BrandDto modifyBrand(Long brandId, @Valid BrandModifyRequestDto request) {
-        Brand brandToModify = productSupport.findBrandById(brandId)
-                .orElseThrow(() -> new CustomException(FailureCode.BRAND_NOT_FOUND));
+        Brand brandToModify = findBrandExists(brandId);
 
         String newName = toPlainText(request.name());
 

--- a/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/BrandUseCase.java
@@ -6,6 +6,7 @@ import com.back.product.adapter.out.BrandRepository;
 import com.back.product.domain.Brand;
 import com.back.product.dto.request.BrandCreateRequestDto;
 import com.back.product.dto.BrandDto;
+import com.back.product.dto.response.BrandListResponseDto;
 import com.back.product.mapper.BrandMapper;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -14,7 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,20 +33,16 @@ public class BrandUseCase {
     }
 
     @Transactional
-    public BrandDto createBrand(@Valid BrandCreateRequestDto request) {
-        validateDuplicateBrandName(request.name());
+    public List<BrandDto> createBrands(@Valid BrandCreateRequestDto request) {
+        Map<String, Brand> existsBrands = productSupport.getAllBrands().stream().collect(Collectors.toMap(Brand::getName, brand -> brand));
 
-        Brand brand = brandMapper.toEntity(request);
+        List<Brand> brandsToCreate = request.brands().stream()
+                .filter(newBrand -> !existsBrands.containsKey(newBrand.name()))
+                .map(brandMapper::toEntity).toList();
 
-        Brand newBrand = brandRepository.save(brand);
+        List<Brand> createdBrands = brandRepository.saveAll(brandsToCreate);
 
-        return brandMapper.toDto(newBrand);
-    }
-
-    private void validateDuplicateBrandName(String name) {
-        if (productSupport.existsBrandByName(name)) {
-            throw new CustomException(FailureCode.BRAND_NAME_DUPLICATE);
-        }
+        return createdBrands.stream().map(brandMapper::toDto).toList();
     }
 
     @Transactional(readOnly = true)

--- a/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
@@ -7,6 +7,7 @@ import com.back.product.adapter.out.CategoryRepository;
 import com.back.product.domain.Category;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.request.CategoryModifyRequestDto;
 import com.back.product.mapper.CategoryMapper;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -56,6 +57,26 @@ public class CategoryUseCase {
     public Category findCategoryExists(Long categoryId) {
         return productSupport.findCategoryById(categoryId)
                 .orElseThrow(() -> new CustomException(FailureCode.CATEGORY_NOT_FOUND));
+    }
+
+    @Transactional
+    public CategoryDto modifyCategory(Long categoryId, @Valid CategoryModifyRequestDto request) {
+        Category categoryToModify = findCategoryExists(categoryId);
+
+        String newName = toPlainText(request.name());
+
+        productSupport.getAllCategories().stream()
+                .filter(existsCategory -> !existsCategory.getId().equals(categoryId))
+                .map(existsCategory -> toPlainText(existsCategory.getName()))
+                .filter(existsCategoryPlainName -> existsCategoryPlainName.equals(newName))
+                .findFirst()
+                .ifPresent(_ -> { throw new CustomException(FailureCode.CATEGORY_NAME_DUPLICATE); });
+
+        categoryToModify.modifyName(request.name());
+
+        categoryToModify.modifyImageUrl(request.imageUrl());
+
+        return categoryMapper.toDto(categoryToModify);
     }
 
     private String toPlainText(String text) {

--- a/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
@@ -2,6 +2,7 @@ package com.back.product.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
+import com.back.common.exception.InvalidValueException;
 import com.back.product.adapter.out.CategoryRepository;
 import com.back.product.domain.Category;
 import com.back.product.dto.CategoryDto;
@@ -33,10 +34,16 @@ public class CategoryUseCase {
     @Transactional
     public List<CategoryDto> createCategories(@Valid CategoryCreateRequestDto request) {
         Map<String, Category> existsCategories = productSupport.getAllCategories().stream()
-                .collect(Collectors.toMap(Category::getName, category -> category));
+                .collect(Collectors.toMap(
+                        category -> toPlainText(category.getName()),
+                        category -> category
+                ));
 
         List<Category> categoriesToCreate = request.categories().stream()
-                .filter(newCategory -> !existsCategories.containsKey(newCategory.name()))
+                .filter(newCategory -> {
+                    String newName = toPlainText(newCategory.name());
+                    return !existsCategories.containsKey(newName);
+                })
                 .map(categoryMapper::toEntity)
                 .toList();
 
@@ -49,5 +56,13 @@ public class CategoryUseCase {
     public Category findCategoryExists(Long categoryId) {
         return productSupport.findCategoryById(categoryId)
                 .orElseThrow(() -> new CustomException(FailureCode.CATEGORY_NOT_FOUND));
+    }
+
+    private String toPlainText(String text) {
+        if (text == null) {
+            throw new InvalidValueException();
+        }
+
+        return text.toLowerCase();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,20 +31,18 @@ public class CategoryUseCase {
     }
 
     @Transactional
-    public CategoryDto createCategory(@Valid CategoryCreateRequestDto request) {
-        isDuplicateCategoryName(request.name());
+    public List<CategoryDto> createCategories(@Valid CategoryCreateRequestDto request) {
+        Map<String, Category> existsCategories = productSupport.getAllCategories().stream()
+                .collect(Collectors.toMap(Category::getName, category -> category));
 
-        Category category = categoryMapper.toEntity(request);
+        List<Category> categoriesToCreate = request.categories().stream()
+                .filter(newCategory -> !existsCategories.containsKey(newCategory.name()))
+                .map(categoryMapper::toEntity)
+                .toList();
 
-        Category newCategory = categoryRepository.save(category);
+        List<Category> newCategories = categoryRepository.saveAll(categoriesToCreate);
 
-        return categoryMapper.toDto(newCategory);
-    }
-
-    private void isDuplicateCategoryName(String name) {
-        if (productSupport.existsCategoryByName(name)) {
-            throw new CustomException(FailureCode.CATEGORY_NAME_DUPLICATE);
-        }
+        return newCategories.stream().map(categoryMapper::toDto).toList();
     }
 
     @Transactional(readOnly = true)

--- a/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/CategoryUseCase.java
@@ -79,6 +79,11 @@ public class CategoryUseCase {
         return categoryMapper.toDto(categoryToModify);
     }
 
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        categoryRepository.deleteById(categoryId);
+    }
+
     private String toPlainText(String text) {
         if (text == null) {
             throw new InvalidValueException();

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -74,4 +74,9 @@ public class ProductInfoUseCase {
     public Boolean isBrandInUse(Long brandId) {
         return productSupport.existsProductInfoByBrand(brandId);
     }
+
+    @Transactional
+    public Boolean isCategoryInUse(Long categoryId) {
+        return productSupport.existsProductInfoByCategory(categoryId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductInfoUseCase.java
@@ -69,4 +69,9 @@ public class ProductInfoUseCase {
         return productSupport.findProductInfoById(productInfoId)
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
     }
+
+    @Transactional
+    public Boolean isBrandInUse(Long brandId) {
+        return productSupport.existsProductInfoByBrand(brandId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -95,4 +95,9 @@ public class ProductSupport {
     public Boolean existsProductInfoByBrand(Long brandId) {
         return productInfoRepository.existsByBrand_Id(brandId);
     }
+
+    @Transactional(readOnly = true)
+    public Boolean existsProductInfoByCategory(Long categoryId) {
+        return productInfoRepository.existsByCategory_Id(categoryId);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -92,41 +92,6 @@ public class ProductSupport {
     }
 
     @Transactional(readOnly = true)
-    public List<OptionGroup> getAllProductOptionGroups() {
-        return optionGroupRepository.findAll();
-    }
-
-    @Transactional(readOnly = true)
-    public List<OptionValue> getAllProductOptionValuesByOptionGroupIn(List<OptionGroup> productOptionGroups) {
-        return optionValueRepository.findAllByOptionGroupIn(productOptionGroups);
-    }
-
-    @Transactional(readOnly = true)
-    public OptionGroup getOptionGroupByName(String name) {
-        return optionGroupRepository.findByName(name);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<OptionGroup> getOptionGroupById(Long optionGroupId) {
-        return optionGroupRepository.findById(optionGroupId);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<OptionValue> getOptionValueById(Long optionValueId) {
-        return optionValueRepository.findById(optionValueId);
-    }
-
-    @Transactional(readOnly = true)
-    public Boolean existsProductByOptionGroupId(Long optionGroupId) {
-        return productOptionValuesRepository.existsByOptionValue_OptionGroup_Id(optionGroupId);
-    }
-
-    @Transactional(readOnly = true)
-    public Boolean existsProductByOptionValueId(Long optionValueId) {
-        return productOptionValuesRepository.existsByOptionValue_Id(optionValueId);
-    }
-
-    @Transactional(readOnly = true)
     public Boolean existsProductInfoByBrand(Long brandId) {
         return productInfoRepository.existsByBrand_Id(brandId);
     }

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -21,6 +21,7 @@ public class ProductSupport {
     private final ProductRepository productRepository;
     private final ProductOptionValuesRepository productOptionValuesRepository;
     private final ProductImageRepository productImageRepository;
+    private final OptionGroupRepository optionGroupRepository;
 
     @Transactional(readOnly = true)
     public List<Brand> getAllBrands() {
@@ -88,5 +89,45 @@ public class ProductSupport {
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
 
         return productRepository.findAllByProductInfo(productInfo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionGroup> getAllProductOptionGroups() {
+        return optionGroupRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionValue> getAllProductOptionValuesByOptionGroupIn(List<OptionGroup> productOptionGroups) {
+        return optionValueRepository.findAllByOptionGroupIn(productOptionGroups);
+    }
+
+    @Transactional(readOnly = true)
+    public OptionGroup getOptionGroupByName(String name) {
+        return optionGroupRepository.findByName(name);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<OptionGroup> getOptionGroupById(Long optionGroupId) {
+        return optionGroupRepository.findById(optionGroupId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<OptionValue> getOptionValueById(Long optionValueId) {
+        return optionValueRepository.findById(optionValueId);
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean existsProductByOptionGroupId(Long optionGroupId) {
+        return productOptionValuesRepository.existsByOptionValue_OptionGroup_Id(optionGroupId);
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean existsProductByOptionValueId(Long optionValueId) {
+        return productOptionValuesRepository.existsByOptionValue_Id(optionValueId);
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean existsProductInfoByBrand(Long brandId) {
+        return productInfoRepository.existsByBrand_Id(brandId);
     }
 }

--- a/product/src/main/java/com/back/product/domain/Brand.java
+++ b/product/src/main/java/com/back/product/domain/Brand.java
@@ -24,4 +24,12 @@ public class Brand extends BaseTimeEntity {
 
     @Column(nullable = false, length = 255)
     private String imageUrl;
+
+    public void modifyName(String name) {
+        this.name = name;
+    }
+
+    public void modifyImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/product/src/main/java/com/back/product/domain/Category.java
+++ b/product/src/main/java/com/back/product/domain/Category.java
@@ -24,4 +24,12 @@ public class Category extends BaseTimeEntity {
 
     @Column(nullable = false, length = 255)
     private String imageUrl;
+
+    public void modifyName(String name) {
+        this.name = name;
+    }
+
+    public void modifyImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/product/src/main/java/com/back/product/dto/request/BrandCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/BrandCreateRequestDto.java
@@ -1,19 +1,29 @@
 package com.back.product.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
-public record BrandCreateRequestDto(
-        @NotBlank(message = "브랜드 이름은 필수입니다.")
-        @Size(min=1, max=50, message = "브랜드 이름은 1자 이상 50자 이하여야 합니다.")
-        @Pattern(regexp = "^[a-zA-Z0-9 .&_+-]+$", message = "브랜드명은 영문, 숫자, 공백 및 일부 특수문자(.&_+-만) 허용됩니다.")
-        String name,
+import java.util.List;
 
-        @NotBlank(message = "로고 URL은 필수입니다.")
-        @Size(min=1, max=255, message = "로고 URL은 1자 이상 255자 이하여야 합니다.")
-        @URL(message = "유효한 URL 형식이 아닙니다.")
-        String logoUrl
+public record BrandCreateRequestDto(
+        @NotEmpty(message = "Brands cannot be null")
+        @Valid
+        List<BrandDto> brands
 ) {
+    public record BrandDto(
+            @NotBlank(message = "브랜드 이름은 필수입니다.")
+            @Size(min=1, max=50, message = "브랜드 이름은 1자 이상 50자 이하여야 합니다.")
+            @Pattern(regexp = "^[a-zA-Z0-9 .&_+-]+$", message = "브랜드명은 영문, 숫자, 공백 및 일부 특수문자(.&_+-만) 허용됩니다.")
+            String name,
+
+            @NotBlank(message = "로고 URL은 필수입니다.")
+            @Size(min=1, max=255, message = "로고 URL은 1자 이상 255자 이하여야 합니다.")
+            @URL(message = "유효한 URL 형식이 아닙니다.")
+            String logoUrl
+    ) {
+    }
 }

--- a/product/src/main/java/com/back/product/dto/request/BrandCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/BrandCreateRequestDto.java
@@ -5,15 +5,18 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
 
+@Builder
 public record BrandCreateRequestDto(
         @NotEmpty(message = "Brands cannot be null")
         @Valid
         List<BrandDto> brands
 ) {
+    @Builder
     public record BrandDto(
             @NotBlank(message = "브랜드 이름은 필수입니다.")
             @Size(min=1, max=50, message = "브랜드 이름은 1자 이상 50자 이하여야 합니다.")

--- a/product/src/main/java/com/back/product/dto/request/BrandModifyRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/BrandModifyRequestDto.java
@@ -1,0 +1,21 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import org.hibernate.validator.constraints.URL;
+
+@Builder
+public record BrandModifyRequestDto(
+        @NotBlank(message = "브랜드 이름은 필수입니다.")
+        @Size(min=1, max=50, message = "브랜드 이름은 1자 이상 50자 이하여야 합니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9 .&_+-]+$", message = "브랜드명은 영문, 숫자, 공백 및 일부 특수문자(.&_+-만) 허용됩니다.")
+        String name,
+
+        @NotBlank(message = "로고 URL은 필수입니다.")
+        @Size(min=1, max=255, message = "로고 URL은 1자 이상 255자 이하여야 합니다.")
+        @URL(message = "유효한 URL 형식이 아닙니다.")
+        String imageUrl
+) {
+}

--- a/product/src/main/java/com/back/product/dto/request/CategoryCreateRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/CategoryCreateRequestDto.java
@@ -1,21 +1,32 @@
 package com.back.product.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import org.hibernate.validator.constraints.URL;
 
+import java.util.List;
+
 @Builder
 public record CategoryCreateRequestDto(
-        @NotBlank(message = "카테고리 이름은 필수입니다.")
-        @Size(min=1, max=50, message = "카테고리 이름은 1자 이상 50자 이하여야 합니다.")
-        @Pattern(regexp = "^[a-zA-Z]+$", message = "카테고리 명은 영문만 허용됩니다.")
-        String name,
-
-        @NotBlank(message = "이미지 URL은 필수입니다.")
-        @Size(min=1, max=255, message = "이미지 URL은 1자 이상 255자 이하여야 합니다.")
-        @URL(message = "유효한 URL 형식이 아닙니다.")
-        String imageUrl
+        @NotEmpty(message = "Categories cannot be empty")
+        @Valid
+    List<CategoryDto> categories
 ) {
+    @Builder
+    public record CategoryDto(
+            @NotBlank(message = "카테고리 이름은 필수입니다.")
+            @Size(min=1, max=50, message = "카테고리 이름은 1자 이상 50자 이하여야 합니다.")
+            @Pattern(regexp = "^[a-zA-Z]+$", message = "카테고리 명은 영문만 허용됩니다.")
+            String name,
+
+            @NotBlank(message = "이미지 URL은 필수입니다.")
+            @Size(min=1, max=255, message = "이미지 URL은 1자 이상 255자 이하여야 합니다.")
+            @URL(message = "유효한 URL 형식이 아닙니다.")
+            String imageUrl
+    ) {
+    }
 }

--- a/product/src/main/java/com/back/product/dto/request/CategoryModifyRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/CategoryModifyRequestDto.java
@@ -1,0 +1,22 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import org.hibernate.validator.constraints.URL;
+
+@Builder
+public record CategoryModifyRequestDto (
+    @NotBlank(message = "카테고리 이름은 필수입니다.")
+    @Size(min=1, max=50, message = "카테고리 이름은 1자 이상 50자 이하여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "카테고리 명은 영문만 허용됩니다.")
+    String name,
+
+    @NotBlank(message = "이미지 URL은 필수입니다.")
+    @Size(min=1, max=255, message = "이미지 URL은 1자 이상 255자 이하여야 합니다.")
+    @URL(message = "유효한 URL 형식이 아닙니다.")
+    String imageUrl
+) {
+
+}

--- a/product/src/main/java/com/back/product/mapper/BrandMapper.java
+++ b/product/src/main/java/com/back/product/mapper/BrandMapper.java
@@ -15,7 +15,7 @@ public class BrandMapper {
                 .build();
     }
 
-    public Brand toEntity(BrandCreateRequestDto request) {
+    public Brand toEntity(BrandCreateRequestDto.BrandDto request) {
         return Brand.builder()
                 .name(request.name())
                 .imageUrl(request.logoUrl())

--- a/product/src/main/java/com/back/product/mapper/CategoryMapper.java
+++ b/product/src/main/java/com/back/product/mapper/CategoryMapper.java
@@ -15,7 +15,7 @@ public class CategoryMapper {
                 .build();
     }
 
-    public Category toEntity(CategoryCreateRequestDto request) {
+    public Category toEntity(CategoryCreateRequestDto.CategoryDto request) {
         return Category.builder()
                 .name(request.name())
                 .imageUrl(request.imageUrl())

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
@@ -5,6 +5,7 @@ import com.back.common.exception.CustomException;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.response.BrandListResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -75,10 +77,17 @@ class ApiV1BrandControllerTest {
         @WithMockUser
         void createBrand_Success() throws Exception {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("New Balance", "https://exmaple.com/logo.png");
-            BrandDto responseDto = BrandDto.builder().name("New Balance").logoUrl("https://exmaple.com/logo.png").build();
+            BrandCreateRequestDto.BrandDto newBrand1 = new BrandCreateRequestDto.BrandDto("New Balance", "https://example.com/logo.png");
+            BrandCreateRequestDto.BrandDto newBrand2 = new BrandCreateRequestDto.BrandDto("Nike", "https://example.com/logo2.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(List.of(newBrand1, newBrand2));
 
-            given(productFacade.createBrand(any(BrandCreateRequestDto.class))).willReturn(responseDto);
+            BrandListResponseDto responseDto = BrandListResponseDto.builder()
+                    .brands(List.of(
+                            new BrandDto(1L, "New Balance", "https://example.com/logo.png"),
+                            new BrandDto(2L, "Nike", "https://example.com/logo2.png")
+                    )).build();
+
+            given(productFacade.createBrands(any(BrandCreateRequestDto.class))).willReturn(responseDto);
 
             // when & then
             mockMvc.perform(
@@ -88,20 +97,31 @@ class ApiV1BrandControllerTest {
                     ).andDo(print())
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.code").value("CREATED"))
-                    .andExpect(jsonPath("$.data.brand.name").value("New Balance"))
-                    .andExpect(jsonPath("$.data.brand.logoUrl").value("https://exmaple.com/logo.png"));
+                    .andExpect(jsonPath("$.data.brands.length()").value(2))
+                    .andExpect(jsonPath("$.data.brands[0].name").value("New Balance"))
+                    .andExpect(jsonPath("$.data.brands[1].name").value("Nike"));
 
-            verify(productFacade).createBrand(any(BrandCreateRequestDto.class));
+            verify(productFacade).createBrands(any(BrandCreateRequestDto.class));
         }
 
         @Test
-        @DisplayName("중복된 브랜드 이름으로 생성 시 409 Conflict를 반환한다")
+        @DisplayName("요청에 중복된 브랜드 이름이 포함되어 있어도, 생성 가능한 브랜드만 생성하고 201 Created를 반환한다")
         @WithMockUser
-        void createBrand_Fail_DuplicateName() throws Exception {
+        void createBrand_Filter_DuplicateName() throws Exception {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("Existing Brand", "https://exmaple.com/logo.png");
-            given(productFacade.createBrand(any(BrandCreateRequestDto.class)))
-                    .willThrow(new CustomException(FailureCode.BRAND_NAME_DUPLICATE));
+            BrandCreateRequestDto.BrandDto existingBrand = new BrandCreateRequestDto.BrandDto("Existing Brand", "https://example.com/logo_exist.png");
+            BrandCreateRequestDto.BrandDto newBrand = new BrandCreateRequestDto.BrandDto("New Brand", "https://example.com/logo_new.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(List.of(existingBrand, newBrand));
+
+            // UseCase에서 중복을 걸러내고, 새로 생성된 브랜드만 반환
+            BrandListResponseDto responseDto = BrandListResponseDto.builder()
+                    .brands(List.of(
+                            new BrandDto(1L, "New Brand", "https://example.com/logo_new.png")
+                    )).build();
+
+
+            given(productFacade.createBrands(any(BrandCreateRequestDto.class)))
+                    .willReturn(responseDto);
 
             // when & then
             mockMvc.perform(
@@ -109,17 +129,22 @@ class ApiV1BrandControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(requestDto))
                     ).andDo(print())
-                    .andExpect(status().isConflict());
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.brands.length()").value(1))
+                    .andExpect(jsonPath("$.data.brands[0].name").value("New Brand"));
 
-            verify(productFacade).createBrand(any(BrandCreateRequestDto.class));
+            verify(productFacade).createBrands(any(BrandCreateRequestDto.class));
         }
+
 
         @Test
         @DisplayName("유효하지 않은 요청 값으로 생성 시 400 Bad Request를 반환한다")
         @WithMockUser
         void createBrand_Fail_Validation() throws Exception {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(" ", "https://exmaple.com/logo.png");
+            BrandCreateRequestDto.BrandDto invalidBrand = new BrandCreateRequestDto.BrandDto(" ", "invalid-url");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(List.of(invalidBrand));
+
 
             // when & then
             mockMvc.perform(
@@ -129,7 +154,7 @@ class ApiV1BrandControllerTest {
                     ).andDo(print())
                     .andExpect(status().isBadRequest());
 
-            verify(productFacade, never()).createBrand(any(BrandCreateRequestDto.class));
+            verify(productFacade, never()).createBrands(any(BrandCreateRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
@@ -26,8 +26,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -265,6 +264,52 @@ class ApiV1BrandControllerTest {
                     .andExpect(status().isBadRequest());
 
             verify(productFacade, never()).modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/products/brands/{brandId}")
+    class DeleteBrandTest {
+
+        private final Long BRAND_ID = 1L;
+
+        @Test
+        @DisplayName("브랜드 삭제를 성공한다")
+        @WithMockUser
+        void deleteBrand_Success() throws Exception {
+            // given
+            // productFacade.deleteBrand(BRAND_ID)가 호출될 때 아무것도 하지 않도록 설정 (void 메소드)
+            doNothing().when(productFacade).deleteBrand(BRAND_ID);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/products/brands/{brandId}", BRAND_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    ).andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // productFacade.deleteBrand가 올바른 ID로 호출되었는지 검증
+            verify(productFacade).deleteBrand(BRAND_ID);
+        }
+
+        @Test
+        @DisplayName("사용 중인 브랜드를 삭제 시도 시 409 Conflict를 반환한다")
+        @WithMockUser
+        void deleteBrand_Fail_BrandInUse() throws Exception {
+            // given
+            // productFacade.deleteBrand(BRAND_ID)가 호출될 때 BRAND_IN_USE 예외를 던지도록 설정
+            doThrow(new CustomException(FailureCode.BRAND_IN_USE)).when(productFacade).deleteBrand(BRAND_ID);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/products/brands/{brandId}", BRAND_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    ).andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("BRAND_IN_USE"));
+
+            // productFacade.deleteBrand가 올바른 ID로 호출되었는지 검증
+            verify(productFacade).deleteBrand(BRAND_ID);
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1BrandControllerTest.java
@@ -5,7 +5,9 @@ import com.back.common.exception.CustomException;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.BrandModifyRequestDto;
 import com.back.product.dto.response.BrandListResponseDto;
+import com.back.product.dto.response.BrandResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -18,15 +20,15 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -155,6 +157,114 @@ class ApiV1BrandControllerTest {
                     .andExpect(status().isBadRequest());
 
             verify(productFacade, never()).createBrands(any(BrandCreateRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/products/brands/{brandId}")
+    class ModifyBrandTest {
+
+        private final Long BRAND_ID = 1L;
+
+        @Test
+        @DisplayName("브랜드 수정을 성공한다")
+        @WithMockUser
+        void modifyBrand_Success() throws Exception {
+            // given
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder()
+                    .name("Modified Brand")
+                    .imageUrl("https://example.com/modified_logo.png")
+                    .build();
+            BrandResponseDto responseDto = BrandResponseDto.builder()
+                    .brand(new BrandDto(BRAND_ID, "Modified Brand", "https://example.com/modified_logo.png"))
+                    .build();
+
+            given(productFacade.modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class))).willReturn(responseDto);
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/brands/{brandId}", BRAND_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("OK"))
+                    .andExpect(jsonPath("$.data.brand.brandId").value(BRAND_ID))
+                    .andExpect(jsonPath("$.data.brand.name").value("Modified Brand"));
+
+            verify(productFacade).modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 브랜드 수정 시 404 Not Found를 반환한다")
+        @WithMockUser
+        void modifyBrand_Fail_BrandNotFound() throws Exception {
+            // given
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder()
+                    .name("NonExistent Brand")
+                    .imageUrl("https://example.com/non_existent.png")
+                    .build();
+
+            given(productFacade.modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class)))
+                    .willThrow(new CustomException(FailureCode.BRAND_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/brands/{brandId}", BRAND_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("BRAND_NOT_FOUND"));
+
+            verify(productFacade).modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("중복된 이름으로 브랜드 수정 시 409 Conflict를 반환한다")
+        @WithMockUser
+        void modifyBrand_Fail_DuplicateName() throws Exception {
+            // given
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder()
+                    .name("Existing Brand Name")
+                    .imageUrl("https://example.com/existing.png")
+                    .build();
+
+            given(productFacade.modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class)))
+                    .willThrow(new CustomException(FailureCode.BRAND_NAME_DUPLICATE));
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/brands/{brandId}", BRAND_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("BRAND_NAME_DUPLICATE"));
+
+            verify(productFacade).modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청 값으로 브랜드 수정 시 400 Bad Request를 반환한다")
+        @WithMockUser
+        void modifyBrand_Fail_Validation() throws Exception {
+            // given
+            // Invalid name (blank) and invalid URL
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder()
+                    .name(" ")
+                    .imageUrl("invalid-url")
+                    .build();
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/brands/{brandId}", BRAND_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).modifyBrand(eq(BRAND_ID), any(BrandModifyRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
@@ -5,7 +5,9 @@ import com.back.common.exception.CustomException;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.request.CategoryModifyRequestDto;
 import com.back.product.dto.response.CategoryListResponseDto;
+import com.back.product.dto.response.CategoryResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -22,11 +24,11 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -151,6 +153,114 @@ class ApiV1CategoryControllerTest {
                     .andExpect(status().isBadRequest());
 
             verify(productFacade, never()).createCategories(any(CategoryCreateRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/products/categories/{categoryId}")
+    class ModifyCategoryTest {
+
+        private final Long CATEGORY_ID = 1L;
+
+        @Test
+        @DisplayName("카테고리 수정을 성공한다")
+        @WithMockUser
+        void modifyCategory_Success() throws Exception {
+            // given
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder()
+                    .name("ModifiedCategory")
+                    .imageUrl("https://example.com/modified_image.png")
+                    .build();
+            CategoryResponseDto responseDto = CategoryResponseDto.builder()
+                    .category(new CategoryDto(CATEGORY_ID, "Modified Category", "https://example.com/modified_image.png"))
+                    .build();
+
+            given(productFacade.modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class))).willReturn(responseDto);
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/categories/{categoryId}", CATEGORY_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("OK"))
+                    .andExpect(jsonPath("$.data.category.categoryId").value(CATEGORY_ID))
+                    .andExpect(jsonPath("$.data.category.name").value("Modified Category"));
+
+            verify(productFacade).modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리 수정 시 404 Not Found를 반환한다")
+        @WithMockUser
+        void modifyCategory_Fail_CategoryNotFound() throws Exception {
+            // given
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder()
+                    .name("NonExistentCategory")
+                    .imageUrl("https://example.com/non_existent.png")
+                    .build();
+
+            given(productFacade.modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class)))
+                    .willThrow(new CustomException(FailureCode.CATEGORY_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/categories/{categoryId}", CATEGORY_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CATEGORY_NOT_FOUND"));
+
+            verify(productFacade).modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("중복된 이름으로 카테고리 수정 시 409 Conflict를 반환한다")
+        @WithMockUser
+        void modifyCategory_Fail_DuplicateName() throws Exception {
+            // given
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder()
+                    .name("ExistingCategoryName")
+                    .imageUrl("https://example.com/existing.png")
+                    .build();
+
+            given(productFacade.modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class)))
+                    .willThrow(new CustomException(FailureCode.CATEGORY_NAME_DUPLICATE));
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/categories/{categoryId}", CATEGORY_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("CATEGORY_NAME_DUPLICATE"));
+
+            verify(productFacade).modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청 값으로 카테고리 수정 시 400 Bad Request를 반환한다")
+        @WithMockUser
+        void modifyCategory_Fail_Validation() throws Exception {
+            // given
+            // Invalid name (blank or non-alphabet) and invalid URL
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder()
+                    .name("123") // Fails @Pattern(regexp = "^[a-zA-Z]+$")
+                    .imageUrl("invalid-url")
+                    .build();
+
+            // when & then
+            mockMvc.perform(
+                            put("/api/v1/products/categories/{categoryId}", CATEGORY_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
@@ -26,8 +26,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -261,6 +260,53 @@ class ApiV1CategoryControllerTest {
                     .andExpect(status().isBadRequest());
 
             verify(productFacade, never()).modifyCategory(eq(CATEGORY_ID), any(CategoryModifyRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/products/categories/{categoryId}")
+    class DeleteCategoryTest {
+
+        private final Long CATEGORY_ID = 1L;
+
+        @Test
+        @DisplayName("카테고리 삭제를 성공한다")
+        @WithMockUser
+        void deleteCategory_Success() throws Exception {
+            // given
+            // productFacade.deleteCategory(CATEGORY_ID)가 호출될 때 아무것도 하지 않도록 설정 (void 메소드)
+            doNothing().when(productFacade).deleteCategory(CATEGORY_ID);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/products/categories/{categoryId}", CATEGORY_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    ).andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // productFacade.deleteCategory가 올바른 ID로 호출되었는지 검증
+            verify(productFacade).deleteCategory(CATEGORY_ID);
+        }
+
+        @Test
+        @DisplayName("사용 중인 카테고리를 삭제 시도 시 409 Conflict를 반환한다")
+        @WithMockUser
+        void deleteCategory_Fail_CategoryInUse() throws Exception {
+            // given
+            // productFacade.deleteCategory(CATEGORY_ID)가 호출될 때 CATEGORY_IN_USE 예외를 던지도록 설정
+            doThrow(new CustomException(FailureCode.CATEGORY_IN_USE))
+                    .when(productFacade).deleteCategory(CATEGORY_ID);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/products/categories/{categoryId}", CATEGORY_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    ).andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("CATEGORY_IN_USE"));
+
+            // productFacade.deleteCategory가 올바른 ID로 호출되었는지 검증
+            verify(productFacade).deleteCategory(CATEGORY_ID);
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1CategoryControllerTest.java
@@ -5,6 +5,7 @@ import com.back.common.exception.CustomException;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.response.CategoryListResponseDto;
 import com.back.security.jwt.JWTUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -68,17 +70,24 @@ class ApiV1CategoryControllerTest {
 
     @Nested
     @DisplayName("POST /api/v1/products/categories")
-    class CreateCategoryTest {
+    class CreateCategoriesTest {
 
         @Test
         @DisplayName("카테고리 생성을 성공한다")
         @WithMockUser
-        void createCategory_Success() throws Exception {
+        void createCategories_Success() throws Exception {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Tops").imageUrl("https://exmaple.com/image.png").build();
-            CategoryDto responseDto = CategoryDto.builder().name("Tops").build();
+            CategoryCreateRequestDto.CategoryDto newCategory1 = new CategoryCreateRequestDto.CategoryDto("Tops", "https://example.com/image1.png");
+            CategoryCreateRequestDto.CategoryDto newCategory2 = new CategoryCreateRequestDto.CategoryDto("Bottoms", "https://example.com/image2.png");
+            CategoryCreateRequestDto requestDto = new CategoryCreateRequestDto(List.of(newCategory1, newCategory2));
 
-            given(productFacade.createCategory(any(CategoryCreateRequestDto.class))).willReturn(responseDto);
+            CategoryListResponseDto responseDto = CategoryListResponseDto.builder()
+                    .categories(List.of(
+                            new CategoryDto(1L, "Tops", "https://example.com/image1.png"),
+                            new CategoryDto(2L, "Bottoms", "https://example.com/image2.png")
+                    )).build();
+
+            given(productFacade.createCategories(any(CategoryCreateRequestDto.class))).willReturn(responseDto);
 
             // when & then
             mockMvc.perform(
@@ -88,19 +97,29 @@ class ApiV1CategoryControllerTest {
                     ).andDo(print())
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.code").value("CREATED"))
-                    .andExpect(jsonPath("$.data.category.name").value("Tops"));
+                    .andExpect(jsonPath("$.data.categories.length()").value(2))
+                    .andExpect(jsonPath("$.data.categories[0].name").value("Tops"))
+                    .andExpect(jsonPath("$.data.categories[1].name").value("Bottoms"));
 
-            verify(productFacade).createCategory(any(CategoryCreateRequestDto.class));
+            verify(productFacade).createCategories(any(CategoryCreateRequestDto.class));
         }
 
         @Test
-        @DisplayName("중복된 카테고리 이름으로 생성 시 409 Conflict를 반환한다")
+        @DisplayName("요청에 중복된 카테고리 이름이 있어도, 새로운 카테고리만 생성하고 201 Created를 반환한다")
         @WithMockUser
-        void createCategory_Fail_DuplicateName() throws Exception {
+        void createCategories_Filter_DuplicateName() throws Exception {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Existed").imageUrl("https://exmaple.com/image.png").build();
-            given(productFacade.createCategory(any(CategoryCreateRequestDto.class)))
-                    .willThrow(new CustomException(FailureCode.CATEGORY_NAME_DUPLICATE));
+            CategoryCreateRequestDto.CategoryDto existingCategory = new CategoryCreateRequestDto.CategoryDto("Existed", "https://example.com/image_exist.png");
+            CategoryCreateRequestDto.CategoryDto newCategory = new CategoryCreateRequestDto.CategoryDto("New", "https://example.com/image_new.png");
+            CategoryCreateRequestDto requestDto = new CategoryCreateRequestDto(List.of(existingCategory, newCategory));
+
+            CategoryListResponseDto responseDto = CategoryListResponseDto.builder()
+                    .categories(List.of(
+                            new CategoryDto(1L, "New", "https://example.com/image_new.png")
+                    )).build();
+
+            given(productFacade.createCategories(any(CategoryCreateRequestDto.class)))
+                    .willReturn(responseDto);
 
             // when & then
             mockMvc.perform(
@@ -108,17 +127,20 @@ class ApiV1CategoryControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(requestDto))
                     ).andDo(print())
-                    .andExpect(status().isConflict());
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.categories.length()").value(1))
+                    .andExpect(jsonPath("$.data.categories[0].name").value("New"));
 
-            verify(productFacade).createCategory(any(CategoryCreateRequestDto.class));
+            verify(productFacade).createCategories(any(CategoryCreateRequestDto.class));
         }
 
         @Test
         @DisplayName("유효하지 않은 요청 값으로 생성 시 400 Bad Request를 반환한다")
         @WithMockUser
-        void createCategory_Fail_Validation() throws Exception {
+        void createCategories_Fail_Validation() throws Exception {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name(" ").name("https://exmaple.com/image.png").build();
+            CategoryCreateRequestDto.CategoryDto invalidCategory = new CategoryCreateRequestDto.CategoryDto("123", "invalid-url");
+            CategoryCreateRequestDto requestDto = new CategoryCreateRequestDto(List.of(invalidCategory));
 
             // when & then
             mockMvc.perform(
@@ -128,7 +150,7 @@ class ApiV1CategoryControllerTest {
                     ).andDo(print())
                     .andExpect(status().isBadRequest());
 
-            verify(productFacade, never()).createCategory(any(CategoryCreateRequestDto.class));
+            verify(productFacade, never()).createCategories(any(CategoryCreateRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -2,10 +2,7 @@ package com.back.product.app;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
-import com.back.product.app.usecase.BrandUseCase;
-import com.back.product.app.usecase.OptionUseCase;
-import com.back.product.app.usecase.ProductInfoUseCase;
-import com.back.product.app.usecase.ProductUseCase;
+import com.back.product.app.usecase.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,6 +30,9 @@ class ProductFacadeTest {
 
     @Mock
     private BrandUseCase brandUseCase;
+
+    @Mock
+    private CategoryUseCase categoryUseCase;
 
     @Nested
     @DisplayName("deleteBrand 메소드")
@@ -75,6 +75,50 @@ class ProductFacadeTest {
             verify(productInfoUseCase).isBrandInUse(BRAND_ID);
             // brandUseCase.deleteBrand는 호출되지 않았는지 검증
             verify(brandUseCase, never()).deleteBrand(BRAND_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCategory 메소드")
+    class DeleteCategoryTest {
+
+        private final Long CATEGORY_ID = 1L;
+
+        @Test
+        @DisplayName("카테고리가 사용 중이지 않으면 카테고리 삭제를 성공한다")
+        void deleteCategory_Success() {
+            // given
+            // isCategoryInUse가 false를 반환하도록 설정
+            given(productInfoUseCase.isCategoryInUse(CATEGORY_ID)).willReturn(false);
+            // deleteCategory는 void이므로 아무것도 하지 않도록 설정
+            doNothing().when(categoryUseCase).deleteCategory(CATEGORY_ID);
+
+            // when
+            productFacade.deleteCategory(CATEGORY_ID);
+
+            // then
+            // 각 UseCase의 메소드가 올바른 인자로 호출되었는지 검증
+            verify(productInfoUseCase).isCategoryInUse(CATEGORY_ID);
+            verify(categoryUseCase).deleteCategory(CATEGORY_ID);
+        }
+
+        @Test
+        @DisplayName("카테고리가 사용 중이면 CATEGORY_IN_USE 예외를 발생시킨다")
+        void deleteCategory_Fail_CategoryInUse() {
+            // given
+            // isCategoryInUse가 true를 반환하도록 설정
+            given(productInfoUseCase.isCategoryInUse(CATEGORY_ID)).willReturn(true);
+
+            // when & then
+            // 예외 발생을 검증
+            assertThatThrownBy(() -> productFacade.deleteCategory(CATEGORY_ID))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("failureCode", FailureCode.CATEGORY_IN_USE);
+
+            // isCategoryInUse는 호출되었는지 검증
+            verify(productInfoUseCase).isCategoryInUse(CATEGORY_ID);
+            // categoryUseCase.deleteCategory는 호출되지 않았는지 검증
+            verify(categoryUseCase, never()).deleteCategory(CATEGORY_ID);
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -29,108 +29,10 @@ class ProductFacadeTest {
     private ProductFacade productFacade;
 
     @Mock
-    private ProductUseCase productUseCase;
-
-    @Mock
     private ProductInfoUseCase productInfoUseCase;
 
     @Mock
-    private OptionUseCase optionUseCase;
-
-    @Mock
     private BrandUseCase brandUseCase;
-
-    @Nested
-    @DisplayName("deleteOptionGroup 메서드")
-    class DeleteOptionGroupTest {
-
-        @Test
-        @DisplayName("성공: 옵션 그룹이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
-        void deleteOptionGroup_success_whenNotInUse() {
-            // given
-            Long optionGroupId = 1L;
-
-            // 1. productUseCase가 "사용 중이 아님(false)"을 반환하도록 설정
-            given(productUseCase.isOptionGroupInUse(anyLong())).willReturn(false);
-
-            // 2. optionUseCase.deleteOptions는 void를 반환하므로, 호출되었는지만 검증하면 됨
-            // doNothing().when(optionUseCase).deleteOptions(anyLong()); // 이 코드는 선택 사항
-
-            // when & then
-            // 예외가 발생하지 않는 것을 검증
-            assertDoesNotThrow(() -> productFacade.deleteOptionGroup(optionGroupId));
-
-            // verify
-            // 1. 사용 여부 확인 메서드가 호출되었는지 검증
-            verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
-            // 2. 삭제 메서드가 호출되었는지 검증
-            verify(optionUseCase, times(1)).deleteOptions(eq(optionGroupId));
-        }
-
-        @Test
-        @DisplayName("실패: 옵션 그룹이 사용 중일 때, CustomException을 발생시킨다")
-        void deleteOptionGroup_fail_whenInUse() {
-            // given
-            Long optionGroupId = 1L;
-
-            // 1. productUseCase가 "사용 중(true)"임을 반환하도록 설정
-            given(productUseCase.isOptionGroupInUse(anyLong())).willReturn(true);
-
-            // when & then
-            // 2. CustomException이 발생하는지 검증
-            CustomException exception = assertThrows(CustomException.class, () ->
-                    productFacade.deleteOptionGroup(optionGroupId)
-            );
-
-            // 3. 발생한 예외의 코드가 올바른지 확인
-            assertEquals(FailureCode.OPTION_GROUP_IN_USE, exception.getFailureCode());
-
-            // verify
-            // 1. 사용 여부 확인 메서드는 호출되었는지 검증
-            verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
-            // 2. 옵션이 사용 중이므로, 삭제 메서드는 호출되지 않았는지 검증
-            verify(optionUseCase, never()).deleteOptions(anyLong());
-        }
-    }
-
-    @Nested
-    @DisplayName("deleteOptionValue 메서드")
-    class DeleteOptionValueTest {
-
-        @Test
-        @DisplayName("성공: 옵션 값이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
-        void deleteOptionValue_success_whenNotInUse() {
-            // given
-            Long optionValueId = 1L;
-            given(productUseCase.isOptionValueInUse(anyLong())).willReturn(false);
-
-            // when & then
-            assertDoesNotThrow(() -> productFacade.deleteOptionValue(optionValueId));
-
-            // verify
-            verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
-            verify(optionUseCase, times(1)).deleteOption(eq(optionValueId));
-        }
-
-        @Test
-        @DisplayName("실패: 옵션 값이 사용 중일 때, CustomException을 발생시킨다")
-        void deleteOptionValue_fail_whenInUse() {
-            // given
-            Long optionValueId = 1L;
-            given(productUseCase.isOptionValueInUse(anyLong())).willReturn(true);
-
-            // when & then
-            CustomException exception = assertThrows(CustomException.class, () ->
-                    productFacade.deleteOptionValue(optionValueId)
-            );
-
-            assertEquals(FailureCode.OPTION_VALUE_IN_USE, exception.getFailureCode());
-
-            // verify
-            verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
-            verify(optionUseCase, never()).deleteOption(anyLong());
-        }
-    }
 
     @Nested
     @DisplayName("deleteBrand 메소드")

--- a/product/src/test/java/com/back/product/app/ProductFacadeTest.java
+++ b/product/src/test/java/com/back/product/app/ProductFacadeTest.java
@@ -1,0 +1,178 @@
+package com.back.product.app;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.app.usecase.BrandUseCase;
+import com.back.product.app.usecase.OptionUseCase;
+import com.back.product.app.usecase.ProductInfoUseCase;
+import com.back.product.app.usecase.ProductUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductFacade 단위 테스트")
+class ProductFacadeTest {
+
+    @InjectMocks
+    private ProductFacade productFacade;
+
+    @Mock
+    private ProductUseCase productUseCase;
+
+    @Mock
+    private ProductInfoUseCase productInfoUseCase;
+
+    @Mock
+    private OptionUseCase optionUseCase;
+
+    @Mock
+    private BrandUseCase brandUseCase;
+
+    @Nested
+    @DisplayName("deleteOptionGroup 메서드")
+    class DeleteOptionGroupTest {
+
+        @Test
+        @DisplayName("성공: 옵션 그룹이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
+        void deleteOptionGroup_success_whenNotInUse() {
+            // given
+            Long optionGroupId = 1L;
+
+            // 1. productUseCase가 "사용 중이 아님(false)"을 반환하도록 설정
+            given(productUseCase.isOptionGroupInUse(anyLong())).willReturn(false);
+
+            // 2. optionUseCase.deleteOptions는 void를 반환하므로, 호출되었는지만 검증하면 됨
+            // doNothing().when(optionUseCase).deleteOptions(anyLong()); // 이 코드는 선택 사항
+
+            // when & then
+            // 예외가 발생하지 않는 것을 검증
+            assertDoesNotThrow(() -> productFacade.deleteOptionGroup(optionGroupId));
+
+            // verify
+            // 1. 사용 여부 확인 메서드가 호출되었는지 검증
+            verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
+            // 2. 삭제 메서드가 호출되었는지 검증
+            verify(optionUseCase, times(1)).deleteOptions(eq(optionGroupId));
+        }
+
+        @Test
+        @DisplayName("실패: 옵션 그룹이 사용 중일 때, CustomException을 발생시킨다")
+        void deleteOptionGroup_fail_whenInUse() {
+            // given
+            Long optionGroupId = 1L;
+
+            // 1. productUseCase가 "사용 중(true)"임을 반환하도록 설정
+            given(productUseCase.isOptionGroupInUse(anyLong())).willReturn(true);
+
+            // when & then
+            // 2. CustomException이 발생하는지 검증
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productFacade.deleteOptionGroup(optionGroupId)
+            );
+
+            // 3. 발생한 예외의 코드가 올바른지 확인
+            assertEquals(FailureCode.OPTION_GROUP_IN_USE, exception.getFailureCode());
+
+            // verify
+            // 1. 사용 여부 확인 메서드는 호출되었는지 검증
+            verify(productUseCase, times(1)).isOptionGroupInUse(eq(optionGroupId));
+            // 2. 옵션이 사용 중이므로, 삭제 메서드는 호출되지 않았는지 검증
+            verify(optionUseCase, never()).deleteOptions(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteOptionValue 메서드")
+    class DeleteOptionValueTest {
+
+        @Test
+        @DisplayName("성공: 옵션 값이 사용 중이지 않을 때, 삭제 로직을 정상적으로 호출한다")
+        void deleteOptionValue_success_whenNotInUse() {
+            // given
+            Long optionValueId = 1L;
+            given(productUseCase.isOptionValueInUse(anyLong())).willReturn(false);
+
+            // when & then
+            assertDoesNotThrow(() -> productFacade.deleteOptionValue(optionValueId));
+
+            // verify
+            verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
+            verify(optionUseCase, times(1)).deleteOption(eq(optionValueId));
+        }
+
+        @Test
+        @DisplayName("실패: 옵션 값이 사용 중일 때, CustomException을 발생시킨다")
+        void deleteOptionValue_fail_whenInUse() {
+            // given
+            Long optionValueId = 1L;
+            given(productUseCase.isOptionValueInUse(anyLong())).willReturn(true);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productFacade.deleteOptionValue(optionValueId)
+            );
+
+            assertEquals(FailureCode.OPTION_VALUE_IN_USE, exception.getFailureCode());
+
+            // verify
+            verify(productUseCase, times(1)).isOptionValueInUse(eq(optionValueId));
+            verify(optionUseCase, never()).deleteOption(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteBrand 메소드")
+    class DeleteBrandTest {
+
+        private final Long BRAND_ID = 1L;
+
+        @Test
+        @DisplayName("브랜드가 사용 중이지 않으면 브랜드 삭제를 성공한다")
+        void deleteBrand_Success() {
+            // given
+            // isBrandInUse가 false를 반환하도록 설정
+            given(productInfoUseCase.isBrandInUse(BRAND_ID)).willReturn(false);
+            // deleteBrand는 void이므로 아무것도 하지 않도록 설정
+            doNothing().when(brandUseCase).deleteBrand(BRAND_ID);
+
+            // when
+            productFacade.deleteBrand(BRAND_ID);
+
+            // then
+            // 각 UseCase의 메소드가 올바른 인자로 호출되었는지 검증
+            verify(productInfoUseCase).isBrandInUse(BRAND_ID);
+            verify(brandUseCase).deleteBrand(BRAND_ID);
+        }
+
+        @Test
+        @DisplayName("브랜드가 사용 중이면 BRAND_IN_USE 예외를 발생시킨다")
+        void deleteBrand_Fail_BrandInUse() {
+            // given
+            // isBrandInUse가 true를 반환하도록 설정
+            given(productInfoUseCase.isBrandInUse(BRAND_ID)).willReturn(true);
+
+            // when & then
+            // 예외 발생을 검증
+            assertThatThrownBy(() -> productFacade.deleteBrand(BRAND_ID))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("failureCode", FailureCode.BRAND_IN_USE);
+
+            // isBrandInUse는 호출되었는지 검증
+            verify(productInfoUseCase).isBrandInUse(BRAND_ID);
+            // brandUseCase.deleteBrand는 호출되지 않았는지 검증
+            verify(brandUseCase, never()).deleteBrand(BRAND_ID);
+        }
+    }
+}

--- a/product/src/test/java/com/back/product/app/usecase/BrandUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/BrandUseCaseTest.java
@@ -1,9 +1,12 @@
 package com.back.product.app.usecase;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.BrandRepository;
 import com.back.product.domain.Brand;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.request.BrandCreateRequestDto;
+import com.back.product.dto.request.BrandModifyRequestDto;
 import com.back.product.mapper.BrandMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,16 +14,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("BrandUseCase 단위 테스트")
@@ -132,6 +137,80 @@ class BrandUseCaseTest {
             verify(brandRepository).saveAll(List.of(newEntity));
             verify(brandMapper, times(1)).toEntity(any(BrandCreateRequestDto.BrandDto.class));
             verify(brandMapper, times(1)).toDto(any(Brand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyBrand 메서드")
+    class ModifyBrandTest {
+
+        @Spy
+        private Brand brandToModify = Brand.builder().id(1L).name("Original Name").imageUrl("original.png").build();
+
+        @Test
+        @DisplayName("브랜드 수정을 성공한다")
+        void modifyBrand_Success() {
+            // given
+            final Long BRAND_ID = 1L;
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder()
+                    .name("Modified Name")
+                    .imageUrl("modified.png")
+                    .build();
+
+            given(productSupport.findBrandById(BRAND_ID)).willReturn(Optional.of(brandToModify));
+            given(productSupport.getAllBrands()).willReturn(List.of(brandToModify));
+            given(brandMapper.toDto(brandToModify)).willReturn(new BrandDto(BRAND_ID, "Modified Name", "modified.png"));
+
+            // when
+            BrandDto result = brandUseCase.modifyBrand(BRAND_ID, requestDto);
+
+            // then
+            assertThat(result.name()).isEqualTo("Modified Name");
+            assertThat(result.logoUrl()).isEqualTo("modified.png");
+            verify(productSupport).findBrandById(BRAND_ID);
+            verify(productSupport).getAllBrands();
+            verify(brandToModify).modifyName("Modified Name");
+            verify(brandToModify).modifyImageUrl("modified.png");
+            verify(brandMapper).toDto(brandToModify);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 브랜드를 수정하려고 하면 예외를 발생시킨다")
+        void modifyBrand_Fail_BrandNotFound() {
+            // given
+            final Long NON_EXISTENT_ID = 99L;
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder().name("any").imageUrl("any.png").build();
+
+            given(productSupport.findBrandById(NON_EXISTENT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> brandUseCase.modifyBrand(NON_EXISTENT_ID, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("failureCode", FailureCode.BRAND_NOT_FOUND);
+
+            verify(productSupport).findBrandById(NON_EXISTENT_ID);
+            verify(productSupport, never()).getAllBrands();
+        }
+
+        @Test
+        @DisplayName("다른 브랜드와 이름이 중복되면 예외를 발생시킨다")
+        void modifyBrand_Fail_DuplicateName() {
+            // given
+            final Long BRAND_ID = 1L;
+            Brand existingBrandWithSameName = Brand.builder().id(2L).name("Existing Name").imageUrl("existing.png").build();
+            BrandModifyRequestDto requestDto = BrandModifyRequestDto.builder().name("Existing Name").imageUrl("modified.png").build();
+
+            given(productSupport.findBrandById(BRAND_ID)).willReturn(Optional.of(brandToModify));
+            given(productSupport.getAllBrands()).willReturn(List.of(brandToModify, existingBrandWithSameName));
+
+            // when & then
+            assertThatThrownBy(() -> brandUseCase.modifyBrand(BRAND_ID, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("failureCode", FailureCode.BRAND_NAME_DUPLICATE);
+
+            verify(productSupport).findBrandById(BRAND_ID);
+            verify(productSupport).getAllBrands();
+            verify(brandToModify, never()).modifyName(anyString());
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/BrandUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/BrandUseCaseTest.java
@@ -1,51 +1,58 @@
 package com.back.product.app.usecase;
 
-import com.back.common.exception.CustomException;
-import com.back.product.BaseIntegrationTest;
 import com.back.product.adapter.out.BrandRepository;
 import com.back.product.domain.Brand;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.request.BrandCreateRequestDto;
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import com.back.product.mapper.BrandMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@SpringBootTest
-@Transactional
-@Testcontainers
-@DisplayName("BrandUseCase 통합 테스트")
-class BrandUseCaseTest extends BaseIntegrationTest {
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BrandUseCase 단위 테스트")
+class BrandUseCaseTest {
 
-    @Autowired
+    @InjectMocks
     private BrandUseCase brandUseCase;
 
-    @Autowired
-    private BrandRepository brandRepository;
+    @Mock
+    private BrandMapper brandMapper;
 
-    @BeforeEach
-    void setUp() {
-        brandRepository.deleteAll();
-    }
+    @Mock
+    private ProductSupport productSupport;
+
+    @Mock
+    private BrandRepository brandRepository;
 
     @Nested
     @DisplayName("getBrands 메서드")
     class GetBrandsTest {
 
         @Test
-        @DisplayName("DB에 저장된 모든 브랜드를 조회하여 DTO 리스트로 반환한다")
+        @DisplayName("모든 브랜드를 조회하여 DTO 리스트로 반환한다")
         void getBrands_Success() {
             // given
-            brandRepository.saveAll(List.of(
-                    Brand.builder().name("Nike").imageUrl("https://example.com/logo1.png").build(),
-                    Brand.builder().name("Adidas").imageUrl("https://example.com/logo2.png").build()
-            ));
+            Brand brand1 = Brand.builder().id(1L).name("Nike").imageUrl("https://example.com/logo1.png").build();
+            Brand brand2 = Brand.builder().id(2L).name("Adidas").imageUrl("https://example.com/logo2.png").build();
+            List<Brand> allBrands = List.of(brand1, brand2);
+
+            given(productSupport.getAllBrands()).willReturn(allBrands);
+            given(brandMapper.toDto(brand1)).willReturn(new BrandDto(1L, "Nike", "https://example.com/logo1.png"));
+            given(brandMapper.toDto(brand2)).willReturn(new BrandDto(2L, "Adidas", "https://example.com/logo2.png"));
 
             // when
             List<BrandDto> result = brandUseCase.getBrands();
@@ -53,45 +60,78 @@ class BrandUseCaseTest extends BaseIntegrationTest {
             // then
             assertThat(result).hasSize(2);
             assertThat(result).extracting(BrandDto::name).containsExactlyInAnyOrder("Nike", "Adidas");
+            verify(productSupport).getAllBrands();
+            verify(brandMapper, times(2)).toDto(any(Brand.class));
         }
     }
 
     @Nested
-    @DisplayName("createBrand 메서드")
-    class CreateBrandTest {
+    @DisplayName("createBrands 메서드")
+    class CreateBrandsTest {
 
         @Test
-        @DisplayName("새로운 브랜드를 DB에 저장하고 생성된 정보를 반환한다")
-        void createBrand_Success() {
+        @DisplayName("새로운 브랜드들을 DB에 저장하고 생성된 정보 리스트를 반환한다")
+        void createBrands_Success() {
             // given
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("New Balance", "https://example.com/logo.png");
+            BrandCreateRequestDto.BrandDto newBrandDto1 = new BrandCreateRequestDto.BrandDto("New Balance", "https://example.com/logo.png");
+            BrandCreateRequestDto.BrandDto newBrandDto2 = new BrandCreateRequestDto.BrandDto("Nike", "https://example.com/logo2.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(List.of(newBrandDto1, newBrandDto2));
+
+            Brand newBrandEntity1 = Brand.builder().name("New Balance").imageUrl("https://example.com/logo.png").build();
+            Brand newBrandEntity2 = Brand.builder().name("Nike").imageUrl("https://example.com/logo2.png").build();
+            List<Brand> brandsToCreate = List.of(newBrandEntity1, newBrandEntity2);
+
+            Brand savedBrandEntity1 = Brand.builder().id(1L).name("New Balance").imageUrl("https://example.com/logo.png").build();
+            Brand savedBrandEntity2 = Brand.builder().id(2L).name("Nike").imageUrl("https://example.com/logo2.png").build();
+            List<Brand> savedBrands = List.of(savedBrandEntity1, savedBrandEntity2);
+
+            given(productSupport.getAllBrands()).willReturn(Collections.emptyList());
+            given(brandMapper.toEntity(newBrandDto1)).willReturn(newBrandEntity1);
+            given(brandMapper.toEntity(newBrandDto2)).willReturn(newBrandEntity2);
+            given(brandRepository.saveAll(brandsToCreate)).willReturn(savedBrands);
+            given(brandMapper.toDto(savedBrandEntity1)).willReturn(new BrandDto(1L, "New Balance", "https://example.com/logo.png"));
+            given(brandMapper.toDto(savedBrandEntity2)).willReturn(new BrandDto(2L, "Nike", "https://example.com/logo2.png"));
 
             // when
-            BrandDto result = brandUseCase.createBrand(requestDto);
+            List<BrandDto> result = brandUseCase.createBrands(requestDto);
 
             // then
-            assertThat(result.name()).isEqualTo("New Balance");
-            assertThat(result.logoUrl()).isEqualTo("https://example.com/logo.png");
-
-            // DB에 실제 저장되었는지, ID는 생성되었는지 재검증
-            List<Brand> allBrands = brandRepository.findAll();
-            assertThat(allBrands).hasSize(1);
-            assertThat(allBrands.get(0).getId()).isNotNull();
-            assertThat(allBrands.get(0).getName()).isEqualTo("New Balance");
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(BrandDto::name).containsExactlyInAnyOrder("New Balance", "Nike");
+            verify(productSupport).getAllBrands();
+            verify(brandRepository).saveAll(brandsToCreate);
+            verify(brandMapper, times(2)).toEntity(any(BrandCreateRequestDto.BrandDto.class));
+            verify(brandMapper, times(2)).toDto(any(Brand.class));
         }
 
         @Test
-        @DisplayName("이미 존재하는 브랜드 이름이면 예외를 발생시킨다")
-        void createBrand_Fail_DuplicateName() {
+        @DisplayName("이미 존재하는 브랜드 이름은 필터링하고, 새로운 브랜드만 생성한다")
+        void createBrands_Should_Filter_DuplicateName() {
             // given
-            // DB에 미리 같은 이름의 브랜드를 저장
-            brandRepository.save(Brand.builder().name("Existing Brand").imageUrl("https://example.com/logo.png").build());
-            BrandCreateRequestDto requestDto = new BrandCreateRequestDto("Existing Brand", "https://example.com/logo.png");
+            BrandCreateRequestDto.BrandDto existingBrandDto = new BrandCreateRequestDto.BrandDto("Existing Brand", "https://example.com/logo_exist.png");
+            BrandCreateRequestDto.BrandDto newBrandDto = new BrandCreateRequestDto.BrandDto("New Brand", "https://example.com/logo_new.png");
+            BrandCreateRequestDto requestDto = new BrandCreateRequestDto(List.of(existingBrandDto, newBrandDto));
 
-            // when & then
-            assertThatThrownBy(() -> brandUseCase.createBrand(requestDto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("이미 존재하는 브랜드 이름입니다.");
+            Brand existingEntity = Brand.builder().id(1L).name("Existing Brand").imageUrl("https://example.com/logo_exist.png").build();
+            Brand newEntity = Brand.builder().name("New Brand").imageUrl("https://example.com/logo_new.png").build();
+            Brand savedNewEntity = Brand.builder().id(2L).name("New Brand").imageUrl("https://example.com/logo_new.png").build();
+
+            given(productSupport.getAllBrands()).willReturn(List.of(existingEntity));
+            given(brandMapper.toEntity(newBrandDto)).willReturn(newEntity);
+            given(brandRepository.saveAll(List.of(newEntity))).willReturn(List.of(savedNewEntity));
+            given(brandMapper.toDto(savedNewEntity)).willReturn(new BrandDto(2L, "New Brand", "https://example.com/logo_new.png"));
+
+            // when
+            List<BrandDto> result = brandUseCase.createBrands(requestDto);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).name()).isEqualTo("New Brand");
+
+            verify(productSupport).getAllBrands();
+            verify(brandRepository).saveAll(List.of(newEntity));
+            verify(brandMapper, times(1)).toEntity(any(BrandCreateRequestDto.BrandDto.class));
+            verify(brandMapper, times(1)).toDto(any(Brand.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/CategoryUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/CategoryUseCaseTest.java
@@ -1,9 +1,12 @@
 package com.back.product.app.usecase;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.CategoryRepository;
 import com.back.product.domain.Category;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
+import com.back.product.dto.request.CategoryModifyRequestDto;
 import com.back.product.mapper.CategoryMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,16 +14,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CategoryUseCase 단위 테스트")
@@ -133,6 +139,80 @@ class CategoryUseCaseTest {
             verify(categoryRepository).saveAll(List.of(newEntity));
             verify(categoryMapper, times(1)).toEntity(any(CategoryCreateRequestDto.CategoryDto.class));
             verify(categoryMapper, times(1)).toDto(any(Category.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyCategory 메서드")
+    class ModifyCategoryTest {
+
+        @Spy
+        private Category categoryToModify = Category.builder().id(1L).name("Original Name").imageUrl("original.png").build();
+
+        @Test
+        @DisplayName("카테고리 수정을 성공한다")
+        void modifyCategory_Success() {
+            // given
+            final Long CATEGORY_ID = 1L;
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder()
+                    .name("Modified")
+                    .imageUrl("modified.png")
+                    .build();
+
+            given(productSupport.findCategoryById(CATEGORY_ID)).willReturn(Optional.of(categoryToModify));
+            given(productSupport.getAllCategories()).willReturn(List.of(categoryToModify));
+            given(categoryMapper.toDto(categoryToModify)).willReturn(new CategoryDto(CATEGORY_ID, "Modified", "modified.png"));
+
+            // when
+            CategoryDto result = categoryUseCase.modifyCategory(CATEGORY_ID, requestDto);
+
+            // then
+            assertThat(result.name()).isEqualTo("Modified");
+            assertThat(result.imageUrl()).isEqualTo("modified.png");
+            verify(productSupport).findCategoryById(CATEGORY_ID);
+            verify(productSupport).getAllCategories();
+            verify(categoryToModify).modifyName("Modified");
+            verify(categoryToModify).modifyImageUrl("modified.png");
+            verify(categoryMapper).toDto(categoryToModify);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리를 수정하려고 하면 예외를 발생시킨다")
+        void modifyCategory_Fail_CategoryNotFound() {
+            // given
+            final Long NON_EXISTENT_ID = 99L;
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder().name("any").imageUrl("any.png").build();
+
+            given(productSupport.findCategoryById(NON_EXISTENT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> categoryUseCase.modifyCategory(NON_EXISTENT_ID, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("failureCode", FailureCode.CATEGORY_NOT_FOUND);
+
+            verify(productSupport).findCategoryById(NON_EXISTENT_ID);
+            verify(productSupport, never()).getAllCategories();
+        }
+
+        @Test
+        @DisplayName("다른 카테고리와 이름이 중복되면 예외를 발생시킨다")
+        void modifyCategory_Fail_DuplicateName() {
+            // given
+            final Long CATEGORY_ID = 1L;
+            Category existingCategoryWithSameName = Category.builder().id(2L).name("Existing").imageUrl("existing.png").build();
+            CategoryModifyRequestDto requestDto = CategoryModifyRequestDto.builder().name("Existing").imageUrl("modified.png").build();
+
+            given(productSupport.findCategoryById(CATEGORY_ID)).willReturn(Optional.of(categoryToModify));
+            given(productSupport.getAllCategories()).willReturn(List.of(categoryToModify, existingCategoryWithSameName));
+
+            // when & then
+            assertThatThrownBy(() -> categoryUseCase.modifyCategory(CATEGORY_ID, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("failureCode", FailureCode.CATEGORY_NAME_DUPLICATE);
+
+            verify(productSupport).findCategoryById(CATEGORY_ID);
+            verify(productSupport).getAllCategories();
+            verify(categoryToModify, never()).modifyName(anyString());
         }
     }
 }

--- a/product/src/test/java/com/back/product/app/usecase/CategoryUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/CategoryUseCaseTest.java
@@ -1,51 +1,59 @@
 package com.back.product.app.usecase;
 
-import com.back.common.exception.CustomException;
-import com.back.product.BaseIntegrationTest;
 import com.back.product.adapter.out.CategoryRepository;
 import com.back.product.domain.Category;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.request.CategoryCreateRequestDto;
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import com.back.product.mapper.CategoryMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@SpringBootTest
-@Transactional
-@Testcontainers
-@DisplayName("CategoryUseCase 통합 테스트")
-class CategoryUseCaseTest extends BaseIntegrationTest {
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CategoryUseCase 단위 테스트")
+class CategoryUseCaseTest {
 
-    @Autowired
+    @InjectMocks
     private CategoryUseCase categoryUseCase;
 
-    @Autowired
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    @Mock
+    private ProductSupport productSupport;
+
+    @Mock
     private CategoryRepository categoryRepository;
 
-    @BeforeEach
-    void setUp() {
-        categoryRepository.deleteAll();
-    }
 
     @Nested
     @DisplayName("getCategories 메서드")
     class GetCategoriesTest {
 
         @Test
-        @DisplayName("DB에 저장된 모든 카테고리를 조회하여 DTO 리스트로 반환한다")
+        @DisplayName("모든 카테고리를 조회하여 DTO 리스트로 반환한다")
         void getCategories_Success() {
             // given
-            categoryRepository.saveAll(List.of(
-                    Category.builder().name("Tops").imageUrl("https://example.com/image.png").build(),
-                    Category.builder().name("Bottoms").imageUrl("https://example.com/image.png").build()
-            ));
+            Category category1 = Category.builder().id(1L).name("Tops").imageUrl("https://example.com/image.png").build();
+            Category category2 = Category.builder().id(2L).name("Bottoms").imageUrl("https://example.com/image.png").build();
+            List<Category> allCategories = List.of(category1, category2);
+
+            given(productSupport.getAllCategories()).willReturn(allCategories);
+            given(categoryMapper.toDto(category1)).willReturn(new CategoryDto(1L, "Tops", "https://example.com/image.png"));
+            given(categoryMapper.toDto(category2)).willReturn(new CategoryDto(2L, "Bottoms", "https://example.com/image.png"));
 
             // when
             List<CategoryDto> result = categoryUseCase.getCategories();
@@ -53,44 +61,78 @@ class CategoryUseCaseTest extends BaseIntegrationTest {
             // then
             assertThat(result).hasSize(2);
             assertThat(result).extracting(CategoryDto::name).containsExactlyInAnyOrder("Tops", "Bottoms");
+            verify(productSupport).getAllCategories();
+            verify(categoryMapper, times(2)).toDto(any(Category.class));
         }
     }
 
     @Nested
-    @DisplayName("createCategory 메서드")
-    class CreateCategoryTest {
+    @DisplayName("createCategories 메서드")
+    class CreateCategoriesTest {
 
         @Test
-        @DisplayName("새로운 카테고리를 DB에 저장하고 생성된 정보를 반환한다")
-        void createCategory_Success() {
+        @DisplayName("새로운 카테고리들을 DB에 저장하고 생성된 정보 리스트를 반환한다")
+        void createCategories_Success() {
             // given
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Accessories").imageUrl("https://example.com/image.png").build();
+            CategoryCreateRequestDto.CategoryDto newCategoryDto1 = new CategoryCreateRequestDto.CategoryDto("Tops", "https://e.com/1.png");
+            CategoryCreateRequestDto.CategoryDto newCategoryDto2 = new CategoryCreateRequestDto.CategoryDto("Bottoms", "https://e.com/2.png");
+            CategoryCreateRequestDto requestDto = new CategoryCreateRequestDto(List.of(newCategoryDto1, newCategoryDto2));
+
+            Category newCategoryEntity1 = Category.builder().name("Tops").imageUrl("https://e.com/1.png").build();
+            Category newCategoryEntity2 = Category.builder().name("Bottoms").imageUrl("https://e.com/2.png").build();
+            List<Category> categoriesToCreate = List.of(newCategoryEntity1, newCategoryEntity2);
+
+            Category savedCategoryEntity1 = Category.builder().id(1L).name("Tops").imageUrl("https://e.com/1.png").build();
+            Category savedCategoryEntity2 = Category.builder().id(2L).name("Bottoms").imageUrl("https://e.com/2.png").build();
+            List<Category> savedCategories = List.of(savedCategoryEntity1, savedCategoryEntity2);
+
+            given(productSupport.getAllCategories()).willReturn(Collections.emptyList());
+            given(categoryMapper.toEntity(newCategoryDto1)).willReturn(newCategoryEntity1);
+            given(categoryMapper.toEntity(newCategoryDto2)).willReturn(newCategoryEntity2);
+            given(categoryRepository.saveAll(categoriesToCreate)).willReturn(savedCategories);
+            given(categoryMapper.toDto(savedCategoryEntity1)).willReturn(new CategoryDto(1L, "Tops", "https://e.com/1.png"));
+            given(categoryMapper.toDto(savedCategoryEntity2)).willReturn(new CategoryDto(2L, "Bottoms", "https://e.com/2.png"));
 
             // when
-            CategoryDto result = categoryUseCase.createCategory(requestDto);
+            List<CategoryDto> result = categoryUseCase.createCategories(requestDto);
 
             // then
-            assertThat(result.name()).isEqualTo("Accessories");
-
-            // DB에 실제 저장되었는지, ID는 생성되었는지 재검증
-            List<Category> allCategories = categoryRepository.findAll();
-            assertThat(allCategories).hasSize(1);
-            assertThat(allCategories.getFirst().getId()).isNotNull();
-            assertThat(allCategories.getFirst().getName()).isEqualTo("Accessories");
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(CategoryDto::name).containsExactlyInAnyOrder("Tops", "Bottoms");
+            verify(productSupport).getAllCategories();
+            verify(categoryRepository).saveAll(categoriesToCreate);
+            verify(categoryMapper, times(2)).toEntity(any(CategoryCreateRequestDto.CategoryDto.class));
+            verify(categoryMapper, times(2)).toDto(any(Category.class));
         }
 
         @Test
-        @DisplayName("이미 존재하는 카테고리 이름이면 예외를 발생시킨다")
-        void createCategory_Fail_DuplicateName() {
+        @DisplayName("이미 존재하는 카테고리 이름은 필터링하고, 새로운 카테고리만 생성한다")
+        void createCategories_Should_Filter_DuplicateName() {
             // given
-            // DB에 미리 같은 이름의 카테고리를 저장
-            categoryRepository.save(Category.builder().name("Existed").imageUrl("https://example.com/image.png").build());
-            CategoryCreateRequestDto requestDto = CategoryCreateRequestDto.builder().name("Existed").imageUrl("https://example.com/image.png").build();
+            CategoryCreateRequestDto.CategoryDto existingDto = new CategoryCreateRequestDto.CategoryDto("Existed", "https://e.com/e.png");
+            CategoryCreateRequestDto.CategoryDto newDto = new CategoryCreateRequestDto.CategoryDto("New", "https://e.com/n.png");
+            CategoryCreateRequestDto requestDto = new CategoryCreateRequestDto(List.of(existingDto, newDto));
 
-            // when & then
-            assertThatThrownBy(() -> categoryUseCase.createCategory(requestDto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("이미 존재하는 카테고리 이름입니다.");
+            Category existingEntity = Category.builder().id(1L).name("Existed").imageUrl("https://e.com/e.png").build();
+            Category newEntity = Category.builder().name("New").imageUrl("https://e.com/n.png").build();
+            Category savedNewEntity = Category.builder().id(2L).name("New").imageUrl("https://e.com/n.png").build();
+
+            given(productSupport.getAllCategories()).willReturn(List.of(existingEntity));
+            given(categoryMapper.toEntity(newDto)).willReturn(newEntity);
+            given(categoryRepository.saveAll(List.of(newEntity))).willReturn(List.of(savedNewEntity));
+            given(categoryMapper.toDto(savedNewEntity)).willReturn(new CategoryDto(2L, "New", "https://e.com/n.png"));
+
+            // when
+            List<CategoryDto> result = categoryUseCase.createCategories(requestDto);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).name()).isEqualTo("New");
+
+            verify(productSupport).getAllCategories();
+            verify(categoryRepository).saveAll(List.of(newEntity));
+            verify(categoryMapper, times(1)).toEntity(any(CategoryCreateRequestDto.CategoryDto.class));
+            verify(categoryMapper, times(1)).toDto(any(Category.class));
         }
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #196 

## 🔎 작업 내용
  **1. 브랜드 (Brand) API 기능 구현 및 개선:**

   * 다중 생성 (`createBrands`):
       * 하나의 요청으로 여러 개의 브랜드를 생성할 수 있도록 기능을 확장했습니다.
       * 브랜드 이름의 대소문자와 영숫자를 구분하지 않고(toPlainText 적용) 중복 브랜드를 필터링하여 생성합니다.
   * 수정 (`modifyBrand`):
       * 기존 브랜드를 수정할 수 있는 기능을 구현했습니다.
       * 수정 시, 다른 브랜드와 이름이 중복되는지(toPlainText 적용) 확인하며, 자기 자신과의 이름 중복은 허용합니다.
   * 삭제 (`deleteBrand`):
       * 브랜드를 소프트 삭제(deleted_at 업데이트)하는 기능을 구현했습니다.
       * 삭제 전, 해당 브랜드가 현재 제품에 사용 중인지 productInfoUseCase를 통해 확인하고, 사용 중일 경우 BRAND_IN_USE 예외를 발생시킵니다.

  **2. 카테고리 (Category) API 기능 구현 및 개선:**

   * 다중 생성 (`createCategories`):
       * 하나의 요청으로 여러 개의 카테고리를 생성할 수 있도록 기능을 확장했습니다.
       * 카테고리 이름의 대소문자를 구분하지 않고(toPlainText 적용) 중복 카테고리를 필터링하여 생성합니다. (DTO 유효성 검사 규칙(^[a-zA-Z]+$)에
         따라 이름에는 영문자만 허용)
   * 수정 (`modifyCategory`):
       * 기존 카테고리를 수정할 수 있는 기능을 구현했습니다.
       * 수정 시, 다른 카테고리와 이름이 중복되는지(toPlainText 적용) 확인하며, 자기 자신과의 이름 중복은 허용합니다. (DTO 유효성 검사 규칙에 따라
         이름에는 영문자만 허용)
   * 삭제 (`deleteCategory`):
       * 카테고리를 소프트 삭제(deleted_at 업데이트)하는 기능을 구현했습니다.
       * 삭제 전, 해당 카테고리가 현재 제품에 사용 중인지 productInfoUseCase를 통해 확인하고, 사용 중일 경우 CATEGORY_IN_USE 예외를 발생시킵니다.

  **3. 단위 테스트 코드 구현:**

   * 컨트롤러 계층 (`ApiV1BrandControllerTest`, `ApiV1CategoryControllerTest`):
       * get*s, create*s, modify*, delete* 각 메소드에 대한 단위 테스트 코드를 구현하여 API 엔드포인트의 동작 및 예외 처리를 검증했습니다.
   * 유스케이스 계층 (`BrandUseCaseTest`, `CategoryUseCaseTest`):
       * @SpringBootTest 기반의 통합 테스트를 Mockito 기반의 단위 테스트로 전환하여, 각 유스케이스의 핵심 비즈니스 로직을 격리하여 검증하도록
         개선했습니다.
       * get*s, create*s, modify* 각 메소드에 대한 단위 테스트 코드를 구현하여 비즈니스 로직 및 의존성 상호작용을 검증했습니다.

## 📷 테스트 결과
- Controller 단위 테스트
  - Brand
    <img width="723" height="397" alt="image" src="https://github.com/user-attachments/assets/0d1f2a5b-7dbe-4582-9a3f-ea9741542f07" />
  - Category  
    <img width="720" height="391" alt="image" src="https://github.com/user-attachments/assets/84430ba1-3406-4f92-a2b3-0b7659c8b4d8" />

- UseCase 단위 테스트 
  - Brand
    <img width="721" height="281" alt="image" src="https://github.com/user-attachments/assets/62e1dbb6-27b8-49da-beb5-a77a8f2dbb6f" />
  - Category    
    <img width="613" height="275" alt="image" src="https://github.com/user-attachments/assets/6fa0b34a-5534-4485-893f-c54040df27de" />

- Facade 단위 테스트 (for delete)
  <img width="608" height="203" alt="image" src="https://github.com/user-attachments/assets/096ea618-01d0-4790-bc8e-b0a4a2248d3c" />


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
