### PR TITLE
[FEAT] 채팅 메시지 삭제 기능 구현 (#201)

### DIFF
--- a/chat/src/main/java/com/back/chat/ChatApplication.java
+++ b/chat/src/main/java/com/back/chat/ChatApplication.java
@@ -7,7 +7,10 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
-@SpringBootApplication(scanBasePackages = "com.back")
+@SpringBootApplication(scanBasePackages = {
+        "com.back.common",
+        "com.back.security"
+})
 @EnableFeignClients
 @EnableJpaAuditing
 public class ChatApplication {

--- a/chat/src/main/java/com/back/chat/adapter/in/ChatController.java
+++ b/chat/src/main/java/com/back/chat/adapter/in/ChatController.java
@@ -46,4 +46,9 @@ public class ChatController {
                 chatFacade.reportMessage(authPrincipal.getUserId(),requestDto)
         );
     }
+
+    @DeleteMapping("/delete/{messageId}")
+    public void deleteMessage(@AuthenticationPrincipal AuthPrincipal authPrincipal,@PathVariable Long messageId) {
+                chatFacade.deleteMessage(authPrincipal.getUserId(),messageId);
+    }
 }

--- a/chat/src/main/java/com/back/chat/adapter/in/ChatMessageDeletedListener.java
+++ b/chat/src/main/java/com/back/chat/adapter/in/ChatMessageDeletedListener.java
@@ -1,0 +1,27 @@
+package com.back.chat.adapter.in;
+
+import com.back.chat.adapter.out.redis.RedisChatEventPublisher;
+import com.back.chat.event.ChatMessageBlindedEvent;
+import com.back.chat.event.ChatMessageDeletedEvent;
+import com.back.chat.event.payload.ChatMessageBlindedPayload;
+import com.back.chat.event.payload.ChatMessageDeletedPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageDeletedListener {
+    private final RedisChatEventPublisher redisChatEventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ChatMessageDeletedEvent event){
+        ChatMessageDeletedPayload payload = new ChatMessageDeletedPayload(event.roomId(), event.messageId());
+        redisChatEventPublisher.publishMessageDeleted(event.roomId(), payload);
+    }
+}

--- a/chat/src/main/java/com/back/chat/adapter/out/ChatMessageRepository.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/ChatMessageRepository.java
@@ -48,4 +48,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
     int blindIfReached(@Param("chatMessageId") Long chatMessageId,
                        @Param("threshold") int threshold);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+    update ChatMessage m
+       set m.messageStatus = com.back.chat.domain.MessageStatus.DELETED,
+           m.deletedAt = CURRENT_TIMESTAMP
+     where m.id = :messageId
+       and m.messageStatus <> com.back.chat.domain.MessageStatus.DELETED
+""")
+    int deleteIfNotDeleted(@Param("messageId") Long messageId);
 }

--- a/chat/src/main/java/com/back/chat/adapter/out/ChatMessageRepository.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/ChatMessageRepository.java
@@ -40,9 +40,9 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         update ChatMessage m
-        set m.isBlinded = true
+        set m.messageStatus = com.back.chat.domain.MessageStatus.BLINDED
         where m.id = :chatMessageId
-          and m.isBlinded = false
+          and m.messageStatus = com.back.chat.domain.MessageStatus.NORMAL
           and m.reportCount >= :threshold
     """)
     int blindIfReached(@Param("chatMessageId") Long chatMessageId,

--- a/chat/src/main/java/com/back/chat/adapter/out/redis/RedisChatEventPublisher.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/redis/RedisChatEventPublisher.java
@@ -3,6 +3,7 @@ package com.back.chat.adapter.out.redis;
 import com.back.chat.event.ChatEventEnvelope;
 import com.back.chat.event.ChatEventType;
 import com.back.chat.event.payload.ChatMessageBlindedPayload;
+import com.back.chat.event.payload.ChatMessageDeletedPayload;
 import com.back.chat.event.payload.ChatMessagePayload;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -30,6 +31,10 @@ public class RedisChatEventPublisher {
 
     public void publishMessageBlinded(Long roomId, ChatMessageBlindedPayload payload) {
         publish(roomId, ChatEventType.MESSAGE_BLINDED, objectMapper.valueToTree(payload));
+    }
+
+    public void publishMessageDeleted(Long roomId, ChatMessageDeletedPayload payload){
+        publish(roomId, ChatEventType.MESSAGE_DELETED, objectMapper.valueToTree(payload));
     }
 
     private void publish(Long roomId, ChatEventType type, JsonNode data) {

--- a/chat/src/main/java/com/back/chat/adapter/out/redis/RedisChatMessageSubscriber.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/redis/RedisChatMessageSubscriber.java
@@ -39,8 +39,8 @@ public class RedisChatMessageSubscriber implements MessageListener {
                     String destination = roomTopic(payload.roomId());
                     messagingTemplate.convertAndSend(destination, payload);
 
-                    log.info("[CHAT][REDIS-SUB] channel={}, type=CHAT_MESSAGE roomId={}, messageId={}, blinded={}, destination={}",
-                            channel, payload.roomId(), payload.messageId(), payload.isBlinded(), destination);
+                    log.info("[CHAT][REDIS-SUB] channel={}, type=CHAT_MESSAGE roomId={}, messageId={}, messageStatus={}, destination={}",
+                            channel, payload.roomId(), payload.messageId(), payload.messageStatus(), destination);
                 }
 
                 case MESSAGE_BLINDED -> {

--- a/chat/src/main/java/com/back/chat/adapter/out/redis/RedisChatMessageSubscriber.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/redis/RedisChatMessageSubscriber.java
@@ -2,6 +2,7 @@ package com.back.chat.adapter.out.redis;
 
 import com.back.chat.event.ChatEventEnvelope;
 import com.back.chat.event.payload.ChatMessageBlindedPayload;
+import com.back.chat.event.payload.ChatMessageDeletedPayload;
 import com.back.chat.event.payload.ChatMessagePayload;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +53,14 @@ public class RedisChatMessageSubscriber implements MessageListener {
 
                     log.info("[CHAT][REDIS-SUB] channel={}, type=MESSAGE_BLINDED roomId={}, messageId={}, destination={}",
                             channel, payload.roomId(), payload.chatMessageId(), destination);
+                }
+
+                case MESSAGE_DELETED -> {
+                    ChatMessageDeletedPayload payload =
+                            objectMapper.treeToValue(envelope.data(), ChatMessageDeletedPayload.class);
+
+                    String destination = roomTopic(payload.roomId());
+                    messagingTemplate.convertAndSend(destination,payload);
                 }
 
                 default -> log.warn("[CHAT][REDIS-SUB][WARN] unknown type. channel={}, rawBody={}", channel, rawBody);

--- a/chat/src/main/java/com/back/chat/app/ChatDeleteMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/ChatDeleteMessageUseCase.java
@@ -1,0 +1,39 @@
+package com.back.chat.app;
+
+import com.back.chat.domain.ChatMessage;
+import com.back.chat.event.ChatMessageDeletedEvent;
+import com.back.chat.mapper.ChatMessageMapper;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.common.exception.ForbiddenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatDeleteMessageUseCase {
+    private final ChatSupport chatSupport;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void deleteMessage(Long userId, Long messageId) {
+        ChatMessage message = chatSupport.findMessageById(messageId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (!message.getUserId().equals(userId)) {
+            throw new ForbiddenException(FailureCode.CHAT_DELETE_NOT_ALLOWED);
+        }
+
+        int updated = chatSupport.deleteIfNotDeleted(messageId);
+
+        ChatMessage latest = chatSupport.findMessageById(messageId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (updated == 1) {
+            eventPublisher.publishEvent(new ChatMessageDeletedEvent(
+                    latest.getId(),
+                    latest.getRoomId()
+            ));
+        }
+    }
+}

--- a/chat/src/main/java/com/back/chat/app/ChatFacade.java
+++ b/chat/src/main/java/com/back/chat/app/ChatFacade.java
@@ -18,6 +18,7 @@ public class ChatFacade {
     private final ChatSendMessageUseCase chatSendMessageUseCase;
     private final ChatGetHistoryUseCase chatGetHistoryUseCase;
     private final ChatReportMessageUseCase chatReportMessageUseCase;
+    private final ChatDeleteMessageUseCase chatDeleteMessageUseCase;
 
     @Transactional
     public ChatRoomEnterResponseDto enterChatRoom(Long brandId){
@@ -37,5 +38,10 @@ public class ChatFacade {
     @Transactional
     public ChatMessageReportResponseDto reportMessage(Long reporterUserId, ChatMessageReportRequestDto requestDto) {
         return chatReportMessageUseCase.reportMessage(reporterUserId, requestDto);
+    }
+
+    @Transactional
+    public void deleteMessage(Long userId, Long messageId) {
+        chatDeleteMessageUseCase.deleteMessage(userId, messageId);
     }
 }

--- a/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSendMessageUseCase.java
@@ -46,7 +46,7 @@ public class ChatSendMessageUseCase {
                 userId,
                 roomId,
                 savedMessage.getContent(),
-                savedMessage.isBlinded(),
+                savedMessage.getMessageStatus(),
                 savedMessage.getCreatedAt()
         );
 

--- a/chat/src/main/java/com/back/chat/app/ChatSupport.java
+++ b/chat/src/main/java/com/back/chat/app/ChatSupport.java
@@ -53,4 +53,7 @@ public class ChatSupport {
     }
 
 
+    public int deleteIfNotDeleted(Long messageId) {
+        return chatMessageRepository.deleteIfNotDeleted(messageId);
+    }
 }

--- a/chat/src/main/java/com/back/chat/domain/ChatMessage.java
+++ b/chat/src/main/java/com/back/chat/domain/ChatMessage.java
@@ -25,8 +25,9 @@ public class ChatMessage extends BaseTimeEntity {
     @Column(name = "content", nullable = false, length = 1000)
     private String content;
 
-    @Column(name = "is_blinded", nullable = false)
-    private boolean isBlinded = false;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_status", nullable = false)
+    private MessageStatus messageStatus = MessageStatus.NORMAL;
 
     @Column(name = "report_count", nullable = false)
     private int reportCount = 0;
@@ -39,7 +40,7 @@ public class ChatMessage extends BaseTimeEntity {
         this.roomId = roomId;
         this.userId = userId;
         this.content = content;
-        this.isBlinded = false;
+        this.messageStatus = MessageStatus.NORMAL;
     }
 
     public static ChatMessage create(

--- a/chat/src/main/java/com/back/chat/domain/MessageStatus.java
+++ b/chat/src/main/java/com/back/chat/domain/MessageStatus.java
@@ -1,0 +1,7 @@
+package com.back.chat.domain;
+
+public enum MessageStatus {
+    NORMAL,
+    BLINDED,
+    DELETED
+}

--- a/chat/src/main/java/com/back/chat/dto/response/ChatMessageHistoryResponseDto.java
+++ b/chat/src/main/java/com/back/chat/dto/response/ChatMessageHistoryResponseDto.java
@@ -1,5 +1,7 @@
 package com.back.chat.dto.response;
 
+import com.back.chat.domain.MessageStatus;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -13,7 +15,7 @@ public record ChatMessageHistoryResponseDto(
             Long messageId,
             Long userId,
             String content,
-            boolean isBlinded,
+            MessageStatus messageStatus,
             LocalDateTime createdAt
     ) {}
 }

--- a/chat/src/main/java/com/back/chat/dto/response/ChatMessageReportResponseDto.java
+++ b/chat/src/main/java/com/back/chat/dto/response/ChatMessageReportResponseDto.java
@@ -1,8 +1,10 @@
 package com.back.chat.dto.response;
 
+import com.back.chat.domain.MessageStatus;
+
 public record ChatMessageReportResponseDto (
         Long chatMessageId,
-        boolean isBlinded,
+        MessageStatus messageStatus,
         int reportCount
 ){
 }

--- a/chat/src/main/java/com/back/chat/event/ChatEventType.java
+++ b/chat/src/main/java/com/back/chat/event/ChatEventType.java
@@ -2,5 +2,6 @@ package com.back.chat.event;
 
 public enum ChatEventType {
     CHAT_MESSAGE,
-    MESSAGE_BLINDED
+    MESSAGE_BLINDED,
+    MESSAGE_DELETED
 }

--- a/chat/src/main/java/com/back/chat/event/ChatMessageDeletedEvent.java
+++ b/chat/src/main/java/com/back/chat/event/ChatMessageDeletedEvent.java
@@ -1,0 +1,7 @@
+package com.back.chat.event;
+
+public record ChatMessageDeletedEvent (
+        Long messageId,
+        Long roomId
+){
+}

--- a/chat/src/main/java/com/back/chat/event/payload/ChatMessageDeletedPayload.java
+++ b/chat/src/main/java/com/back/chat/event/payload/ChatMessageDeletedPayload.java
@@ -1,0 +1,7 @@
+package com.back.chat.event.payload;
+
+public record ChatMessageDeletedPayload (
+        Long roomId,
+        Long messageId
+){
+}

--- a/chat/src/main/java/com/back/chat/event/payload/ChatMessagePayload.java
+++ b/chat/src/main/java/com/back/chat/event/payload/ChatMessagePayload.java
@@ -1,5 +1,7 @@
 package com.back.chat.event.payload;
 
+import com.back.chat.domain.MessageStatus;
+
 import java.time.LocalDateTime;
 
 public record ChatMessagePayload(
@@ -7,7 +9,7 @@ public record ChatMessagePayload(
         Long userId,
         Long roomId,
         String content,
-        boolean isBlinded,
+        MessageStatus messageStatus,
         LocalDateTime createdAt
 ){
 }

--- a/chat/src/main/java/com/back/chat/mapper/ChatMessageMapper.java
+++ b/chat/src/main/java/com/back/chat/mapper/ChatMessageMapper.java
@@ -1,7 +1,6 @@
 package com.back.chat.mapper;
 
 import com.back.chat.domain.ChatMessage;
-import com.back.chat.domain.ChatMessageBlindPolicy;
 import com.back.chat.dto.response.ChatMessageHistoryResponseDto;
 import com.back.chat.dto.response.ChatMessageReportResponseDto;
 

--- a/chat/src/main/java/com/back/chat/mapper/ChatMessageMapper.java
+++ b/chat/src/main/java/com/back/chat/mapper/ChatMessageMapper.java
@@ -23,7 +23,7 @@ public class ChatMessageMapper {
                 m.getId(),
                 m.getUserId(),
                 m.getContent(),
-                m.isBlinded(),
+                m.getMessageStatus(),
                 m.getCreatedAt()
         );
     }
@@ -31,7 +31,7 @@ public class ChatMessageMapper {
     public static ChatMessageReportResponseDto toReportResponseDto (ChatMessage m){
         return new ChatMessageReportResponseDto(
                 m.getId(),
-                m.isBlinded(),
+                m.getMessageStatus(),
                 m.getReportCount()
         );
     }

--- a/chat/src/test/java/com/back/chat/ChatMessageDeletedListenerTest.java
+++ b/chat/src/test/java/com/back/chat/ChatMessageDeletedListenerTest.java
@@ -1,0 +1,53 @@
+package com.back.chat;
+
+import com.back.chat.adapter.in.ChatMessageDeletedListener;
+import com.back.chat.adapter.out.redis.RedisChatEventPublisher;
+import com.back.chat.event.ChatMessageDeletedEvent;
+import com.back.chat.event.payload.ChatMessageDeletedPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageDeletedListenerTest {
+
+    @Mock
+    private RedisChatEventPublisher redisChatEventPublisher;
+
+    @InjectMocks
+    private ChatMessageDeletedListener listener;
+
+    @Test
+    @DisplayName("메시지 삭제 이벤트 발생 -> Redis로 삭제 이벤트를 발행")
+    void handle_shouldPublishMessageDeletedEvent() {
+        // given
+        Long roomId = 1L;
+        Long messageId = 100L;
+
+        ChatMessageDeletedEvent event = new ChatMessageDeletedEvent(messageId, roomId);
+
+        // when
+        listener.handle(event);
+
+        // then
+        ArgumentCaptor<ChatMessageDeletedPayload> captor =
+                ArgumentCaptor.forClass(ChatMessageDeletedPayload.class);
+
+        verify(redisChatEventPublisher).publishMessageDeleted(eq(roomId), captor.capture());
+
+        ChatMessageDeletedPayload payload = captor.getValue();
+        assertThat(payload.roomId()).isEqualTo(roomId);
+        assertThat(payload.messageId()).isEqualTo(messageId);
+    }
+}
+

--- a/chat/src/test/java/com/back/chat/ChatReportMessageUseCaseTest.java
+++ b/chat/src/test/java/com/back/chat/ChatReportMessageUseCaseTest.java
@@ -8,6 +8,7 @@ import com.back.chat.adapter.out.ChatReportRepository;
 import com.back.chat.app.ChatReportMessageUseCase;
 import com.back.chat.domain.ChatMessage;
 import com.back.chat.domain.ChatReportReason;
+import com.back.chat.domain.MessageStatus;
 import com.back.chat.dto.request.ChatMessageReportRequestDto;
 import com.back.common.exception.BadRequestException;
 import com.back.common.exception.ConflictException;
@@ -65,7 +66,7 @@ class ChatReportMessageUseCaseTest {
 
         ChatMessage after2 = chatMessageRepository.findById(messageId).orElseThrow();
         assertThat(after2.getReportCount()).isEqualTo(2);
-        assertThat(after2.isBlinded()).isFalse();
+        assertThat(after2.getMessageStatus()).isEqualTo(MessageStatus.NORMAL);
 
         // when: 3rd report -> should blind
         chatReportMessageUseCase.reportMessage(reporter3, dto);
@@ -73,7 +74,7 @@ class ChatReportMessageUseCaseTest {
         // then
         ChatMessage after3 = chatMessageRepository.findById(messageId).orElseThrow();
         assertThat(after3.getReportCount()).isEqualTo(3);
-        assertThat(after3.isBlinded()).isTrue();
+        assertThat(after3.getMessageStatus()).isEqualTo(MessageStatus.BLINDED);
     }
 
     @Test

--- a/chat/src/test/java/com/back/chat/RedisChatMessageSubscriberTest.java
+++ b/chat/src/test/java/com/back/chat/RedisChatMessageSubscriberTest.java
@@ -1,6 +1,7 @@
 package com.back.chat;
 
 import com.back.chat.adapter.out.redis.RedisChatMessageSubscriber;
+import com.back.chat.domain.MessageStatus;
 import com.back.chat.event.ChatEventEnvelope;
 import com.back.chat.event.ChatEventType;
 import com.back.chat.event.payload.ChatMessagePayload;
@@ -44,7 +45,7 @@ class RedisChatMessageSubscriberTest {
                 2L,          // userId
                 roomId,      // roomId
                 "hello",     // content
-                false,       // isBlinded
+                MessageStatus.NORMAL,       // isBlinded
                 LocalDateTime.of(2026, 1, 30, 14, 50, 0) // createdAt
         );
 

--- a/chat/src/test/java/com/back/chat/RedisChatMessageSubscriberTest2.java
+++ b/chat/src/test/java/com/back/chat/RedisChatMessageSubscriberTest2.java
@@ -1,0 +1,67 @@
+package com.back.chat;
+
+import com.back.chat.adapter.out.redis.RedisChatMessageSubscriber;
+import com.back.chat.event.ChatEventEnvelope;
+import com.back.chat.event.ChatEventType;
+import com.back.chat.event.payload.ChatMessageDeletedPayload;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RedisChatMessageSubscriberTest2 {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private ObjectMapper objectMapper;
+    private RedisChatMessageSubscriber subscriber;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        subscriber = new RedisChatMessageSubscriber(objectMapper, messagingTemplate);
+    }
+
+    @Test
+    void onMessage_MESSAGE_DELETED_shouldBroadcastToWebSocket() throws Exception {
+        // given
+        Long roomId = 1L;
+        Long messageId = 100L;
+
+        ChatMessageDeletedPayload payload =
+                new ChatMessageDeletedPayload(roomId, messageId);
+
+        ChatEventEnvelope envelope =
+                new ChatEventEnvelope(ChatEventType.MESSAGE_DELETED,
+                        objectMapper.valueToTree(payload));
+
+        String json = objectMapper.writeValueAsString(envelope);
+
+        Message redisMessage = new DefaultMessage(
+                "chat-room".getBytes(StandardCharsets.UTF_8), // channel
+                json.getBytes(StandardCharsets.UTF_8)         // body
+        );
+
+        // when
+        subscriber.onMessage(redisMessage, null);
+
+        // then
+        verify(messagingTemplate).convertAndSend(
+                "/topic/chat/room/" + roomId,
+                payload
+        );
+    }
+}
+

--- a/chat/src/test/java/com/back/chat/RedisPublishIntegrationTest.java
+++ b/chat/src/test/java/com/back/chat/RedisPublishIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.back.chat;
 
 import com.back.chat.adapter.out.redis.RedisChatEventPublisher;
+import com.back.chat.domain.MessageStatus;
 import com.back.chat.event.payload.ChatMessagePayload;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,7 @@ class RedisPublishIntegrationTest {
                 roomId,
                 1L,
                 "redis publish test",
-                false,
+                MessageStatus.NORMAL,
                 LocalDateTime.now()
         );
 

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -52,6 +52,7 @@ public enum FailureCode {
     SETTLEMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "SETTLEMENT_ACCESS_DENIED", "해당 정산 내역에 접근 권한이 없습니다."),
     CHAT_RESTRICTED(HttpStatus.FORBIDDEN, "CHAT_RESTRICTED", "채팅이 제한된 사용자입니다."),
     OWNER_MISMATCH(HttpStatus.FORBIDDEN, "OWNER_MISMATCH", "결제 요청자 정보가 일치하지 않습니다."),
+    CHAT_DELETE_NOT_ALLOWED(HttpStatus.FORBIDDEN,"CHAT_DELETE_NOT_ALLOWED", "이 메시지를 삭제할 권한이 없습니다."),
     /**
      * 404 Not Found
      */


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #201 

## 🔎 작업 내용

- 채팅 메시지 삭제 기능 구현

<br>


## 📷 테스트 결과
- Redis 발행 테스트
<img width="521" height="121" alt="image" src="https://github.com/user-attachments/assets/f08310dc-e113-4847-84f4-d0a65f09e258" />

- Redis 수신 및 브로드캐스트 테스트
  <img width="518" height="120" alt="image" src="https://github.com/user-attachments/assets/24ed5c1f-7796-4425-8376-9bc8b3a7a140" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
