### PR TITLE
[HOTFIX] user 모듈에서 scanBasePackages 범위 축소 - (#213)

### DIFF
--- a/user/src/main/java/com/back/user/UserApplication.java
+++ b/user/src/main/java/com/back/user/UserApplication.java
@@ -4,7 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(scanBasePackages = "com.back")
+@SpringBootApplication(scanBasePackages = {
+        "com.back.user",
+        "com.back.common",
+        "com.back.security"
+})
 @EnableJpaAuditing
 public class UserApplication {
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #213 

## 🔎 작업 내용

- user 모듈에서 com.back으로 스캔하던 범위를 필요한 모듈만 작성하여 범위를 축소하였습니다. 

<br>
<img width="941" height="365" alt="image" src="https://github.com/user-attachments/assets/68f014a7-95d7-429f-a7e2-1bd099c89a01" />


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
