### PR TITLE
[FEAT] 회원가입 event consumer 구현, Role 필드 삭제 (#178)

### DIFF
--- a/common/src/main/java/com/back/common/market/event/MemberCreatedEvent.java
+++ b/common/src/main/java/com/back/common/market/event/MemberCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.back.common.market.event;
+
+import com.back.common.event.EventName;
+
+public record MemberCreatedEvent(
+        Long id,
+        String role,
+        String nickname,
+        String email,
+        String address,
+        String phone,
+        String profileImageUrl
+) implements EventName {
+}

--- a/common/src/main/java/com/back/common/market/event/UserCreatedEvent.java
+++ b/common/src/main/java/com/back/common/market/event/UserCreatedEvent.java
@@ -2,9 +2,8 @@ package com.back.common.market.event;
 
 import com.back.common.event.EventName;
 
-public record MemberCreatedEvent(
+public record UserCreatedEvent(
         Long id,
-        String role,
         String nickname,
         String email,
         String address,

--- a/market/src/main/java/com/back/market/MarketApplication.java
+++ b/market/src/main/java/com/back/market/MarketApplication.java
@@ -7,7 +7,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableFeignClients //FeignClient 사용 위해 추가
 @EnableJpaAuditing //BaseTimeEntity 작동 위해 추가
-@SpringBootApplication(scanBasePackages = "com.back") // common 모듈 스캔을 위해 추가
+@SpringBootApplication(scanBasePackages = {
+        "com.back.common",
+        "com.back.security",
+        "com.back.market"
+}) // common 모듈 스캔을 위해 추가
 public class MarketApplication {
 
     public static void main(String[] args) {

--- a/market/src/main/java/com/back/market/adapter/in/MarketDataInit.java
+++ b/market/src/main/java/com/back/market/adapter/in/MarketDataInit.java
@@ -4,7 +4,6 @@ import com.back.market.adapter.out.MarketProductRepository;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
-import com.back.market.domain.enums.Role;
 import com.back.market.mapper.MarketProductMapper;
 import com.back.market.mapper.MarketUserMapper;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +42,6 @@ public class MarketDataInit implements CommandLineRunner {
         // 유저 1: 판매자 역할 (ID: 1L)
         MarketUser seller = marketUserMapper.toEntity(
                 1L,
-                Role.USER,
                 "나이키매니아",
                 "seller@resello.com",
                 "서울시 강남구 역삼동",
@@ -56,7 +54,6 @@ public class MarketDataInit implements CommandLineRunner {
         // 유저 2: 구매자 역할 (ID: 2L)
         MarketUser buyer = marketUserMapper.toEntity(
                 2L,
-                Role.USER,
                 "신발덕후",
                 "buyer@resello.com",
                 "경기도 성남시 분당구",

--- a/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
+++ b/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
@@ -21,7 +21,7 @@ public class MarketUserEventConsumer {
 
     @Transactional
     @KafkaListener(
-            topics = "${custom.kafka.topic.member-created}",
+            topics = "${custom.kafka.topic.user-created}",
             groupId = "${custom.kafka.consumer.group-id}"
     )
     public void consume(UserCreatedEvent event) {

--- a/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
+++ b/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
@@ -1,9 +1,8 @@
 package com.back.market.adapter.in.kafka;
 
-import com.back.common.market.event.MemberCreatedEvent;
+import com.back.common.market.event.UserCreatedEvent;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.domain.MarketUser;
-import com.back.market.domain.enums.Role;
 import com.back.market.mapper.MarketUserMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +21,11 @@ public class MarketUserEventConsumer {
 
     @Transactional
     @KafkaListener(
-            topics = "MemberCreatedEvent",
+            topics = "UserCreatedEvent",
             groupId = "resello-market-group"
     )
-    public void consume(MemberCreatedEvent event) {
-        log.info("[Market] MemberCreatedEvent 수신: {}", event.id());
+    public void consume(UserCreatedEvent event) {
+        log.info("[Market] UserCreatedEvent 수신: {}", event.id());
 
         if (marketUserRepository.existsById(event.id())) {
             log.info("[Market] 이미 존재하는 회원 데이터: id = {}", event.id());
@@ -35,14 +34,13 @@ public class MarketUserEventConsumer {
         }
 
         if (event.id() == null || event.email() == null) {
-            log.error("MemberCreatedEvent의 id 또는 email이 null입니다. event={}", event);
+            log.error("UserCreatedEvent의 id 또는 email이 null입니다. event={}", event);
             return;
         }
 
         try {
             MarketUser marketUser = marketUserMapper.toEntity(
                     event.id(),
-                    Role.valueOf(event.role()),
                     event.nickname(),
                     event.email(),
                     event.address(),

--- a/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
+++ b/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
@@ -21,8 +21,8 @@ public class MarketUserEventConsumer {
 
     @Transactional
     @KafkaListener(
-            topics = "UserCreatedEvent",
-            groupId = "resello-market-group"
+            topics = "${custom.kafka.topic.member-created}",
+            groupId = "${custom.kafka.consumer.group-id}"
     )
     public void consume(UserCreatedEvent event) {
         log.info("[Market] UserCreatedEvent 수신: {}", event.id());

--- a/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
+++ b/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventConsumer.java
@@ -1,0 +1,64 @@
+package com.back.market.adapter.in.kafka;
+
+import com.back.common.market.event.MemberCreatedEvent;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.enums.Role;
+import com.back.market.mapper.MarketUserMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarketUserEventConsumer {
+
+    private final MarketUserRepository marketUserRepository;
+    private final MarketUserMapper marketUserMapper;
+
+    @Transactional
+    @KafkaListener(
+            topics = "MemberCreatedEvent",
+            groupId = "resello-market-group"
+    )
+    public void consume(MemberCreatedEvent event) {
+        log.info("[Market] MemberCreatedEvent 수신: {}", event.id());
+
+        if (marketUserRepository.existsById(event.id())) {
+            log.info("[Market] 이미 존재하는 회원 데이터: id = {}", event.id());
+            // TODO 업데이트 로직 추가하기
+            return;
+        }
+
+        if (event.id() == null || event.email() == null) {
+            log.error("MemberCreatedEvent의 id 또는 email이 null입니다. event={}", event);
+            return;
+        }
+
+        try {
+            MarketUser marketUser = marketUserMapper.toEntity(
+                    event.id(),
+                    Role.valueOf(event.role()),
+                    event.nickname(),
+                    event.email(),
+                    event.address(),
+                    event.phone(),
+                    event.profileImageUrl()
+            );
+
+            marketUserRepository.save(marketUser);
+            log.info("[Market] 회원 데이터 복제 완료: id = {}", event.id());
+        } catch (DataIntegrityViolationException e) {
+            log.error("[Market] 영구적 데이터 에러(스킵) id = {}, error = {}", event.id(), e.getMessage());
+        } catch (Exception e) {
+            //일시적 오류일 경우
+            log.error("[Market] 일시적 오류(재시도): id = {}, error = {}", event.id(), e.getMessage());
+            throw e;
+        }
+    }
+
+}

--- a/market/src/main/java/com/back/market/domain/MarketUser.java
+++ b/market/src/main/java/com/back/market/domain/MarketUser.java
@@ -1,7 +1,6 @@
 package com.back.market.domain;
 
 import com.back.common.entity.BaseTimeEntity;
-import com.back.market.domain.enums.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,10 +28,6 @@ public class MarketUser extends BaseTimeEntity {
     @Id
     @Column(name = "id")
     private Long id;                // Member 모듈의 PK를 그대로 사용
-
-    @Column(name = "role", nullable = false)
-    @Enumerated(EnumType.STRING)
-    private Role role;             // 권한(USER, ADMIN)
 
     @Column(name = "nickname", nullable = false, length = 30)
     private String nickname;        // 닉네임

--- a/market/src/main/java/com/back/market/domain/enums/Role.java
+++ b/market/src/main/java/com/back/market/domain/enums/Role.java
@@ -1,7 +1,0 @@
-package com.back.market.domain.enums;
-
-//User 모듈에서 복사해왔음
-public enum Role {
-    ADMIN,
-    USER
-}

--- a/market/src/main/java/com/back/market/mapper/MarketUserMapper.java
+++ b/market/src/main/java/com/back/market/mapper/MarketUserMapper.java
@@ -1,15 +1,13 @@
 package com.back.market.mapper;
 
 import com.back.market.domain.MarketUser;
-import com.back.market.domain.enums.Role;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MarketUserMapper {
-    public MarketUser toEntity(Long id, Role role, String nickname, String email, String address, String phone, String profileImageUrl){
+    public MarketUser toEntity(Long id, String nickname, String email, String address, String phone, String profileImageUrl){
         return MarketUser.builder()
                 .id(id)
-                .role(role)
                 .nickname(nickname)
                 .email(email)
                 .address(address)

--- a/market/src/main/resources/application.yml
+++ b/market/src/main/resources/application.yml
@@ -2,6 +2,6 @@ spring:
   application:
     name: market
   profiles:
-    active: local
+    active: test
   jackson:
     time-zone: Asia/Seoul

--- a/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
+++ b/market/src/test/java/com/back/market/GetInstantPriceUseCaseTests.java
@@ -11,7 +11,6 @@ import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
-import com.back.market.domain.enums.Role;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
@@ -119,7 +118,6 @@ class GetInstantPriceUseCaseTests {
                     .id(userId)
                     .nickname("tester")
                     .email("test@test.com")
-                    .role(Role.USER)
                     .build());
         }
         // 상품 생성

--- a/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
@@ -11,7 +11,6 @@ import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
-import com.back.market.domain.enums.Role;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.MarketProductMapper;
@@ -70,10 +69,10 @@ public class MatchInstantTradeRollbackTests {
 
     // --- Helper Methods (데이터 정리를 위해 메서드 단위 Transactional 고려 가능) ---
     private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
-        MarketUser seller = marketUserMapper.toEntity(sellerId, Role.USER, "seller", "s@t.com", "판매자주소", "010-1234-5678", "image");
+        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678", "image");
         marketUserRepository.save(seller);
 
-        MarketUser buyer = marketUserMapper.toEntity(buyerId, Role.USER, "buyer", "b@t.com", buyerAddress, "010-1234-5678", "image");
+        MarketUser buyer = marketUserMapper.toEntity(buyerId,"buyer", "b@t.com", buyerAddress, "010-1234-5678", "image");
         marketUserRepository.save(buyer);
 
         if (!marketProductRepository.existsById(productId)) {

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
@@ -14,10 +14,8 @@ import com.back.market.domain.Order;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
 import com.back.market.domain.enums.OrderStatus;
-import com.back.market.domain.enums.Role;
 import com.back.common.dto.cash.enums.PayAndHoldStatus;
 import com.back.market.dto.request.BiddingRequestDto;
-import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.MarketProductMapper;
@@ -78,7 +76,7 @@ public class MatchInstantTradeUseCaseV2Tests {
         Long seller2 = 11L;
         Long buyer = 12L;
         setupBaseData(productId, seller1, buyer, "주소");
-        marketUserRepository.save(MarketUser.builder().id(seller2).nickname("s2").email("s2@t.com").role(Role.USER).build());
+        marketUserRepository.save(MarketUser.builder().id(seller2).nickname("s2").email("s2@t.com").build());
 
         // 동일 가격(20만원)으로 시간차를 두고 입찰 등록
         createBidding(productId, seller1, 200000, BiddingPosition.SELL); // 1. 먼저 등록 (Target)
@@ -241,9 +239,9 @@ public class MatchInstantTradeUseCaseV2Tests {
     // --- Helper Methods (기존과 동일) ---
     private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
         // ... (기존 코드 그대로)
-        MarketUser seller = marketUserMapper.toEntity(sellerId, Role.USER, "seller", "s@t.com", "판매자주소", "010-1234-5678", "img");
+        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678", "img");
         marketUserRepository.save(seller);
-        MarketUser buyer = marketUserMapper.toEntity(buyerId, Role.USER, "buyer", "b@t.com", buyerAddress, "010-1234-5678", "img");
+        MarketUser buyer = marketUserMapper.toEntity(buyerId, "buyer", "b@t.com", buyerAddress, "010-1234-5678", "img");
         marketUserRepository.save(buyer);
         if (!marketProductRepository.existsById(productId)) {
             marketProductRepository.save(marketProductMapper.toEntity(productId, "N", "신발", "N1", "270", 100000L, "S", "img"));

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
@@ -18,6 +18,7 @@ import com.back.market.domain.enums.Role;
 import com.back.common.dto.cash.enums.PayAndHoldStatus;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.MarketProductMapper;
 import com.back.market.mapper.MarketUserMapper;
@@ -86,7 +87,7 @@ public class MatchInstantTradeUseCaseV2Tests {
 
         // [When] 구매 실행
         BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
-        PayAndHoldResponseDto response = matchInstantTradeUseCase.buyNow(buyer, request);
+        MarketPaymentResponseDto response = matchInstantTradeUseCase.buyNow(buyer, request);
 
         // [Then] seller1(먼저 등록한 사람)의 입찰과 체결되었는지 확인
         Order savedOrder = orderRepository.findById(response.relId()).orElseThrow();
@@ -130,7 +131,7 @@ public class MatchInstantTradeUseCaseV2Tests {
         BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(200000), "270");
 
         // [When] UseCase 호출 (반환값 DTO로 변경)
-        PayAndHoldResponseDto response = matchInstantTradeUseCase.buyNow(buyerId, request);
+        MarketPaymentResponseDto response = matchInstantTradeUseCase.buyNow(buyerId, request);
 
         // [Then] 1. 응답 상태 검증 (PAID)
         assertThat(response.status()).isEqualTo(PayAndHoldStatus.PAID);
@@ -196,7 +197,7 @@ public class MatchInstantTradeUseCaseV2Tests {
 
         // [When] 구매 실행
         BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(9000), "270");
-        PayAndHoldResponseDto response = matchInstantTradeUseCase.buyNow(buyerId, request);
+        MarketPaymentResponseDto response = matchInstantTradeUseCase.buyNow(buyerId, request);
 
         // [Then] 응답 검증
         assertThat(response.status()).isEqualTo(PayAndHoldStatus.REQUIRES_PG);
@@ -222,7 +223,7 @@ public class MatchInstantTradeUseCaseV2Tests {
 
         // [When] 즉시 판매 (반환값 변경)
         BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(150000), "270");
-        PayAndHoldResponseDto response = matchInstantTradeUseCase.sellNow(sellerId, request);
+        MarketPaymentResponseDto response = matchInstantTradeUseCase.sellNow(sellerId, request);
 
         // [Then] 1. 응답 상태 검증 (PAID)
         assertThat(response.status()).isEqualTo(PayAndHoldStatus.PAID);

--- a/market/src/test/java/com/back/market/RegisterBidUseCaseV2Tests.java
+++ b/market/src/test/java/com/back/market/RegisterBidUseCaseV2Tests.java
@@ -11,10 +11,8 @@ import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
-import com.back.market.domain.enums.Role;
 import com.back.common.dto.cash.enums.PayAndHoldStatus;
 import com.back.market.dto.request.BiddingRequestDto;
-import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.market.dto.response.MarketPaymentResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,7 +46,6 @@ public class RegisterBidUseCaseV2Tests {
                     .id(USER_ID)
                     .nickname("tester")
                     .email("test@test.com")
-                    .role(Role.USER)
                     .build();
             userRepository.save(user);
         }
@@ -145,7 +142,6 @@ public class RegisterBidUseCaseV2Tests {
                 .id(sellerId)
                 .nickname("seller_user")
                 .email("seller@test.com")
-                .role(Role.USER)
                 .build();
         userRepository.save(seller);
 
@@ -193,7 +189,6 @@ public class RegisterBidUseCaseV2Tests {
                 .id(buyerId)
                 .nickname("buyer_user")
                 .email("seller@test.com")
-                .role(Role.USER)
                 .build();
         userRepository.save(buyer);
 

--- a/market/src/test/java/com/back/market/RegisterBidUseCaseV2Tests.java
+++ b/market/src/test/java/com/back/market/RegisterBidUseCaseV2Tests.java
@@ -15,6 +15,7 @@ import com.back.market.domain.enums.Role;
 import com.back.common.dto.cash.enums.PayAndHoldStatus;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.market.dto.response.MarketPaymentResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,7 @@ public class RegisterBidUseCaseV2Tests {
         BiddingRequestDto request = BiddingRequestDto.of(PRODUCT_ID, price, "270");
 
         // [When] DTO 반환 확인
-        PayAndHoldResponseDto response = useCase.registerBuyBid(USER_ID, request);
+        MarketPaymentResponseDto response = useCase.registerBuyBid(USER_ID, request);
 
         // [Then] 1. 응답 검증
         assertThat(response.status()).isEqualTo(PayAndHoldStatus.PAID);
@@ -92,7 +93,7 @@ public class RegisterBidUseCaseV2Tests {
         BiddingRequestDto request = BiddingRequestDto.of(PRODUCT_ID, price, "270");
 
         // [When] 예외가 발생하지 않고 응답을 받아야 함
-        PayAndHoldResponseDto response = useCase.registerBuyBid(USER_ID, request);
+        MarketPaymentResponseDto response = useCase.registerBuyBid(USER_ID, request);
 
         // [Then]
         assertThat(response.status()).isEqualTo(PayAndHoldStatus.REQUIRES_PG);
@@ -111,7 +112,7 @@ public class RegisterBidUseCaseV2Tests {
         BiddingRequestDto request = BiddingRequestDto.of(PRODUCT_ID, BigDecimal.valueOf(150000), "270");
 
         // [When]
-        PayAndHoldResponseDto response = useCase.registerSellBid(USER_ID, request);
+        MarketPaymentResponseDto response = useCase.registerSellBid(USER_ID, request);
 
         // [Then]
         assertThat(response.status()).isEqualTo(PayAndHoldStatus.PAID);

--- a/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
+++ b/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
@@ -1,0 +1,43 @@
+package com.back.market.event;
+
+import com.back.common.market.event.MemberCreatedEvent;
+import com.back.market.adapter.out.MarketUserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Slf4j
+@SpringBootTest
+public class KafkaIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+    @Autowired
+    private MarketUserRepository marketUserRepository;
+
+    @Test
+    void test1() throws InterruptedException {
+        long testId = 101L;
+        MemberCreatedEvent event = new MemberCreatedEvent(
+                testId,
+                "USER",
+                "테스트유저2",
+                "test2@example.com",
+                "서울시 강남구2",
+                "010-1234-5678",
+                "https://dummyimage.com/100x100/000/fff&text=Test2"
+        );
+        kafkaTemplate.send("MemberCreatedEvent", event);
+        log.info("Event sent to Kafka topic: MemberCreatedEvent (id: {})", testId);
+        Thread.sleep(3000);
+        boolean exists = marketUserRepository.existsById(testId);
+        if(exists) {
+            log.info("Data saved successfully. ID: {}", testId);
+        } else {
+            log.error("Data not saved. ID: {}", testId);
+        }
+    }
+
+}

--- a/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
+++ b/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
@@ -28,7 +28,7 @@ public class KafkaIntegrationTest {
                 "010-1234-5678",
                 "https://dummyimage.com/100x100/000/fff&text=Test2"
         );
-        kafkaTemplate.send("UserCreatedEvent", event);
+        kafkaTemplate.send("${custom.kafka.topic.member-created}", event);
         log.info("Event sent to Kafka topic: UserCreatedEvent (id: {})", testId);
         Thread.sleep(3000);
         boolean exists = marketUserRepository.existsById(testId);

--- a/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
+++ b/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
@@ -28,7 +28,7 @@ public class KafkaIntegrationTest {
                 "010-1234-5678",
                 "https://dummyimage.com/100x100/000/fff&text=Test2"
         );
-        kafkaTemplate.send("${custom.kafka.topic.member-created}", event);
+        kafkaTemplate.send("${custom.kafka.topic.user-created}", event);
         log.info("Event sent to Kafka topic: UserCreatedEvent (id: {})", testId);
         Thread.sleep(3000);
         boolean exists = marketUserRepository.existsById(testId);

--- a/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
+++ b/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.back.market.event;
 
-import com.back.common.market.event.MemberCreatedEvent;
+import com.back.common.market.event.UserCreatedEvent;
 import com.back.market.adapter.out.MarketUserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -20,17 +20,16 @@ public class KafkaIntegrationTest {
     @Test
     void test1() throws InterruptedException {
         long testId = 101L;
-        MemberCreatedEvent event = new MemberCreatedEvent(
+        UserCreatedEvent event = new UserCreatedEvent(
                 testId,
-                "USER",
                 "테스트유저2",
                 "test2@example.com",
                 "서울시 강남구2",
                 "010-1234-5678",
                 "https://dummyimage.com/100x100/000/fff&text=Test2"
         );
-        kafkaTemplate.send("MemberCreatedEvent", event);
-        log.info("Event sent to Kafka topic: MemberCreatedEvent (id: {})", testId);
+        kafkaTemplate.send("UserCreatedEvent", event);
+        log.info("Event sent to Kafka topic: UserCreatedEvent (id: {})", testId);
         Thread.sleep(3000);
         boolean exists = marketUserRepository.existsById(testId);
         if(exists) {


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #178 

## 🔎 작업 내용

- 회원가입 이벤트 컨슈머 구현
- marketUser에 불필요한 Role 필드 제거
- 이벤트 실패 시 어떻게 처리할것인지 고도화 필요(일단은 이벤트 성공에 대한 것만 구현하였음)

<br>

## 📷 테스트 결과
- 이벤트 발행 및 복제 처리 테스트
  <br>
  <img width="1002" height="524" alt="image" src="https://github.com/user-attachments/assets/22d92307-c6f8-40ed-93e6-33bc91cdea09" />

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
