### PR TITLE
[FEAT] 구매 확정 api 및 정산 모듈에게 보낼 이벤트 로직 구현 (#182)

### DIFF
--- a/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
@@ -12,4 +12,8 @@ public class KafkaEventPublisher {
     public void publish(EventName event) {
         kafkaTemplate.send(event.getEventName(), event);
     }
+
+    public void publish(String topic, EventName event) {
+        kafkaTemplate.send(topic, event);
+    }
 }

--- a/common/src/main/java/com/back/common/market/event/OrderCompletedEvent.java
+++ b/common/src/main/java/com/back/common/market/event/OrderCompletedEvent.java
@@ -1,0 +1,17 @@
+package com.back.common.market.event;
+
+import com.back.common.event.EventName;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderCompletedEvent (
+        Long orderId,
+        Long productId,
+        Long buyerId,
+        Long sellerId,
+        String sellerName, // 판매자 이름(닉네임)
+        BigDecimal price,
+        LocalDateTime confirmedAt
+) implements EventName {
+}

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -54,4 +54,11 @@ public interface ApiV1Market {
             @AuthenticationPrincipal AuthPrincipal principal,
             @PathVariable Long biddingId
     );
+
+    @Operation(summary = "구매 확정", description = "배송 완료된 주문에 대해 구매 확정을 진행하고 정산 이벤트를 발행한다.")
+    @PatchMapping("/orders/{orderId}/complete")
+    CommonResponse<Void> completeOrder(
+            @AuthenticationPrincipal AuthPrincipal principal,
+             @PathVariable Long orderId
+    );
 }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -90,5 +90,15 @@ public class ApiV1MarketController implements ApiV1Market{
         return CommonResponse.success(SuccessCode.OK, result);
     }
 
+    @Override
+    public CommonResponse<Void> completeOrder(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable Long orderId
+    ) {
+        Long userId = principal.getUserId();
+        marketFacade.completeOrder(userId, orderId);
+        return CommonResponse.success(SuccessCode.OK, null);
+    }
+
 
 }

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -1,17 +1,20 @@
 package com.back.market.app;
 
-import com.back.market.app.usecase.CancelBidUseCase;
-import com.back.market.app.usecase.GetInstantPriceUseCase;
-import com.back.market.app.usecase.MatchInstantTradeUseCase;
-import com.back.market.app.usecase.RegisterBidUseCase;
+import com.back.common.event.KafkaEventPublisher;
+import com.back.common.market.event.OrderCompletedEvent;
+import com.back.market.app.usecase.*;
+import com.back.market.domain.Order;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
 import com.back.market.dto.response.MarketPaymentResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +23,11 @@ public class MarketFacade {
     private final GetInstantPriceUseCase getInstantPriceUseCase;
     private final MatchInstantTradeUseCase matchInstantTradeUseCase;
     private final CancelBidUseCase cancelBidUseCase;
+    private final CompleteOrderUseCase completeOrderUseCase;
+
+    @Value("${custom.kafka.topic.order-completed}")
+    private String orderCompletedTopic;
+    private final KafkaEventPublisher kafkaEventPublisher;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -93,4 +101,24 @@ public class MarketFacade {
         return cancelBidUseCase.cancelBid(userId, biddingId);
     }
 
+    /**
+     * MARKET: 구매 확정 + 정산 모듈에 이벤트 전송
+     * @param userId 사용자ID
+     * @param orderId 주문ID
+     */
+    public void completeOrder(Long userId, Long orderId) {
+
+        Order order = completeOrderUseCase.completeOrder(userId, orderId);
+
+        OrderCompletedEvent event = new OrderCompletedEvent(
+                order.getId(),
+                order.getSellBidding().getMarketProduct().getId(),
+                order.getBuyBidding().getMarketUser().getId(),
+                order.getSellBidding().getMarketUser().getId(),
+                order.getSellBidding().getMarketUser().getNickname(),
+                order.getPrice(),
+                LocalDateTime.now()
+        );
+        kafkaEventPublisher.publish(orderCompletedTopic, event);
+    }
 }

--- a/market/src/main/java/com/back/market/app/usecase/CompleteOrderUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CompleteOrderUseCase.java
@@ -1,0 +1,28 @@
+package com.back.market.app.usecase;
+
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CompleteOrderUseCase {
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public Order completeOrder(Long userId, Long orderId) {
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+
+        if (!order.getBuyBidding().getMarketUser().getId().equals(userId)) {
+            throw new IllegalStateException("구매 확정 권한이 없습니다.");
+        }
+        if(order.getOrderStatus() != OrderStatus.DELIVERY_COMPLETED) {
+            throw new IllegalStateException("배송 완료된 주문만 구매 확정할 수 있습니다.");
+        }
+        order.changeStatus(OrderStatus.COMPLETED);
+        return order;
+    }
+}

--- a/market/src/main/java/com/back/market/domain/enums/OrderStatus.java
+++ b/market/src/main/java/com/back/market/domain/enums/OrderStatus.java
@@ -2,8 +2,11 @@ package com.back.market.domain.enums;
 
 // 주문 상태를 관리하는 Enum
 public enum OrderStatus {
-    HOLD,       // 결제 대기 (낙찰 직후)
-    PAID,       // 결제 완료 (거래 성사)
-    CANCELLED,   // 주문 취소
-    COMPLETED   // 구매 확정(정산 가능)
+    HOLD,        // 결제 대기 (낙찰 직후)
+    PAID,        // 결제 완료 (거래 성사)
+    CANCELLED,   // 주문 취소(결제 후, 배송 전까지만 가능)
+    DELIVERY_PROCESSING,    // 배송중
+    DELIVERY_COMPLETED, // 배송 완료(환불 요청은 배송 완료일로부터 일주일까지 가능)
+    REFUNDED, // 주문 환불(배송중~배송완료 후 1주까지는 환불가능)
+    COMPLETED    // 구매 확정(정산 가능)
 }

--- a/market/src/test/java/com/back/market/event/OrderCompleteEventTest.java
+++ b/market/src/test/java/com/back/market/event/OrderCompleteEventTest.java
@@ -1,0 +1,78 @@
+package com.back.market.event;
+
+import com.back.common.event.KafkaEventPublisher;
+import com.back.common.market.event.OrderCompletedEvent;
+import com.back.market.app.MarketFacade;
+import com.back.market.app.usecase.CompleteOrderUseCase;
+import com.back.market.domain.Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderCompleteEventTest {
+    @Mock
+    private CompleteOrderUseCase completeOrderUseCase;
+
+    @Mock
+    private KafkaEventPublisher kafkaEventPublisher;
+
+    @InjectMocks
+    private MarketFacade marketFacade;
+
+    @BeforeEach
+    void setUp() {
+        // marketFacade 객체의 "orderCompletedTopic" 필드에 "order-confirmed-topic" 값을 직접 주입합니다.
+        ReflectionTestUtils.setField(marketFacade, "orderCompletedTopic", "order-completed");
+    }
+
+    @Test
+    @DisplayName("구매 확정 성공 시 정산 이벤트가 발행되어야 한다")
+    void completeOrder_success_and_publish_event() {
+        // given
+        Long userId = 1L;
+        Long orderId = 100L;
+        // Mock Order 객체 생성 (빌더 사용)
+        Order mockOrder = createMockOrder(orderId, userId);
+
+        given(completeOrderUseCase.completeOrder(userId, orderId)).willReturn(mockOrder);
+
+        // when
+        marketFacade.completeOrder(userId, orderId);
+
+        // then
+        // 1. 유스케이스가 정상 호출되었는지 확인
+        verify(completeOrderUseCase, times(1)).completeOrder(userId, orderId);
+
+        // 2. 카프카 퍼블리셔가 '특정 토픽'과 '이벤트'를 가지고 호출되었는지 확인
+        verify(kafkaEventPublisher, times(1)).publish(anyString(), any(OrderCompletedEvent.class));
+    }
+    /**
+     * 테스트용 가짜 Order 객체를 생성하는 헬퍼 메서드
+     */
+    private Order createMockOrder(Long orderId, Long buyerId) {
+        // Order 엔티티 내부의 연관관계(Bidding)까지 가짜로 만들어줍니다.
+        return Order.builder()
+                .id(orderId)
+                .price(new java.math.BigDecimal("50000"))
+                .buyBidding(com.back.market.domain.Bidding.builder()
+                        .marketUser(com.back.market.domain.MarketUser.builder().id(buyerId).build())
+                        .build())
+                .sellBidding(com.back.market.domain.Bidding.builder()
+                        .marketUser(com.back.market.domain.MarketUser.builder().id(999L).nickname("판매자").build())
+                        .marketProduct(com.back.market.domain.MarketProduct.builder().id(500L).build())
+                        .build())
+                .build();
+    }
+}

--- a/market/src/test/java/com/back/market/event/OrderCompletedIntegrationTests.java
+++ b/market/src/test/java/com/back/market/event/OrderCompletedIntegrationTests.java
@@ -1,0 +1,102 @@
+package com.back.market.event;
+
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.app.MarketFacade;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.domain.enums.OrderStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class OrderCompletedIntegrationTests {
+
+    @Autowired
+    private MarketFacade marketFacade;
+    @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
+    private MarketUserRepository marketUserRepository;
+    @Autowired
+    private MarketProductRepository marketProductRepository;
+    @Autowired
+    private BiddingRepository biddingRepository; // 연관 관계 저장을 위해 주입
+
+    @Test
+    @DisplayName("통합 테스트: 구매 확정 시 DB 상태가 변경되고 실제 Kafka로 이벤트가 발행되어야 한다")
+    void completeOrder_RealInfrastructure_Success() throws InterruptedException {
+        // 1. 기초 데이터 저장 (User)
+        MarketUser buyer = marketUserRepository.save(MarketUser.builder()
+                .id(101L).nickname("통합구매자").email("buyer@test.com").build());
+        MarketUser seller = marketUserRepository.save(MarketUser.builder()
+                .id(111L).nickname("통합판매자").email("seller@test.com").build());
+
+        // 2. 기초 데이터 저장 (MarketProduct - 필수 필드 모두 입력)
+        MarketProduct product = marketProductRepository.save(MarketProduct.builder()
+                .id(500L)
+                .name("조던 1 레트로 하이")
+                .productNumber("DZ5485-612")
+                .productOption("270")
+                .brandName("Nike")
+                .categoryName("Sneakers")
+                .releasePrice(new BigDecimal("200000"))
+                .thumbnailImage("image_url")
+                .build());
+
+        // 3. Bidding 저장 (TransientPropertyValueException 방지)
+        // 반드시 repository.save()를 호출하여 DB에 먼저 넣어야 합니다.
+        Bidding buyBid = biddingRepository.save(Bidding.builder()
+                .marketUser(buyer)
+                .marketProduct(product)
+                .price(new BigDecimal("50000"))
+                .position(BiddingPosition.BUY)
+                .status(BiddingStatus.PROCESS)
+                .build());
+
+        Bidding sellBid = biddingRepository.save(Bidding.builder()
+                .marketUser(seller)
+                .marketProduct(product)
+                .price(new BigDecimal("50000"))
+                .position(BiddingPosition.SELL)
+                .status(BiddingStatus.PROCESS)
+                .build());
+
+        // 4. 저장된 Bidding 객체를 사용하여 Order 생성
+        Order order = orderRepository.save(Order.builder()
+                .buyBidding(buyBid)
+                .sellBidding(sellBid)
+                .orderStatus(OrderStatus.DELIVERY_COMPLETED) // 확정 가능 상태
+                .price(new BigDecimal("50000"))
+                .address("서울시 강남구 테헤란로 123")
+                .requestPaymentDate(java.time.LocalDateTime.now())
+                .build());
+
+        // 5. 실행
+        marketFacade.completeOrder(buyer.getId(), order.getId());
+
+        // 6. 검증: DB 상태 변경 확인
+        Order updatedOrder = orderRepository.findById(order.getId()).orElseThrow();
+        assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.COMPLETED);
+
+        log.info("통합 테스트 성공: 주문상태={}", updatedOrder.getOrderStatus());
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #182 

## 🔎 작업 내용

- 구매 확정 api 구현
- 정산 모듈에게 구매 확정인 주문만 kafka event로 전송

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - 정산 모듈에게 보내는 내용이 정확한지 체크 부탁드립니다.
    - 추후에 정산 모듈에서 event consumer 구현하실 때 common 모듈 - market.event - `OrderCompletedEvent.java` 사용해주시면 됩니다.

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 테스트 결과
  <img width="414" height="310" alt="image" src="https://github.com/user-attachments/assets/c89874f8-54cf-4b38-9b46-d3412e47a19d" />

- 통합 테스트 결과
  <img width="1017" height="574" alt="image" src="https://github.com/user-attachments/assets/fcddb33a-d4d4-4706-a317-05eb4ecfb02c" />

<img width="598" height="287" alt="image" src="https://github.com/user-attachments/assets/2ff90ba6-6788-4f68-b5d4-e117c41f3053" />

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
