### PR TITLE
[FEAT] 상품 다중 조회 API 기능 구현 (#193)

### DIFF
--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductQueryController.java
@@ -25,8 +25,8 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     }
 
     @Override
-    @GetMapping
-    public CommonResponse<ProductSearchListResponseDto> getProductList(
+    @GetMapping(params = "keyword")
+    public CommonResponse<ProductSearchListResponseDto> searchProducts(
        @ModelAttribute @Valid ProductSearchRequestDto request,
        @RequestParam(defaultValue = "0") Long page,
        @RequestParam(defaultValue = "10") Long size

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductQueryController.java
@@ -3,7 +3,9 @@ package com.back.product.adapter.in;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.app.ProductFacade;
+import com.back.product.dto.request.ProductQueryRequestDto;
 import com.back.product.dto.request.ProductSearchRequestDto;
+import com.back.product.dto.response.ProductListResponseDto;
 import com.back.product.dto.response.ProductResponseDto;
 import com.back.product.dto.response.ProductSearchListResponseDto;
 import jakarta.validation.Valid;
@@ -32,6 +34,13 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
        @RequestParam(defaultValue = "10") Long size
      ) {
         ProductSearchListResponseDto response = productFacade.findProductPage(request, page, size);
+        return CommonResponse.success(SuccessCode.OK, response);
+    }
+
+    @Override
+    @GetMapping(params = "productIds")
+    public CommonResponse<ProductListResponseDto> getProducts(@Valid @ModelAttribute ProductQueryRequestDto request) {
+        ProductListResponseDto response = productFacade.getProducts(request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
 }

--- a/product/src/main/java/com/back/product/adapter/in/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ApiV1ProductQueryController.java
@@ -27,7 +27,7 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     }
 
     @Override
-    @GetMapping(params = "keyword")
+    @GetMapping
     public CommonResponse<ProductSearchListResponseDto> searchProducts(
        @ModelAttribute @Valid ProductSearchRequestDto request,
        @RequestParam(defaultValue = "0") Long page,
@@ -38,7 +38,7 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     }
 
     @Override
-    @GetMapping(params = "productIds")
+    @GetMapping("/variants")
     public CommonResponse<ProductListResponseDto> getProducts(@Valid @ModelAttribute ProductQueryRequestDto request) {
         ProductListResponseDto response = productFacade.getProducts(request);
         return CommonResponse.success(SuccessCode.OK, response);

--- a/product/src/main/java/com/back/product/adapter/in/ProductQueryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductQueryApiController.java
@@ -32,5 +32,5 @@ public interface ProductQueryApiController {
     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> getProductList(ProductSearchRequestDto request, Long page, Long size);
+    CommonResponse<?> searchProducts(ProductSearchRequestDto request, Long page, Long size);
 }

--- a/product/src/main/java/com/back/product/adapter/in/ProductQueryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/ProductQueryApiController.java
@@ -1,6 +1,7 @@
 package com.back.product.adapter.in;
 
 import com.back.common.response.CommonResponse;
+import com.back.product.dto.request.ProductQueryRequestDto;
 import com.back.product.dto.request.ProductSearchRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -33,4 +34,16 @@ public interface ProductQueryApiController {
     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> searchProducts(ProductSearchRequestDto request, Long page, Long size);
+
+    @Operation(summary = "단일 항목 상품 다중 조회", description = """
+            단일 항목 상품의 정보를 다중 조회합니다.
+            한 상품의 기본 정보(ProductInfo)를 포함한 단일 상품의 정보를 조회합니다.
+            요청 시, 상품의 ID를 리스트로 받아 다중 조회 처리합니다.
+            ex. 상품의 기본 정보 + 재고 + 옵션 (사이즈 + 색상 + ...) + ... 
+    """)
+    @ApiResponse(responseCode = "200", description = "단일 항목 상품 다중 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> getProducts(ProductQueryRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/out/ProductRepository.java
+++ b/product/src/main/java/com/back/product/adapter/out/ProductRepository.java
@@ -2,10 +2,14 @@ package com.back.product.adapter.out;
 
 import com.back.product.domain.Product;
 import com.back.product.domain.ProductInfo;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByProductInfo(ProductInfo productInfo);
+
+    @EntityGraph(attributePaths = {"productInfo"})
+    List<Product> findAllById(Iterable<Long> ids);
 }

--- a/product/src/main/java/com/back/product/app/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/ProductFacade.java
@@ -6,6 +6,7 @@ import com.back.product.app.usecase.*;
 import com.back.product.domain.*;
 import com.back.product.dto.CategoryDto;
 import com.back.product.dto.ProductDto;
+import com.back.product.dto.ProductInfoDto;
 import com.back.product.dto.request.*;
 import com.back.product.dto.BrandDto;
 import com.back.product.dto.response.*;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -83,6 +85,11 @@ public class ProductFacade {
         }
 
         categoryUseCase.deleteCategory(categoryId);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductListResponseDto getProducts(@Valid ProductQueryRequestDto request) {
+        return productUseCase.findMultipleProduct(request.productIds());
     }
 
     @Transactional

--- a/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductSupport.java
@@ -135,4 +135,9 @@ public class ProductSupport {
     public Boolean existsProductByOptionValueId(Long optionValueId) {
         return productOptionValuesRepository.existsByOptionValue_Id(optionValueId);
     }
+
+    @Transactional(readOnly = true)
+    public List<Product> findMultipleProductByIds(List<Long> productIds) {
+        return productRepository.findAllById(productIds);
+    }
 }

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -234,7 +234,7 @@ public class ProductUseCase {
         List<Product> products = productSupport.findMultipleProductByIds(productIds);
 
         if (!isSameSize(products, productIds)) {
-            throw new CustomException(FailureCode.PRODUCT_NOT_FOUND);
+            throw new CustomException(FailureCode.ENTITY_NOT_FOUND);
         }
 
         List<ProductImage> productImages = productSupport.getAllProductImagesByProductsIn(products);

--- a/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/ProductUseCase.java
@@ -7,23 +7,29 @@ import com.back.product.adapter.out.ProductOptionValuesRepository;
 import com.back.product.adapter.out.ProductRepository;
 import com.back.product.domain.*;
 import com.back.product.dto.ProductDto;
+import com.back.product.dto.ProductInfoDto;
 import com.back.product.dto.request.ProductVariantCreateRequestDto;
 import com.back.product.dto.request.ProductVariantUpdateRequestDto;
-import com.back.product.mapper.ProductImageMapper;
-import com.back.product.mapper.ProductMapper;
-import com.back.product.mapper.ProductOptionValuesMapper;
+import com.back.product.dto.response.ProductListResponseDto;
+import com.back.product.dto.response.ProductResponseDto;
+import com.back.product.mapper.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 public class ProductUseCase {
     private final ProductMapper productMapper;
     private final ProductImageMapper productImageMapper;
+    private final ProductInfoMapper productInfoMapper;
     private final ProductOptionValuesMapper productOptionValuesMapper;
     private final ProductRepository productRepository;
     private final ProductOptionValuesRepository productOptionValuesRepository;
@@ -55,7 +61,7 @@ public class ProductUseCase {
         List<ProductOptionValues> newProductOptionValues = productOptionValuesRepository.saveAll(createdProductOptionValues);
         List<ProductImage> newProductImages = productImageRepository.saveAll(createdImages);
 
-        return convertToDto(newProducts, newProductOptionValues, newProductImages);
+        return buildProductDto(newProducts, newProductOptionValues, newProductImages);
     }
 
     @Transactional
@@ -91,7 +97,7 @@ public class ProductUseCase {
         List<ProductOptionValues> productOptionValues = productSupport.getAllProductOptionValuesByProductsIn(products);
         List<ProductImage> productImages = productSupport.getAllProductImagesByProductsIn(products);
 
-        return convertToDto(products, productOptionValues, productImages);
+        return buildProductDto(products, productOptionValues, productImages);
     }
 
     private void handleCreations(ProductInfo productInfo, List<ProductVariantUpdateRequestDto> variantsToCreate, Map<Long, OptionValue> optionValueMap) {
@@ -194,7 +200,7 @@ public class ProductUseCase {
         ).toList();
     }
 
-    private List<ProductDto> convertToDto(
+    private List<ProductDto> buildProductDto(
             List<Product> products,
             List<ProductOptionValues> productOptionValues,
             List<ProductImage> productImages
@@ -221,5 +227,48 @@ public class ProductUseCase {
     @Transactional
     public Boolean isOptionValueInUse(Long optionValueId) {
         return productSupport.existsProductByOptionValueId(optionValueId);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductListResponseDto findMultipleProduct(List<Long> productIds) {
+        List<Product> products = productSupport.findMultipleProductByIds(productIds);
+
+        if (!isSameSize(products, productIds)) {
+            throw new CustomException(FailureCode.PRODUCT_NOT_FOUND);
+        }
+
+        List<ProductImage> productImages = productSupport.getAllProductImagesByProductsIn(products);
+        List<ProductOptionValues> productOptions = productSupport.getAllProductOptionValuesByProductsIn(products);
+
+        return buildProductResponseDto(products, productOptions, productImages);
+    }
+
+    private ProductListResponseDto buildProductResponseDto(List<Product> products, List<ProductOptionValues> options, List<ProductImage> images) {
+        Map<Product, List<ProductImage>> imagesByProduct = images.stream()
+                .collect(Collectors.groupingBy(ProductImage::getProduct));
+
+        Map<Product, List<ProductOptionValues>> optionsByProduct = options.stream()
+                .collect(Collectors.groupingBy(ProductOptionValues::getProduct));;
+
+        Map<ProductInfo, List<Product>> productsByInfo = products.stream()
+                .collect(Collectors.groupingBy(Product::getProductInfo));
+
+        List<ProductResponseDto> productResponseDtos = productsByInfo.entrySet().stream().map(entry -> {
+            ProductInfoDto productInfoDto = productInfoMapper.toDto(entry.getKey());
+
+            List<ProductDto> productDtos = entry.getValue().stream().map(product -> productMapper.toDto(
+                    product,
+                    optionsByProduct.getOrDefault(product, Collections.emptyList()),
+                    imagesByProduct.getOrDefault(product, Collections.emptyList())
+            )).toList();
+
+            return ProductResponseDto.builder().productInfo(productInfoDto).products(productDtos).build();
+        }).toList();
+
+        return ProductListResponseDto.builder().products(productResponseDtos).build();
+    }
+
+    private Boolean isSameSize(List<?> list1, List<?> list2) {
+        return list1.size() == list2.size();
     }
 }

--- a/product/src/main/java/com/back/product/dto/request/ProductQueryRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductQueryRequestDto.java
@@ -1,0 +1,16 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductQueryRequestDto(
+        @NotEmpty(message = "Product IDs cannot be empty")
+        @Valid
+        List<@Min(value = 1, message = "Product ID must be Integer") Long> productIds
+) {
+}

--- a/product/src/main/java/com/back/product/dto/response/ProductListResponseDto.java
+++ b/product/src/main/java/com/back/product/dto/response/ProductListResponseDto.java
@@ -1,0 +1,11 @@
+package com.back.product.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductListResponseDto(
+        List<ProductResponseDto> products
+) {
+}

--- a/product/src/main/java/com/back/product/mapper/ProductMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductMapper.java
@@ -6,8 +6,6 @@ import com.back.product.domain.ProductInfo;
 import com.back.product.domain.ProductOptionValues;
 import com.back.product.dto.ProductDto;
 import com.back.product.dto.ProductOptionDto;
-import com.back.product.dto.request.ProductVariantCreateRequestDto;
-import com.back.product.dto.request.ProductVariantUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
@@ -4,7 +4,9 @@ import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.product.app.ProductFacade;
 import com.back.product.dto.enums.ProductSortType;
+import com.back.product.dto.request.ProductQueryRequestDto;
 import com.back.product.dto.request.ProductSearchRequestDto;
+import com.back.product.dto.response.ProductListResponseDto;
 import com.back.product.dto.response.ProductResponseDto;
 import com.back.product.dto.response.ProductSearchListResponseDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
@@ -18,11 +20,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.BDDMockito.*;
@@ -30,8 +37,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ApiV1ProductQueryController.class)
 @DisplayName("ApiV1ProductQueryController 테스트")
@@ -155,6 +161,123 @@ class ApiV1ProductQueryControllerTest {
                     .andExpect(status().isBadRequest());
 
             verify(productFacade, never()).findProductPage(any(), anyLong(), anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/products/variants")
+    class GetProductsTest {
+
+        @Test
+        @DisplayName("유효한 상품 ID 리스트로 상품 목록 조회를 성공한다")
+        void getProducts_Success() throws Exception {
+            // given
+            List<ProductResponseDto> products = Arrays.asList(
+                    ProductResponseDto.builder()
+                            .productInfo(com.back.product.dto.ProductInfoDto.builder()
+                                    .productInfoId(1L)
+                                    .name("Test Product 1")
+                                    .brand(com.back.product.dto.BrandDto.builder().name("Brand 1").build())
+                                    .category(com.back.product.dto.CategoryDto.builder().name("category1").build())
+                                    .releasePrice(BigDecimal.valueOf(10000))
+                                    .build())
+                            .products(List.of(com.back.product.dto.ProductDto.builder()
+                                    .productId(1L)
+                                    .inventory(10L)
+                                    .imageUrls(List.of("image1.jpg"))
+                                    .options(List.of(
+                                            com.back.product.dto.ProductOptionDto.builder().groupName("size").value("M").build(),
+                                            com.back.product.dto.ProductOptionDto.builder().groupName("color").value("red").build()
+                                    ))
+                                    .build()))
+                            .build(),
+                    ProductResponseDto.builder()
+                            .productInfo(com.back.product.dto.ProductInfoDto.builder()
+                                    .productInfoId(2L)
+                                    .name("Test Product 2")
+                                    .brand(com.back.product.dto.BrandDto.builder().name("Brand 2").build())
+                                    .category(com.back.product.dto.CategoryDto.builder().name("category2").build())
+                                    .releasePrice(BigDecimal.valueOf(20000))
+                                    .build())
+                            .products(List.of(com.back.product.dto.ProductDto.builder()
+                                    .productId(2L)
+                                    .inventory(20L)
+                                    .imageUrls(List.of("image2.jpg"))
+                                    .options(List.of(
+                                            com.back.product.dto.ProductOptionDto.builder().groupName("size").value("L").build(),
+                                            com.back.product.dto.ProductOptionDto.builder().groupName("color").value("blue").build()
+                                    ))
+                                    .build()))
+                            .build(),
+                    ProductResponseDto.builder()
+                            .productInfo(com.back.product.dto.ProductInfoDto.builder()
+                                    .productInfoId(3L)
+                                    .name("Test Product 3")
+                                    .brand(com.back.product.dto.BrandDto.builder().name("Brand 3").build())
+                                    .category(com.back.product.dto.CategoryDto.builder().name("category3").build())
+                                    .releasePrice(BigDecimal.valueOf(30000))
+                                    .build())
+                            .products(List.of(com.back.product.dto.ProductDto.builder()
+                                    .productId(3L)
+                                    .inventory(30L)
+                                    .imageUrls(List.of("image3.jpg"))
+                                    .options(List.of(
+                                            com.back.product.dto.ProductOptionDto.builder().groupName("size").value("S").build(),
+                                            com.back.product.dto.ProductOptionDto.builder().groupName("color").value("green").build()
+                                    ))
+                                    .build()))
+                            .build()
+            );
+            ProductListResponseDto responseDto = ProductListResponseDto.builder().products(products).build();
+
+            given(productFacade.getProducts(any(ProductQueryRequestDto.class))).willReturn(responseDto);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/products/variants")
+                            .param("productIds", "1")
+                            .param("productIds", "2")
+                            .param("productIds", "3")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value("OK"))
+                    .andExpect(jsonPath("$.data.products.length()").value(products.size()))
+                    .andExpect(jsonPath("$.data.products[0].products[0].productId").value(1L))
+                    .andExpect(jsonPath("$.data.products[0].productInfo.name").value("Test Product 1"))
+                    .andDo(print());
+
+            verify(productFacade).getProducts(any(ProductQueryRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 ID 리스트가 비어있을 때 Bad Request을 반환한다")
+        void getProducts_Failed_Enable_Values() throws Exception {
+            // given & when & then
+            mockMvc.perform(get("/api/v1/products/variants")
+                            .param("productIds", "")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andDo(print());
+
+            verify(productFacade, never()).getProducts(any(ProductQueryRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("상품 ID 리스트 중 하나라도 값을 찾지 못하면 PRODUCT_NOT_FOUND 에러를 반환한다.")
+        void getProducts_Failed_Not_Found_Product() throws Exception {
+            // given
+            given(productFacade.getProducts(any(ProductQueryRequestDto.class)))
+                    .willThrow(new CustomException(FailureCode.ENTITY_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/products/variants")
+                            .param("productIds", "1", "999") // 999 is a non-existent product ID
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(FailureCode.ENTITY_NOT_FOUND.name()))
+                    .andDo(print());
+
+            verify(productFacade).getProducts(any(ProductQueryRequestDto.class));
         }
     }
 }

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
@@ -99,12 +99,12 @@ class ApiV1ProductQueryControllerTest {
 
     @Nested
     @DisplayName("GET /api/v1/products")
-    class GetProductListTest {
+    class SearchProductsTest {
 
         @Test
         @DisplayName("상품 목록 조회 및 검색을 성공한다")
         @WithMockUser
-        void getProductList_Success() throws Exception {
+        void searchProducts_Success() throws Exception {
             // given
             ProductSearchResponseDto productSearchResponseDto = ProductSearchResponseDto.builder()
                     .productInfoId(1L)
@@ -144,7 +144,7 @@ class ApiV1ProductQueryControllerTest {
         @Test
         @DisplayName("잘못된 정렬 조건으로 조회 시 400 Bad Request를 반환한다")
         @WithMockUser
-        void getProductList_Fail_InvalidSort() throws Exception {
+        void searchProducts_Fail_InvalidSort() throws Exception {
             // when & then
             mockMvc.perform(
                             get("/api/v1/products")

--- a/product/src/test/java/com/back/product/app/usecase/ProductUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductUseCaseTest.java
@@ -59,6 +59,9 @@ class ProductUseCaseTest {
     @Mock
     private ProductSupport productSupport; // Though not used in create, good to have for other methods
 
+    @Mock
+    private com.back.product.mapper.ProductInfoMapper productInfoMapper;
+
     private ProductInfo productInfo;
     private OptionValue optionValue1, optionValue2;
 
@@ -286,6 +289,75 @@ class ProductUseCaseTest {
             verify(productSupport).getAllProductsByProductInfo(productInfo);
             verify(productSupport, never()).getAllProductOptionValuesByProductsIn(any());
             verify(productSupport, never()).getAllProductImagesByProductsIn(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("findMultipleProduct 메서드")
+    class FindMultipleProductTest {
+
+        @Test
+        @DisplayName("성공: 여러 상품 ID로 조회하여 ProductListResponseDto를 반환한다")
+        void findMultipleProduct_Success() {
+            // given
+            List<Long> productIds = List.of(1L, 2L);
+            Product product1 = Product.builder().id(1L).productInfo(productInfo).inventory(10L).build();
+            Product product2 = Product.builder().id(2L).productInfo(productInfo).inventory(20L).build();
+            List<Product> foundProducts = List.of(product1, product2);
+
+            com.back.product.domain.ProductImage image1 = com.back.product.domain.ProductImage.builder().product(product1).imageUrl("img1.jpg").build();
+            ProductOptionValues option1 = ProductOptionValues.builder().product(product1).optionValue(optionValue1).build();
+
+            given(productSupport.findMultipleProductByIds(productIds)).willReturn(foundProducts);
+            given(productSupport.getAllProductImagesByProductsIn(foundProducts)).willReturn(List.of(image1));
+            given(productSupport.getAllProductOptionValuesByProductsIn(foundProducts)).willReturn(List.of(option1));
+
+            com.back.product.dto.ProductInfoDto productInfoDto = com.back.product.dto.ProductInfoDto.builder().productInfoId(productInfo.getId()).name(productInfo.getName()).build();
+            given(productInfoMapper.toDto(productInfo)).willReturn(productInfoDto);
+
+            com.back.product.dto.ProductDto productDto1 = com.back.product.dto.ProductDto.builder().productId(1L).build();
+            com.back.product.dto.ProductDto productDto2 = com.back.product.dto.ProductDto.builder().productId(2L).build();
+            given(productMapper.toDto(org.mockito.ArgumentMatchers.eq(product1), any(), any())).willReturn(productDto1);
+            given(productMapper.toDto(org.mockito.ArgumentMatchers.eq(product2), any(), any())).willReturn(productDto2);
+
+            // when
+            com.back.product.dto.response.ProductListResponseDto result = productUseCase.findMultipleProduct(productIds);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.products()).hasSize(1);
+            com.back.product.dto.response.ProductResponseDto productResponse = result.products().get(0);
+            assertThat(productResponse.productInfo()).isEqualTo(productInfoDto);
+            assertThat(productResponse.products()).containsExactlyInAnyOrder(productDto1, productDto2);
+
+            verify(productSupport).findMultipleProductByIds(productIds);
+            verify(productSupport).getAllProductImagesByProductsIn(foundProducts);
+            verify(productSupport).getAllProductOptionValuesByProductsIn(foundProducts);
+            verify(productInfoMapper).toDto(productInfo);
+            verify(productMapper, times(2)).toDto(any(Product.class), any(), any());
+        }
+
+        @Test
+        @DisplayName("실패: 요청한 ID와 다른 수의 상품이 조회되면 예외를 발생시킨다")
+        void findMultipleProduct_Fail_NotFound() {
+            // given
+            List<Long> productIds = List.of(1L, 999L);
+            Product product1 = Product.builder().id(1L).productInfo(productInfo).build();
+            List<Product> foundProducts = List.of(product1); // Only one found
+
+            given(productSupport.findMultipleProductByIds(productIds)).willReturn(foundProducts);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    productUseCase.findMultipleProduct(productIds)
+            );
+            assertThat(exception.getFailureCode()).isEqualTo(FailureCode.ENTITY_NOT_FOUND);
+
+            verify(productSupport).findMultipleProductByIds(productIds);
+            verify(productSupport, never()).getAllProductImagesByProductsIn(any());
+            verify(productSupport, never()).getAllProductOptionValuesByProductsIn(any());
+            verify(productInfoMapper, never()).toDto(any());
+            verify(productMapper, never()).toDto(any(), any(), any());
         }
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #193 

## 🔎 작업 내용

- 단일 항목 상품 다중 조회 API 기능 구현 (`GET /api/v1/products/variants?productIds=[1,2,3,...]`)
    - 상품의 기본 정보(`ProductInfo`)와 함께 재고, 옵션 등 상세 정보를 조회하는 기능을 구현했습니다.
- 단위 테스트 코드 구현
    - 단일 항목 상품 다중 조회 API에 대한 Controller 단위 테스트를 구현했습니다.
    - 관련 UseCase에 대한 단위 테스트를 구현했습니다.

<br>

## 📷 테스트 결과
- Controller 단위 테스트
  <img width="628" height="155" alt="image" src="https://github.com/user-attachments/assets/6012da08-f618-4e8c-b074-b42a125e4b9e" />


- UseCase 단위 테스트
  <img width="516" height="131" alt="image" src="https://github.com/user-attachments/assets/76d92d13-64a6-4d56-b2ef-8c5ffb43842e" />

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수