### PR TITLE
[REFACTOR] MarketSupport 클래스에 조회 메서드 모아두기 (#246)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/out/cash/MarketCashAdapter.java
+++ b/market/src/main/java/com/back/market/adapter/out/cash/MarketCashAdapter.java
@@ -1,0 +1,64 @@
+package com.back.market.adapter.out.cash;
+
+import com.back.common.code.FailureCode;
+import com.back.common.code.SuccessCode;
+import com.back.common.exception.BadRequestException;
+import com.back.common.response.CommonResponse;
+import com.back.common.dto.cash.request.PayAndHoldRequestDto;
+import com.back.common.dto.cash.request.PaymentCancelRequestDto;
+import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.common.dto.cash.response.PaymentCancelResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarketCashAdapter {
+    private final CashClient cashClient;
+
+    public PayAndHoldResponseDto getPayAndHoldResult(PayAndHoldRequestDto paymentReq) {
+        CommonResponse<PayAndHoldResponseDto> response = cashClient.requestBidHold(paymentReq);
+
+        boolean isSuccess = response != null && SuccessCode.OK.getCode().equals(response.getCode());
+
+        if (!isSuccess) {
+            // 응답이 아예 없거나 실패한 경우
+            if (response != null) {
+
+                if (FailureCode.WALLET_CHARGE_FAILED.getCode().equals(response.getCode())) {
+                    throw new BadRequestException(FailureCode.WALLET_CHARGE_FAILED);
+                }
+                // 그 외 실패 사유
+                log.error("[MarketSupport] Cash 모듈 에러 - Code: {}, Msg: {}", response.getCode(), response.getMessage());
+            } else {
+                log.error("[MarketSupport] Cash 모듈 응답 없음 (Null)");
+            }
+            // 공통 에러 던지기
+            throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+        }
+        return response.getData();
+    }
+
+    public PaymentCancelResponseDto refundBidPayment(PaymentCancelRequestDto refundRequest) {
+        // 1. 요청 전송
+        CommonResponse<PaymentCancelResponseDto> response = cashClient.refundBidHold(refundRequest);
+
+        // 2. 응답 검증
+        boolean isSuccess = response != null && SuccessCode.OK.getCode().equals(response.getCode());
+
+        if (!isSuccess) {
+            String msg = (response != null) ? response.getMessage() : "No Response";
+            log.error("[MarketSupport] 환불 요청 실패 - User: {}, Reason: {}", refundRequest.userId(), msg);
+
+            // 환불 실패 시 예외를 던져 트랜잭션 롤백 유도
+            throw new BadRequestException(FailureCode.WALLET_REFUND_FAILED);
+        }
+
+        log.info("[MarketSupport] 환불 성공: {}, RelId: {}", (response.getMessage() != null ? response.getMessage() : "OK"), refundRequest.relId());
+
+        // 3. 데이터 반환 (.getData() 사용)
+        return response.getData();
+    }
+}

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -46,7 +46,7 @@ public class MarketSupport {
      */
     public Order findOrderById(Long orderId) {
         return orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+                .orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
     }
 
     /**

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -1,65 +1,116 @@
 package com.back.market.app;
 
-import com.back.common.code.FailureCode;
-import com.back.common.code.SuccessCode;
-import com.back.common.exception.BadRequestException;
-import com.back.common.response.CommonResponse;
-import com.back.market.adapter.out.cash.CashClient;
-import com.back.common.dto.cash.request.PayAndHoldRequestDto;
-import com.back.common.dto.cash.request.PaymentCancelRequestDto;
-import com.back.common.dto.cash.response.PayAndHoldResponseDto;
-import com.back.common.dto.cash.response.PaymentCancelResponseDto;
+import com.back.market.adapter.out.*;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
+import com.back.market.domain.MarketUser;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-@Slf4j
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * repository에 있는 조회 메서드들을 관리하는 클래스
+ */
 @Component
 @RequiredArgsConstructor
 public class MarketSupport {
-    private final CashClient cashClient;
+    private final MarketUserRepository marketUserRepository;
+    private final BiddingRepository biddingRepository;
+    private final OrderRepository orderRepository;
+    private final CartRepository cartRepository;
+    private final MarketProductRepository marketProductRepository;
 
-    public PayAndHoldResponseDto getPayAndHoldResult(PayAndHoldRequestDto paymentReq) {
-        CommonResponse<PayAndHoldResponseDto> response = cashClient.requestBidHold(paymentReq);
-
-        boolean isSuccess = response != null && SuccessCode.OK.getCode().equals(response.getCode());
-
-        if (!isSuccess) {
-            // 응답이 아예 없거나 실패한 경우
-            if (response != null) {
-
-                if (FailureCode.WALLET_CHARGE_FAILED.getCode().equals(response.getCode())) {
-                    throw new BadRequestException(FailureCode.WALLET_CHARGE_FAILED);
-                }
-                // 그 외 실패 사유
-                log.error("[MarketSupport] Cash 모듈 에러 - Code: {}, Msg: {}", response.getCode(), response.getMessage());
-            } else {
-                log.error("[MarketSupport] Cash 모듈 응답 없음 (Null)");
-            }
-            // 공통 에러 던지기
-            throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
-        }
-        return response.getData();
+    /**
+     * Bidding 엔티티 조회
+     * @param biddingId PK
+     * @return Bidding
+     */
+    public Optional<Bidding> findBiddingById(Long biddingId) {
+        return biddingRepository.findById(biddingId);
     }
 
-    public PaymentCancelResponseDto refundBidPayment(PaymentCancelRequestDto refundRequest) {
-        // 1. 요청 전송
-        CommonResponse<PaymentCancelResponseDto> response = cashClient.refundBidHold(refundRequest);
+    /**
+     * Order 엔티티 조회
+     * @param orderId PK
+     * @return Order
+     */
+    public Optional<Order> findOrderById(Long orderId) {
+        return orderRepository.findById(orderId);
+    }
 
-        // 2. 응답 검증
-        boolean isSuccess = response != null && SuccessCode.OK.getCode().equals(response.getCode());
+    /**
+     * MarketUser의 Cart 존재 여부 확인
+     * @param user MarketUser
+     * @return boolean
+     */
+    public boolean existsCartByMarketUser(MarketUser user) {
+        return cartRepository.existsByMarketUser(user);
+    }
 
-        if (!isSuccess) {
-            String msg = (response != null) ? response.getMessage() : "No Response";
-            log.error("[MarketSupport] 환불 요청 실패 - User: {}, Reason: {}", refundRequest.userId(), msg);
+    /**
+     * MarketUser 엔티티 조회
+     * @param userId PK
+     * @return MarketUser
+     */
+    public Optional<MarketUser> findMarketUserById(Long userId) {
+        return marketUserRepository.findById(userId);
+    }
 
-            // 환불 실패 시 예외를 던져 트랜잭션 롤백 유도
-            throw new BadRequestException(FailureCode.WALLET_REFUND_FAILED);
-        }
+    /**
+     * MarketProduct 존재 여부 확인
+     * @param productId PK
+     * @return boolean
+     */
+    public boolean existsByMarketProduct(Long productId) {
+        return marketProductRepository.existsById(productId);
+    }
 
-        log.info("[MarketSupport] 환불 성공: {}, RelId: {}", (response.getMessage() != null ? response.getMessage() : "OK"), refundRequest.relId());
+    /**
+     * MarketProduct 엔티티 조회
+     * @param productId PK
+     * @return MarketProduct
+     */
+    public Optional<MarketProduct> findMarketProductById(Long productId) {
+        return marketProductRepository.findById(productId);
+    }
 
-        // 3. 데이터 반환 (.getData() 사용)
-        return response.getData();
+    /**
+     * Settlement 대상 주문 조회
+     * @param startDateTime 시작 날짜
+     * @param endDateTime 종료 날짜
+     * @param pageable 페이지
+     * @return List<Order>
+     */
+    public List<Order> findSettlementTargetOrders(LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable) {
+        return orderRepository.findSettlementTargetOrders(startDateTime, endDateTime, pageable);
+    }
+
+    /**
+     * 즉시 구매가 조회(최저가 판매 입찰 조회)
+     * @param productId 상품 PK
+     * @param position 구매/판매
+     * @param status 구매 상태
+     * @return Optional<Bidding>
+     */
+    public Optional<Bidding> findInstantBuyPrice(Long productId, BiddingPosition position, BiddingStatus status) {
+        return biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(productId, position, status);
+    }
+
+    /**
+     * 즉시 판매가 조회
+     * @param productId 상품 PK
+     * @param position 구매/판매
+     * @param status 구매 상태
+     * @return Optional<Bidding>
+     */
+    public Optional<Bidding> findInstantSellPrice(Long productId, BiddingPosition position, BiddingStatus status) {
+        return biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(productId, position, status);
     }
 }

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -1,5 +1,7 @@
 package com.back.market.app;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.*;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketProduct;
@@ -32,8 +34,9 @@ public class MarketSupport {
      * @param biddingId PK
      * @return Bidding
      */
-    public Optional<Bidding> findBiddingById(Long biddingId) {
-        return biddingRepository.findById(biddingId);
+    public Bidding findBiddingById(Long biddingId) {
+        return biddingRepository.findById(biddingId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
     }
 
     /**
@@ -41,8 +44,9 @@ public class MarketSupport {
      * @param orderId PK
      * @return Order
      */
-    public Optional<Order> findOrderById(Long orderId) {
-        return orderRepository.findById(orderId);
+    public Order findOrderById(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
     }
 
     /**
@@ -59,7 +63,16 @@ public class MarketSupport {
      * @param userId PK
      * @return MarketUser
      */
-    public Optional<MarketUser> findMarketUserById(Long userId) {
+    public MarketUser findMarketUserById(Long userId) {
+        return marketUserRepository.findById(userId).orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * MarketUser 엔티티 조회(Optional)
+     * @param userId PK
+     * @return MarketUser
+     */
+    public Optional<MarketUser> findMarketUserByIdOptional(Long userId) {
         return marketUserRepository.findById(userId);
     }
 
@@ -77,8 +90,9 @@ public class MarketSupport {
      * @param productId PK
      * @return MarketProduct
      */
-    public Optional<MarketProduct> findMarketProductById(Long productId) {
-        return marketProductRepository.findById(productId);
+    public MarketProduct findMarketProductById(Long productId) {
+        return marketProductRepository.findById(productId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.PRODUCT_NOT_FOUND));
     }
 
     /**
@@ -104,7 +118,7 @@ public class MarketSupport {
     }
 
     /**
-     * 즉시 판매가 조회
+     * 즉시 판매가 조회(최고가 구매 입찰 조회)
      * @param productId 상품 PK
      * @param position 구매/판매
      * @param status 구매 상태

--- a/market/src/main/java/com/back/market/app/usecase/CancelBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CancelBidUseCase.java
@@ -3,7 +3,7 @@ package com.back.market.app.usecase;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.BiddingRepository;
-import com.back.market.app.MarketSupport;
+import com.back.market.adapter.out.cash.MarketCashAdapter;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 @RequiredArgsConstructor
 public class CancelBidUseCase {
     private final BiddingRepository biddingRepository;
-    private final MarketSupport marketSupport;
+    private final MarketCashAdapter marketCashAdapter;
 
     @Transactional
     public PaymentCancelResponseDto cancelBid(Long userId, Long biddingId) {
@@ -53,7 +53,7 @@ public class CancelBidUseCase {
                     bidding.getPrice() //예치금 전액 환불
             );
             //MarketSupport -> cashclient -> 결과반환
-            return marketSupport.refundBidPayment(refundRequest);
+            return marketCashAdapter.refundBidPayment(refundRequest);
         } else {
             //판매입찰인 경우 환불금액 0원
             return PaymentCancelResponseDto.of(userId, BigDecimal.ZERO);

--- a/market/src/main/java/com/back/market/app/usecase/CancelBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CancelBidUseCase.java
@@ -2,8 +2,8 @@ package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
-import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.cash.MarketCashAdapter;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
@@ -21,14 +21,14 @@ import java.math.BigDecimal;
 @Service
 @RequiredArgsConstructor
 public class CancelBidUseCase {
-    private final BiddingRepository biddingRepository;
+
     private final MarketCashAdapter marketCashAdapter;
+    private final MarketSupport marketSupport;
 
     @Transactional
     public PaymentCancelResponseDto cancelBid(Long userId, Long biddingId) {
         //입찰 조회
-        Bidding bidding = biddingRepository.findById(biddingId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+        Bidding bidding = marketSupport.findBiddingById(biddingId).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
         //권한 검증: 본인 입찰 아니면 에러
         if(!bidding.getMarketUser().getId().equals(userId)){

--- a/market/src/main/java/com/back/market/app/usecase/CancelBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CancelBidUseCase.java
@@ -28,7 +28,7 @@ public class CancelBidUseCase {
     @Transactional
     public PaymentCancelResponseDto cancelBid(Long userId, Long biddingId) {
         //입찰 조회
-        Bidding bidding = marketSupport.findBiddingById(biddingId).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+        Bidding bidding = marketSupport.findBiddingById(biddingId);
 
         //권한 검증: 본인 입찰 아니면 에러
         if(!bidding.getMarketUser().getId().equals(userId)){

--- a/market/src/main/java/com/back/market/app/usecase/CompleteOrderUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CompleteOrderUseCase.java
@@ -15,7 +15,7 @@ public class CompleteOrderUseCase {
 
     @Transactional
     public Order completeOrder(Long userId, Long orderId) {
-        Order order = marketSupport.findOrderById(orderId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+        Order order = marketSupport.findOrderById(orderId);
 
         if (!order.getBuyBidding().getMarketUser().getId().equals(userId)) {
             throw new IllegalStateException("구매 확정 권한이 없습니다.");

--- a/market/src/main/java/com/back/market/app/usecase/CompleteOrderUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CompleteOrderUseCase.java
@@ -1,6 +1,6 @@
 package com.back.market.app.usecase;
 
-import com.back.market.adapter.out.OrderRepository;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.OrderStatus;
 import lombok.RequiredArgsConstructor;
@@ -10,11 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class CompleteOrderUseCase {
-    private final OrderRepository orderRepository;
+
+    private final MarketSupport marketSupport;
 
     @Transactional
     public Order completeOrder(Long userId, Long orderId) {
-        Order order = orderRepository.findById(orderId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+        Order order = marketSupport.findOrderById(orderId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
 
         if (!order.getBuyBidding().getMarketUser().getId().equals(userId)) {
             throw new IllegalStateException("구매 확정 권한이 없습니다.");

--- a/market/src/main/java/com/back/market/app/usecase/ConfirmPaymentUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/ConfirmPaymentUseCase.java
@@ -2,8 +2,7 @@ package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
-import com.back.market.adapter.out.BiddingRepository;
-import com.back.market.adapter.out.OrderRepository;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.BiddingStatus;
@@ -20,8 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ConfirmPaymentUseCase {
 
-    private final OrderRepository orderRepository;
-    private final BiddingRepository biddingRepository;
+    private final MarketSupport marketSupport;
 
     /**
      * Cash 모듈로부터 결제 완료(입금 확인) 통지를 수신하여 주문 상태를 확정 or 입찰 상태를 PROCESS로 변경
@@ -46,7 +44,7 @@ public class ConfirmPaymentUseCase {
      */
     private boolean processOrderPayment(PaymentCompletedRequestDto requestDto) {
         // 1. 주문 조회
-        Order order = orderRepository.findById(requestDto.relId()).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+        Order order = marketSupport.findOrderById(requestDto.relId()).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
 
         // 2. 금액 검증 (DB가격 & totalAmount)
         if (order.getPrice().compareTo(requestDto.totalAmount()) != 0) {
@@ -75,7 +73,7 @@ public class ConfirmPaymentUseCase {
      */
     private boolean processBiddingPayment(PaymentCompletedRequestDto requestDto) {
         // 1. 입찰 조회
-        Bidding bidding = biddingRepository.findById(requestDto.relId())
+        Bidding bidding = marketSupport.findBiddingById(requestDto.relId())
                 .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
         // 2. 금액 검증 (입찰희망가 vs 결제된 금액)

--- a/market/src/main/java/com/back/market/app/usecase/ConfirmPaymentUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/ConfirmPaymentUseCase.java
@@ -44,7 +44,7 @@ public class ConfirmPaymentUseCase {
      */
     private boolean processOrderPayment(PaymentCompletedRequestDto requestDto) {
         // 1. 주문 조회
-        Order order = marketSupport.findOrderById(requestDto.relId()).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+        Order order = marketSupport.findOrderById(requestDto.relId());
 
         // 2. 금액 검증 (DB가격 & totalAmount)
         if (order.getPrice().compareTo(requestDto.totalAmount()) != 0) {
@@ -73,8 +73,7 @@ public class ConfirmPaymentUseCase {
      */
     private boolean processBiddingPayment(PaymentCompletedRequestDto requestDto) {
         // 1. 입찰 조회
-        Bidding bidding = marketSupport.findBiddingById(requestDto.relId())
-                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+        Bidding bidding = marketSupport.findBiddingById(requestDto.relId());
 
         // 2. 금액 검증 (입찰희망가 vs 결제된 금액)
         if (bidding.getPrice().compareTo(requestDto.totalAmount()) != 0) {

--- a/market/src/main/java/com/back/market/app/usecase/CreateCartUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CreateCartUseCase.java
@@ -3,24 +3,25 @@ package com.back.market.app.usecase;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.market.adapter.out.CartRepository;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Cart;
 import com.back.market.domain.MarketUser;
 import com.back.market.mapper.CartMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CreateCartUseCase {
+    private final MarketSupport marketSupport;
     private final CartRepository cartRepository;
     private final CartMapper cartMapper;
 
     public void createCart(MarketUser user) {
         // 장바구니 존재하는지 확인
-        if (cartRepository.existsByMarketUser(user)) {
+        if (marketSupport.existsCartByMarketUser(user)) {
             log.info("[Market] 이미 장바구니가 존재하는 사용자입니다. id = {}", user.getId());
             return;
         }

--- a/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
@@ -4,24 +4,25 @@ import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.common.user.event.UserCreatedEvent;
 import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.MarketUser;
 import com.back.market.mapper.MarketUserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CreateMarketMemberUseCase {
+    private final MarketSupport marketSupport;
     private final MarketUserRepository marketUserRepository;
     private final MarketUserMapper marketUserMapper;
 
     public MarketUser createMarketMember(UserCreatedEvent event) {
         // 기존 회원 존재 여부 확인
-        MarketUser existingUser = marketUserRepository.findById(event.id()).orElse(null);
+        MarketUser existingUser = marketSupport.findMarketUserById(event.id()).orElse(null);
 
         if (existingUser != null) {
             log.info("[CreateMarketMemberUseCase] 이미 존재하는 회원: id = {}", event.id());

--- a/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
@@ -22,7 +22,7 @@ public class CreateMarketMemberUseCase {
 
     public MarketUser createMarketMember(UserCreatedEvent event) {
         // 기존 회원 존재 여부 확인
-        MarketUser existingUser = marketSupport.findMarketUserById(event.id()).orElse(null);
+        MarketUser existingUser = marketSupport.findMarketUserByIdOptional(event.id()).orElse(null);
 
         if (existingUser != null) {
             log.info("[CreateMarketMemberUseCase] 이미 존재하는 회원: id = {}", event.id());

--- a/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
@@ -2,8 +2,7 @@ package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
-import com.back.market.adapter.out.BiddingRepository;
-import com.back.market.adapter.out.MarketProductRepository;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
@@ -22,8 +21,7 @@ import java.math.BigDecimal;
 @RequiredArgsConstructor
 public class GetInstantPriceUseCase {
 
-    private final BiddingRepository biddingRepository;
-    private final MarketProductRepository marketProductRepository;
+    private final MarketSupport marketSupport;
 
     /**
      * 즉시 구매가 조회
@@ -33,9 +31,9 @@ public class GetInstantPriceUseCase {
     @Transactional(readOnly = true)
     public InstantBuyPriceResponseDto getBuyNowPrice(Long productId) {
         // 상품 존재 여부 검증
-        validateProductExists(productId);
+        verifyProductExists(productId);
         
-        BigDecimal price = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(
+        BigDecimal price = marketSupport.findInstantBuyPrice(
                 productId,
                 BiddingPosition.SELL,
                 BiddingStatus.PROCESS
@@ -52,8 +50,8 @@ public class GetInstantPriceUseCase {
     @Transactional(readOnly = true)
     public InstantSellPriceResponseDto getSellNowPrice(Long productId) {
         //상품 존재 여부 검증
-        validateProductExists(productId);
-        BigDecimal price = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
+        verifyProductExists(productId);
+        BigDecimal price = marketSupport.findInstantSellPrice(
                 productId,
                 BiddingPosition.BUY,
                 BiddingStatus.PROCESS
@@ -62,8 +60,8 @@ public class GetInstantPriceUseCase {
         return InstantSellPriceResponseDto.of(productId, price);
     }
 
-    private void validateProductExists(Long productId) {
-        if(!marketProductRepository.existsById(productId)) {
+    private void verifyProductExists(Long productId) {
+        if (!marketSupport.existsByMarketProduct(productId)) {
             throw new BadRequestException(FailureCode.PRODUCT_NOT_FOUND);
         }
     }

--- a/market/src/main/java/com/back/market/app/usecase/GetSettlementDataUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetSettlementDataUseCase.java
@@ -1,7 +1,7 @@
 package com.back.market.app.usecase;
 
 import com.back.common.dto.settlement.SettlementTargetOrder;
-import com.back.market.adapter.out.OrderRepository;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Order;
 import com.back.market.mapper.OrderMapper;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class GetSettlementDataUseCase {
 
     private final OrderMapper orderMapper;
-    private final OrderRepository orderRepository;
+    private final MarketSupport marketSupport;
 
     @Transactional(readOnly = true)
     public List<SettlementTargetOrder> getSettlementData(LocalDate targetDate, int page, int size) {
@@ -34,7 +34,7 @@ public class GetSettlementDataUseCase {
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
 
         // DB 조회
-        List<Order> orders = orderRepository.findSettlementTargetOrders(startDateTime, endDateTime, pageable);
+        List<Order> orders = marketSupport.findSettlementTargetOrders(startDateTime, endDateTime, pageable);
 
         return orders.stream()
                 .map(orderMapper::toSettlementTargetOrder)

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -53,7 +53,8 @@ public class MatchInstantTradeUseCase {
     @Transactional
     public MarketPaymentResponseDto buyNow(Long buyerId, BiddingRequestDto requestDto) {
         // 즉시 구매가 조회(최저가 판매 입찰 조회)
-        Bidding targetSellBid = marketSupport.findInstantBuyPrice(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+        Bidding targetSellBid = marketSupport.findInstantBuyPrice(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS)
+                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
         // 정합성 검사 추가: 사용자가 화면에서 본 가격과 실제 조회된 가격이 다르면 예외 처리
         validatePriceMatch(targetSellBid, requestDto.price());
@@ -105,7 +106,7 @@ public class MatchInstantTradeUseCase {
 
         // 2. 입찰 생성 및 상태 변경
         // 사용자 조회
-        MarketUser me = marketSupport.findMarketUserById(userId).orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
+        MarketUser me = marketSupport.findMarketUserById(userId);
 
         Bidding myBid = biddingMapper.toEntity(requestDto, me, targetBid.getMarketProduct(), myPosition);
         myBid.changeStatus(BiddingStatus.MATCHED);

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -5,9 +5,9 @@ import com.back.common.event.KafkaEventPublisher;
 import com.back.common.exception.BadRequestException;
 import com.back.common.market.event.BiddingCompletedEvent;
 import com.back.market.adapter.out.BiddingRepository;
-import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.adapter.out.OrderRepository;
 import com.back.market.adapter.out.cash.MarketCashAdapter;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.Order;
@@ -37,11 +37,11 @@ public class MatchInstantTradeUseCase {
     private final BiddingRepository biddingRepository;
     private final OrderRepository orderRepository;
     private final OrderMapper orderMapper;
-    private final MarketUserRepository marketUserRepository;
     private final BiddingMapper biddingMapper;
     private final CashRequestMapper cashRequestMapper;
     private final MarketCashAdapter marketCashAdapter;
     private final KafkaEventPublisher kafkaEventPublisher;
+    private final MarketSupport marketSupport;
 
     /**
      * MARKET-009 즉시 구매 실행
@@ -52,7 +52,8 @@ public class MatchInstantTradeUseCase {
      */
     @Transactional
     public MarketPaymentResponseDto buyNow(Long buyerId, BiddingRequestDto requestDto) {
-        Bidding targetSellBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+        // 즉시 구매가 조회(최저가 판매 입찰 조회)
+        Bidding targetSellBid = marketSupport.findInstantBuyPrice(requestDto.productId(), BiddingPosition.SELL, BiddingStatus.PROCESS).orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
         // 정합성 검사 추가: 사용자가 화면에서 본 가격과 실제 조회된 가격이 다르면 예외 처리
         validatePriceMatch(targetSellBid, requestDto.price());
@@ -69,7 +70,8 @@ public class MatchInstantTradeUseCase {
      */
     @Transactional
     public MarketPaymentResponseDto sellNow(Long sellerId, BiddingRequestDto requestDto) {
-        Bidding targetBuyBid = biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
+        // 즉시 판매가 조회(최고가 구매 입찰 조회)
+        Bidding targetBuyBid = marketSupport.findInstantSellPrice(
                         requestDto.productId(), BiddingPosition.BUY, BiddingStatus.PROCESS)
                 .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
@@ -102,7 +104,8 @@ public class MatchInstantTradeUseCase {
         }
 
         // 2. 입찰 생성 및 상태 변경
-        MarketUser me = marketUserRepository.findById(userId).orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
+        // 사용자 조회
+        MarketUser me = marketSupport.findMarketUserById(userId).orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
 
         Bidding myBid = biddingMapper.toEntity(requestDto, me, targetBid.getMarketProduct(), myPosition);
         myBid.changeStatus(BiddingStatus.MATCHED);
@@ -194,6 +197,5 @@ public class MatchInstantTradeUseCase {
         
         kafkaEventPublisher.publish(event);
     }
-
 
 }

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -7,7 +7,7 @@ import com.back.common.market.event.BiddingCompletedEvent;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.adapter.out.OrderRepository;
-import com.back.market.app.MarketSupport;
+import com.back.market.adapter.out.cash.MarketCashAdapter;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketUser;
 import com.back.market.domain.Order;
@@ -40,7 +40,7 @@ public class MatchInstantTradeUseCase {
     private final MarketUserRepository marketUserRepository;
     private final BiddingMapper biddingMapper;
     private final CashRequestMapper cashRequestMapper;
-    private final MarketSupport marketSupport;
+    private final MarketCashAdapter marketCashAdapter;
     private final KafkaEventPublisher kafkaEventPublisher;
 
     /**
@@ -125,7 +125,7 @@ public class MatchInstantTradeUseCase {
         if(myPosition == BiddingPosition.BUY) {
             // Cash 호출
             PayAndHoldRequestDto paymentReq = cashRequestMapper.toPayAndHoldRequestForOrder(savedOrder);
-            PayAndHoldResponseDto resultData = marketSupport.getPayAndHoldResult(paymentReq);
+            PayAndHoldResponseDto resultData = marketCashAdapter.getPayAndHoldResult(paymentReq);
 
             // 6. 결과 상태에 따른 주문 상태 업데이트
             if (resultData.status() == PayAndHoldStatus.PAID) {

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -3,9 +3,8 @@ package com.back.market.app.usecase;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.BiddingRepository;
-import com.back.market.adapter.out.MarketProductRepository;
-import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.adapter.out.cash.MarketCashAdapter;
+import com.back.market.app.MarketSupport;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
@@ -34,11 +33,10 @@ import java.math.BigDecimal;
 @RequiredArgsConstructor
 public class RegisterBidUseCase {
     private final BiddingRepository biddingRepository;
-    private final MarketUserRepository marketUserRepository;
-    private final MarketProductRepository marketProductRepository;
     private final BiddingMapper biddingMapper;
     private final CashRequestMapper cashRequestMapper;
     private final MarketCashAdapter marketCashAdapter;
+    private final MarketSupport marketSupport;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -55,22 +53,22 @@ public class RegisterBidUseCase {
         // 에러 발생 시 즉시 구매로 유도
         checkBuyPricePolicy(userId, requestDto);
 
-        // 엔티티 조회 및 예외 처리
-        MarketUser user = marketUserRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
-        MarketProduct product = marketProductRepository.findById(requestDto.productId())
-                .orElseThrow(() -> new BadRequestException(FailureCode.PRODUCT_NOT_FOUND));
+        UserProduct userProduct = getVerifiedUserAndProduct(userId, requestDto.productId());
+        MarketUser user = userProduct.user();
+        MarketProduct product = userProduct.product();
 
         // 구매 입찰 엔티티 생성 및 저장(id 생성을 위해 먼저 진행)
         Bidding bidding = biddingMapper.toEntity(requestDto, user, product, BiddingPosition.BUY);
         Bidding savedBidding = biddingRepository.save(bidding);
 
-        // TODO: 구매 입찰 등록 시 포인트 잔액 확인 및 차감 로직 추가 필요. 임시로 FakeCashClient 구현해서 테스트(marketSupport 클래스 확인)
+        // Cash 모듈에 예치금 확인 및 차감 요청
         PayAndHoldRequestDto cashRequest = cashRequestMapper.toPayAndHoldRequestForBidding(
                 userId,
                 requestDto.price(),
                 savedBidding.getId()
         );
+
+        //요청에 따른 결과 수신
         PayAndHoldResponseDto responseData = marketCashAdapter.getPayAndHoldResult(cashRequest);
 
         if (responseData.status() == PayAndHoldStatus.PAID) {
@@ -103,18 +101,17 @@ public class RegisterBidUseCase {
         // 에러 발생 시 즉시 판매로 유도
         checkSellPricePolicy(userId, requestDto);
 
-        // 엔티티 조회 및 예외 처리
-        MarketUser user = marketUserRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
-        MarketProduct product = marketProductRepository.findById(requestDto.productId())
-                .orElseThrow(() -> new BadRequestException(FailureCode.PRODUCT_NOT_FOUND));
+        // 엔티티 조회
+        UserProduct userProduct = getVerifiedUserAndProduct(userId, requestDto.productId());
+        MarketUser user = userProduct.user();
+        MarketProduct product = userProduct.product();
 
         // 판매 입찰 저장
         Bidding bidding = biddingMapper.toEntity(requestDto, user, product, BiddingPosition.SELL);
         bidding.changeStatus(BiddingStatus.PROCESS); // 판매 입찰은 결제 과정이 없으므로 즉시 활성화
         Bidding savedBidding = biddingRepository.save(bidding);
 
-        // 가짜 Cash 응답 생성 (판매는 결제 완료 상태)
+        // 가짜 Cash 응답 생성 (판매는 결제 완료 상태이므로 cash 모듈과 통신 필요없음)
         PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(
                 PayAndHoldStatus.PAID,
                 RelType.BIDDING,
@@ -148,7 +145,7 @@ public class RegisterBidUseCase {
      * @param requestDto BiddingRequestDto
      */
     private void checkBuyPricePolicy(Long userId, BiddingRequestDto requestDto) {
-        biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceAsc(
+        marketSupport.findInstantBuyPrice(
                 requestDto.productId(),
                 BiddingPosition.SELL,
                 BiddingStatus.PROCESS
@@ -170,7 +167,7 @@ public class RegisterBidUseCase {
      * @param requestDto BiddingRequestDto
      */
     private void checkSellPricePolicy(Long userId, BiddingRequestDto requestDto) {
-        biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(
+        marketSupport.findInstantSellPrice(
                 requestDto.productId(),
                 BiddingPosition.BUY,
                 BiddingStatus.PROCESS
@@ -185,4 +182,25 @@ public class RegisterBidUseCase {
             }
         });
     }
+
+    /**
+     * 사용자와 상품의 유효성을 검사하여 UserProduct 객체를 반환하는 메서드
+     * @param userId 사용자ID
+     * @param productId 상품ID
+     * @return UserProduct 객체
+     */
+    private UserProduct getVerifiedUserAndProduct(Long userId, Long productId) {
+        MarketUser user = marketSupport.findMarketUserById(userId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
+        MarketProduct product = marketSupport.findMarketProductById(productId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.PRODUCT_NOT_FOUND));
+        return new UserProduct(user, product);
+    }
+
+    /**
+     * 사용자와 상품 정보를 담은 record 클래스
+     * @param user MarketUser
+     * @param product MarketProduct
+     */
+    private record UserProduct(MarketUser user, MarketProduct product) {}
 }

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -190,10 +190,8 @@ public class RegisterBidUseCase {
      * @return UserProduct 객체
      */
     private UserProduct getVerifiedUserAndProduct(Long userId, Long productId) {
-        MarketUser user = marketSupport.findMarketUserById(userId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.USER_NOT_FOUND));
-        MarketProduct product = marketSupport.findMarketProductById(productId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.PRODUCT_NOT_FOUND));
+        MarketUser user = marketSupport.findMarketUserById(userId);
+        MarketProduct product = marketSupport.findMarketProductById(productId);
         return new UserProduct(user, product);
     }
 

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -5,7 +5,7 @@ import com.back.common.exception.BadRequestException;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.MarketProductRepository;
 import com.back.market.adapter.out.MarketUserRepository;
-import com.back.market.app.MarketSupport;
+import com.back.market.adapter.out.cash.MarketCashAdapter;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
@@ -38,7 +38,7 @@ public class RegisterBidUseCase {
     private final MarketProductRepository marketProductRepository;
     private final BiddingMapper biddingMapper;
     private final CashRequestMapper cashRequestMapper;
-    private final MarketSupport marketSupport;
+    private final MarketCashAdapter marketCashAdapter;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -71,7 +71,7 @@ public class RegisterBidUseCase {
                 requestDto.price(),
                 savedBidding.getId()
         );
-        PayAndHoldResponseDto responseData = marketSupport.getPayAndHoldResult(cashRequest);
+        PayAndHoldResponseDto responseData = marketCashAdapter.getPayAndHoldResult(cashRequest);
 
         if (responseData.status() == PayAndHoldStatus.PAID) {
             savedBidding.changeStatus(BiddingStatus.PROCESS);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #246 

## 🔎 작업 내용

- 기존에 usecase에서 조회 메서드들도 repository 주입을 직접 하고 있었어서 MarketSupport에 조회 메서드들을 불러오고, usecase들에서 엔티티 조회가 필요할 때에는 marketsupport를 주입하도록 리팩토링했습니다.

<br>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
