### PR TITLE
[REFACTOR] market_user에서 프로필 사진 컬럼 삭제, 이벤트 토픽 yml에서 불러오는 부분 수정 (#261)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/MarketDataInit.java
+++ b/market/src/main/java/com/back/market/adapter/in/MarketDataInit.java
@@ -45,8 +45,7 @@ public class MarketDataInit implements CommandLineRunner {
                 "나이키매니아",
                 "seller@resello.com",
                 "서울시 강남구 역삼동",
-                "010-1234-5678",
-                "https://dummyimage.com/100x100/000/fff&text=Seller"
+                "010-1234-5678"
         );
 
         MarketUser savedSeller = marketUserRepository.save(seller);
@@ -57,8 +56,7 @@ public class MarketDataInit implements CommandLineRunner {
                 "신발덕후",
                 "buyer@resello.com",
                 "경기도 성남시 분당구",
-                "010-9876-5432",
-                null
+                "010-9876-5432"
         );
         MarketUser savedBuyer = marketUserRepository.save(buyer);
 

--- a/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventListener.java
@@ -17,8 +17,8 @@ public class MarketUserEventListener {
     private final MarketInternalFacade marketInternalFacade;
 
     @KafkaListener(
-            topics = "${custom.kafka.topic.user-created}",
-            groupId = "${custom.kafka.consumer.group-id}"
+            topics = "${custom.kafka.topic.user-account-created}",
+            groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consume(UserCreatedEvent event) {
         log.info("[MarketUserEventListener] UserCreatedEvent 수신: {}", event.id());

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -30,7 +30,7 @@ public class MarketFacade {
     private final CancelBidUseCase cancelBidUseCase;
     private final CompleteOrderUseCase completeOrderUseCase;
 
-    @Value("${custom.kafka.topic.order-completed}")
+    @Value("${custom.kafka.topic.market-order-completed}")
     private String orderCompletedTopic;
     private final KafkaEventPublisher kafkaEventPublisher;
 

--- a/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
@@ -37,8 +37,7 @@ public class CreateMarketMemberUseCase {
                     event.name(),
                     event.email(),
                     event.address(),
-                    event.phone(),
-                    event.profileImageUrl()
+                    event.phone()
             );
             MarketUser savedUser = marketUserRepository.save(newUser);
             log.info("[CreateMarketMemberUseCase] 복제 완료: id = {}", event.id());

--- a/market/src/main/java/com/back/market/domain/MarketUser.java
+++ b/market/src/main/java/com/back/market/domain/MarketUser.java
@@ -40,7 +40,4 @@ public class MarketUser extends BaseTimeEntity {
 
     @Column(name = "phone", length = 20)
     private String phone;           // 연락처
-
-    @Column(name = "profile_image_url")
-    private String profileImageUrl; // 프로필 이미지
 }

--- a/market/src/main/java/com/back/market/mapper/MarketUserMapper.java
+++ b/market/src/main/java/com/back/market/mapper/MarketUserMapper.java
@@ -5,14 +5,13 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MarketUserMapper {
-    public MarketUser toEntity(Long id, String name, String email, String address, String phone, String profileImageUrl){
+    public MarketUser toEntity(Long id, String name, String email, String address, String phone){
         return MarketUser.builder()
                 .id(id)
                 .name(name)
                 .email(email)
                 .address(address)
                 .phone(phone)
-                .profileImageUrl(profileImageUrl)
                 .build();
     }
 }

--- a/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
@@ -69,10 +69,10 @@ public class MatchInstantTradeRollbackTests {
 
     // --- Helper Methods (데이터 정리를 위해 메서드 단위 Transactional 고려 가능) ---
     private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
-        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678", "image");
+        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678");
         marketUserRepository.save(seller);
 
-        MarketUser buyer = marketUserMapper.toEntity(buyerId,"buyer", "b@t.com", buyerAddress, "010-1234-5678", "image");
+        MarketUser buyer = marketUserMapper.toEntity(buyerId,"buyer", "b@t.com", buyerAddress, "010-1234-5678");
         marketUserRepository.save(buyer);
 
         if (!marketProductRepository.existsById(productId)) {

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
@@ -239,9 +239,9 @@ public class MatchInstantTradeUseCaseV2Tests {
     // --- Helper Methods (기존과 동일) ---
     private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
         // ... (기존 코드 그대로)
-        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678", "img");
+        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678");
         marketUserRepository.save(seller);
-        MarketUser buyer = marketUserMapper.toEntity(buyerId, "buyer", "b@t.com", buyerAddress, "010-1234-5678", "img");
+        MarketUser buyer = marketUserMapper.toEntity(buyerId, "buyer", "b@t.com", buyerAddress, "010-1234-5678");
         marketUserRepository.save(buyer);
         if (!marketProductRepository.existsById(productId)) {
             marketProductRepository.save(marketProductMapper.toEntity(productId, "N", "신발", "N1", "270", 100000L, "S", "img"));

--- a/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
+++ b/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
@@ -22,7 +22,7 @@ public class KafkaIntegrationTest {
     @Autowired
     private CartRepository cartRepository;
 
-    @Value("${custom.kafka.topic.user-created}")
+    @Value("${custom.kafka.topic.user-account-created}")
     private String topic;
 
     @Test

--- a/market/src/test/java/com/back/market/event/OrderCompleteEventTest.java
+++ b/market/src/test/java/com/back/market/event/OrderCompleteEventTest.java
@@ -34,7 +34,7 @@ public class OrderCompleteEventTest {
     @BeforeEach
     void setUp() {
         // marketFacade 객체의 "orderCompletedTopic" 필드에 "order-confirmed-topic" 값을 직접 주입합니다.
-        ReflectionTestUtils.setField(marketFacade, "orderCompletedTopic", "order-completed");
+        ReflectionTestUtils.setField(marketFacade, "orderCompletedTopic", "market.order.completed");
     }
 
     @Test


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #261 

## 🔎 작업 내용

- market_user 엔티티에서 프로필 사진 컬럼 삭제 및 관련 내용들 삭제
- 공통으로 맞춘 이벤트 토픽명으로 yml value 불러오는 부분 수정

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
