### PR TITLE
[FEAT] 주문 조회 api 구현 (#234)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,8 +92,8 @@ configure(subprojects.findAll { it.name in ['common', 'security'] }) {
     jar.enabled = true
 }
 
-// QueryDSL 설정 ( common, settlement 모듈만 )
-configure(subprojects.findAll { it.name in ['common', 'settlement'] }) {
+// QueryDSL 설정 ( common, settlement, market 모듈만 )
+configure(subprojects.findAll { it.name in ['common', 'settlement', 'market'] }) {
     def querydslDir = "${layout.buildDirectory.get()}/generated/querydsl"
 
     sourceSets {

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -35,6 +35,7 @@ public enum FailureCode {
     CANNOT_CANCEL_BID(HttpStatus.BAD_REQUEST, "CANNOT_CANCEL_BID", "이미 체결되었거나 취소할 수 없는 상태입니다."),
     WALLET_REFUND_FAILED(HttpStatus.BAD_REQUEST, "WALLET_REFUND_FAILED", "예치금 환불에 실패하였습니다"),
     CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "CONSTRAINT_VIOLATION", "제약 조건 위반으로 작업을 수행할 수 없습니다."),
+    ORDER_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "ORDER_ACCESS_DENIED", "해당 주문에 대한 접근 권한이 없습니다."),
 
     /**
      * 401 Unauthorized

--- a/market/build.gradle
+++ b/market/build.gradle
@@ -5,4 +5,10 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -68,14 +68,14 @@ public interface ApiV1Market {
     @GetMapping("/orders/buying")
     CommonResponse<Page<OrderListResponseDto>> getBuyingList(
             @AuthenticationPrincipal AuthPrincipal principal,
-            @PageableDefault(size=10, sort = "paymentDate", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     );
 
     @Operation(summary = "판매 내역 조회", description = "특정 사용자의 판매 내역을 조회한다.")
     @GetMapping("/orders/selling")
     CommonResponse<Page<OrderListResponseDto>> getSellingList(
             @AuthenticationPrincipal AuthPrincipal principal,
-            @PageableDefault(size=10, sort = "paymentDate", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     );
 
     @Operation(summary = "구매/판매 상세 내역 조회", description = "특정 사용자의 구매 내역을 조회한다.")

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -2,14 +2,16 @@ package com.back.market.adapter.in;
 
 import com.back.common.response.CommonResponse;
 import com.back.market.dto.request.BiddingRequestDto;
-import com.back.market.dto.response.InstantBuyPriceResponseDto;
-import com.back.market.dto.response.InstantSellPriceResponseDto;
+import com.back.market.dto.response.*;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
-import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -59,6 +61,27 @@ public interface ApiV1Market {
     @PatchMapping("/orders/{orderId}/complete")
     CommonResponse<Void> completeOrder(
             @AuthenticationPrincipal AuthPrincipal principal,
-             @PathVariable Long orderId
+            @PathVariable Long orderId
+    );
+
+    @Operation(summary = "구매 내역 조회", description = "특정 사용자의 구매 내역을 조회한다.")
+    @GetMapping("/orders/buying")
+    CommonResponse<Page<OrderListResponseDto>> getBuyingList(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PageableDefault(size=10, sort = "paymentDate", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+    @Operation(summary = "판매 내역 조회", description = "특정 사용자의 판매 내역을 조회한다.")
+    @GetMapping("/orders/selling")
+    CommonResponse<Page<OrderListResponseDto>> getSellingList(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PageableDefault(size=10, sort = "paymentDate", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+    @Operation(summary = "구매/판매 상세 내역 조회", description = "특정 사용자의 구매 내역을 조회한다.")
+    @GetMapping("/orders/{orderId}")
+    CommonResponse<OrderDetailResponseDto> getOrderDetail(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable Long orderId
     );
 }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -113,7 +113,7 @@ public class ApiV1MarketController implements ApiV1Market{
     }
 
     @Override
-    public CommonResponse<OrderDetailResponseDto> getOrderDetail(@AuthenticationPrincipal AuthPrincipal principal, Long orderId) {
+    public CommonResponse<OrderDetailResponseDto> getOrderDetail(@AuthenticationPrincipal AuthPrincipal principal, @PathVariable Long orderId) {
         OrderDetailResponseDto result = marketFacade.getOrderDetail(principal.getUserId(), orderId);
         return CommonResponse.success(SuccessCode.OK, result);
     }

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -4,13 +4,13 @@ import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.market.app.MarketFacade;
 import com.back.market.dto.request.BiddingRequestDto;
-import com.back.market.dto.response.InstantBuyPriceResponseDto;
-import com.back.market.dto.response.InstantSellPriceResponseDto;
+import com.back.market.dto.response.*;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
-import com.back.market.dto.response.MarketPaymentResponseDto;
 import com.back.security.principal.AuthPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -100,5 +100,22 @@ public class ApiV1MarketController implements ApiV1Market{
         return CommonResponse.success(SuccessCode.OK, null);
     }
 
+    @Override
+    public CommonResponse<Page<OrderListResponseDto>> getBuyingList(@AuthenticationPrincipal AuthPrincipal principal, Pageable pageable) {
+        Page<OrderListResponseDto> result = marketFacade.getBuyingList(principal.getUserId(), pageable);
+        return CommonResponse.success(SuccessCode.OK, result);
+    }
+
+    @Override
+    public CommonResponse<Page<OrderListResponseDto>> getSellingList(@AuthenticationPrincipal AuthPrincipal principal, Pageable pageable) {
+        Page<OrderListResponseDto> result = marketFacade.getSellingList(principal.getUserId(), pageable);
+        return CommonResponse.success(SuccessCode.OK, result);
+    }
+
+    @Override
+    public CommonResponse<OrderDetailResponseDto> getOrderDetail(@AuthenticationPrincipal AuthPrincipal principal, Long orderId) {
+        OrderDetailResponseDto result = marketFacade.getOrderDetail(principal.getUserId(), orderId);
+        return CommonResponse.success(SuccessCode.OK, result);
+    }
 
 }

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.back.market.adapter.out;
 
 import com.back.market.domain.Order;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o JOIN FETCH o.sellBidding sb JOIN FETCH sb.marketUser s JOIN FETCH o.buyBidding bb WHERE o.lastModifiedAt BETWEEN :startDate and :endDate")
@@ -16,4 +18,13 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             @Param("endDate") LocalDateTime endDateTime,
             Pageable pageable
     );
+
+    @Query("SELECT o from Order o JOIN FETCH o.buyBidding bb JOIN FETCH bb.marketProduct WHERE bb.marketUser.id = :userId")
+    Page<Order> findSellHistoryList(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT o from Order o JOIN FETCH o.sellBidding sb JOIN FETCH o.buyBidding bb JOIN FETCH bb.marketProduct WHERE sb.marketUser.id = :userId")
+    Page<Order> findBuyHistoryList(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT o from Order o JOIN FETCH o.buyBidding bb JOIN FETCH o.sellBidding sb JOIN FETCH bb.marketProduct WHERE o.id = :orderId")
+    Optional<Order> findByIdWithDetails(@Param("orderId") Long orderId);
 }

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
@@ -26,5 +26,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Page<Order> findBuyHistoryList(@Param("userId") Long userId, Pageable pageable);
 
     @Query("SELECT o from Order o JOIN FETCH o.buyBidding bb JOIN FETCH o.sellBidding sb JOIN FETCH bb.marketProduct WHERE o.id = :orderId")
-    Optional<Order> findByIdWithDetails(@Param("orderId") Long orderId);
+    Optional<Order> findOrderWithDetails(@Param("orderId") Long orderId);
 }

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
     @Query("SELECT o FROM Order o JOIN FETCH o.sellBidding sb JOIN FETCH sb.marketUser s JOIN FETCH o.buyBidding bb WHERE o.lastModifiedAt BETWEEN :startDate and :endDate")
     List<Order> findSettlementTargetOrders(
             @Param("startDate") LocalDateTime startDateTime,

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepositoryCustom.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.back.market.adapter.out;
+
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepositoryCustom {
+    // 구매 내역 조회
+    Page<Order> findBuyHistoryList(Long userId, List<OrderStatus> statuses, Pageable pageable);
+
+    // 판매 내역 조회
+    Page<Order> findSellHistoryList(Long userId, List<OrderStatus> statuses, Pageable pageable);
+
+    // 상세 조회
+    Optional<Order> findOrderWithDetails(Long userId, Long orderId);
+}

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepositoryImpl.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepositoryImpl.java
@@ -1,0 +1,147 @@
+package com.back.market.adapter.out;
+
+import com.back.market.domain.Order;
+import com.back.market.domain.QOrder;
+import com.back.market.domain.enums.OrderStatus;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.back.market.domain.QBidding.bidding;
+import static com.back.market.domain.QMarketProduct.marketProduct;
+import static com.back.market.domain.QOrder.order;
+
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 구매 내역 조회
+     * @param userId 사용자 아이디
+     * @param statuses 주문 상태 목록
+     * @param pageable 페이지 정보
+     * @return Page<Order>
+     */
+    @Override
+    public Page<Order> findBuyHistoryList(Long userId, List<OrderStatus> statuses, Pageable pageable) {
+
+        // 조회
+        List<Order> content = queryFactory
+                .selectFrom(order)
+                .join(order.buyBidding, bidding).fetchJoin()
+                .join(bidding.marketProduct, marketProduct).fetchJoin()
+                .where(buyBiddingUserIdEq(userId), statusIn(statuses))
+                .orderBy(getOrderSpecifier(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 카운트 쿼리(fetch 조인 제거로 성능 최적화)
+        JPAQuery<Long> countQuery = queryFactory
+                .select(order.count())
+                .from(order)
+                .join(order.buyBidding, bidding)
+                .where(buyBiddingUserIdEq(userId), statusIn(statuses));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 판매 내역 조회
+     * @param userId 사용자 아이디
+     * @param statuses 주문 상태 목록
+     * @param pageable 페이지 정보
+     * @return Page<Order>
+     */
+    @Override
+    public Page<Order> findSellHistoryList(Long userId, List<OrderStatus> statuses, Pageable pageable) {
+        // 조회
+        List<Order> content = queryFactory
+                .selectFrom(order)
+                .join(order.sellBidding, bidding).fetchJoin()
+                .join(order.buyBidding).fetchJoin()
+                .join(order.buyBidding.marketProduct, marketProduct).fetchJoin()
+                .where(sellBiddingUserIdEq(userId), statusIn(statuses))
+                .orderBy(getOrderSpecifier(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 카운트 쿼리(fetch 조인 제거로 성능 최적화)
+        JPAQuery<Long> countQuery = queryFactory
+                .select(order.count())
+                .from(order)
+                .join(order.sellBidding, bidding)
+                .where(sellBiddingUserIdEq(userId), statusIn(statuses));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 주문 상세 조회
+     * @param userId 사용자 아이디
+     * @param orderId 주문 아이디
+     * @return Optional<Order>
+     */
+    @Override
+    public Optional<Order> findOrderWithDetails(Long userId, Long orderId) {
+        Order result = queryFactory
+                .selectFrom(order)
+                .join(order.buyBidding).fetchJoin()
+                .join(order.sellBidding).fetchJoin()
+                .join(order.buyBidding.marketProduct, marketProduct).fetchJoin()
+                .where(order.id.eq(orderId), isMyOrder(userId))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    // BooleanExpressions(검색 조건들)
+
+    // 구매자가 userId와 일치하는지
+    private BooleanExpression buyBiddingUserIdEq(Long userId) {
+        return userId != null ? order.buyBidding.marketUser.id.eq(userId) : null;
+    }
+
+    // 판매자가 userId와 일치하는지
+    private BooleanExpression sellBiddingUserIdEq(Long userId) {
+        return userId != null ? order.sellBidding.marketUser.id.eq(userId) : null;
+    }
+
+    // 상태 리스트 필터링 (statuses에 있는 상태만 조회, HOLD 제외)
+    private BooleanExpression statusIn(List<OrderStatus> statuses) {
+        return (statuses != null && !statuses.isEmpty()) ? order.orderStatus.in(statuses) : null;
+    }
+
+    // 권한 체크: 구매자이거나 판매자인 경우만 허용(기존에 usecase에서 검사하던 내용을 쿼리에서 검증)
+    private BooleanExpression isMyOrder(Long userId) {
+        if(userId == null) return null;
+        return order.buyBidding.marketUser.id.eq(userId)
+                .or(order.sellBidding.marketUser.id.eq(userId));
+    }
+
+    // OrderSpecifier, 정렬 처리
+    private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
+        if(!pageable.getSort().isEmpty()) {
+            for (Sort.Order sortOrder : pageable.getSort()) {
+                // createdAt 필드로 요청이 오면 처리
+                if ("createdAt".equals(sortOrder.getProperty())) {
+                    // 요청이 오름차순/내림차순인지에 따라 처리
+                    return sortOrder.isAscending() ? order.createdAt.asc() : order.createdAt.desc();
+                }
+            }
+        }
+        return order.createdAt.desc();
+    }
+
+
+}

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -10,12 +10,12 @@ import com.back.common.market.event.OrderCompletedEvent;
 import com.back.market.app.usecase.*;
 import com.back.market.domain.Order;
 import com.back.market.dto.request.BiddingRequestDto;
-import com.back.market.dto.response.InstantBuyPriceResponseDto;
-import com.back.market.dto.response.InstantSellPriceResponseDto;
+import com.back.market.dto.response.*;
 import com.back.common.dto.cash.response.PaymentCancelResponseDto;
-import com.back.market.dto.response.MarketPaymentResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +29,7 @@ public class MarketFacade {
     private final MatchInstantTradeUseCase matchInstantTradeUseCase;
     private final CancelBidUseCase cancelBidUseCase;
     private final CompleteOrderUseCase completeOrderUseCase;
+    private final GetOrdersUseCase getOrdersUseCase;
 
     @Value("${custom.kafka.topic.market-order-completed}")
     private String orderCompletedTopic;
@@ -129,5 +130,38 @@ public class MarketFacade {
                 LocalDateTime.now()
         );
         kafkaEventPublisher.publish(orderCompletedTopic, event);
+    }
+
+    /**
+     * MARKET: 구매 내역 조회
+     * @param userId 사용자ID
+     * @param pageable 페이징 정보
+     * @return Page<OrderListResponseDto>
+     */
+    @Transactional(readOnly = true)
+    public Page<OrderListResponseDto> getBuyingList(Long userId, Pageable pageable) {
+        return getOrdersUseCase.getBuyingList(userId, pageable);
+    }
+
+    /**
+     * MARKET: 판매 내역 조회
+     * @param userId 사용자ID
+     * @param pageable 페이징 정보
+     * @return Page<OrderListResponseDto>
+     */
+    @Transactional(readOnly = true)
+    public Page<OrderListResponseDto> getSellingList(Long userId, Pageable pageable) {
+        return getOrdersUseCase.getSellingList(userId, pageable);
+    }
+
+    /**
+     * MARKET: 주문 상세 조회
+     * @param userId 사용자ID
+     * @param orderId 주문ID
+     * @return OrderDetailResponseDto
+     */
+    @Transactional(readOnly = true)
+    public OrderDetailResponseDto getOrderDetail(Long userId, Long orderId) {
+        return getOrdersUseCase.getOrderDetail(userId, orderId);
     }
 }

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -10,6 +10,7 @@ import com.back.market.domain.Order;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -127,4 +128,34 @@ public class MarketSupport {
     public Optional<Bidding> findInstantSellPrice(Long productId, BiddingPosition position, BiddingStatus status) {
         return biddingRepository.findFirstByMarketProductIdAndPositionAndStatusOrderByPriceDesc(productId, position, status);
     }
+
+    /**
+     * 구매 내역 목록 조회
+     * @param userId 사용자 id
+     * @param pageable 페이징
+     * @return Page<Order>
+     */
+    public Page<Order> findBuyHistoryList(Long userId, Pageable pageable) {
+        return orderRepository.findBuyHistoryList(userId, pageable);
+    }
+
+    /**
+     * 판매 내역 목록 조회
+     * @param userId 사용자 id
+     * @param pageable 페이징
+     * @return Page<Order>
+     */
+    public Page<Order> findSellHistoryList(Long userId, Pageable pageable) {
+        return orderRepository.findSellHistoryList(userId, pageable);
+    }
+
+    /**
+     * 주문 상세 조회
+     * @param orderId 주문 PK
+     * @return Order
+     */
+    public Order findOrderWithDetails(Long orderId) {
+        return orderRepository.findByIdWithDetails(orderId).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+    }
+
 }

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -9,12 +9,14 @@ import com.back.market.domain.MarketUser;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
+import com.back.market.domain.enums.OrderStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -130,13 +132,20 @@ public class MarketSupport {
     }
 
     /**
+     * 조회 가능한 주문 상태 리스트 정의(OrderStatus.HOLD 제외)
+     */
+    private static final List<OrderStatus> VISIBLE_STATUSES = Arrays.stream(OrderStatus.values())
+            .filter(status -> status != OrderStatus.HOLD)
+            .toList();
+
+    /**
      * 구매 내역 목록 조회
      * @param userId 사용자 id
      * @param pageable 페이징
      * @return Page<Order>
      */
     public Page<Order> findBuyHistoryList(Long userId, Pageable pageable) {
-        return orderRepository.findBuyHistoryList(userId, pageable);
+        return orderRepository.findBuyHistoryList(userId, VISIBLE_STATUSES, pageable);
     }
 
     /**
@@ -146,7 +155,7 @@ public class MarketSupport {
      * @return Page<Order>
      */
     public Page<Order> findSellHistoryList(Long userId, Pageable pageable) {
-        return orderRepository.findSellHistoryList(userId, pageable);
+        return orderRepository.findSellHistoryList(userId, VISIBLE_STATUSES, pageable);
     }
 
     /**
@@ -154,8 +163,8 @@ public class MarketSupport {
      * @param orderId 주문 PK
      * @return Order
      */
-    public Order findOrderWithDetails(Long orderId) {
-        return orderRepository.findByIdWithDetails(orderId).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+    public Order findOrderWithDetails(Long userId, Long orderId) {
+        return orderRepository.findOrderWithDetails(userId, orderId).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
     }
 
 }

--- a/market/src/main/java/com/back/market/app/usecase/GetOrdersUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetOrdersUseCase.java
@@ -48,13 +48,7 @@ public class GetOrdersUseCase {
      */
     public OrderDetailResponseDto getOrderDetail(Long userId, Long orderId) {
 
-        Order order = marketSupport.findOrderWithDetails(orderId);
-        Long buyerId = order.getBuyBidding().getMarketUser().getId();
-        Long sellerId = order.getSellBidding().getMarketUser().getId();
-
-        if (!userId.equals(buyerId) && !userId.equals(sellerId)) {
-            throw new BadRequestException(FailureCode.ORDER_ACCESS_DENIED);
-        }
+        Order order = marketSupport.findOrderWithDetails(userId, orderId);
         return orderMapper.toOrderDetailResponseDto(order);
     }
 

--- a/market/src/main/java/com/back/market/app/usecase/GetOrdersUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetOrdersUseCase.java
@@ -1,0 +1,61 @@
+package com.back.market.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.market.app.MarketSupport;
+import com.back.market.domain.Order;
+import com.back.market.dto.response.OrderDetailResponseDto;
+import com.back.market.dto.response.OrderListResponseDto;
+import com.back.market.mapper.OrderMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetOrdersUseCase {
+    private final MarketSupport marketSupport;
+    private final OrderMapper orderMapper;
+
+    /**
+     * 구매 내역 목록 조회
+     * @param userId 사용자 ID
+     * @param pageable 페이징
+     * @return Page<OrderListResponseDto>
+     */
+    public Page<OrderListResponseDto> getBuyingList(Long userId, Pageable pageable) {
+        Page<Order> orders = marketSupport.findBuyHistoryList(userId, pageable);
+        return orders.map(orderMapper::toOrderListResponseDto);
+    }
+
+    /**
+     * 판매 내역 목록 조회
+     * @param userId 사용자 ID
+     * @param pageable 페이징
+     * @return Page<OrderListResponseDto>
+     */
+    public Page<OrderListResponseDto> getSellingList(Long userId, Pageable pageable) {
+        Page<Order> orders = marketSupport.findSellHistoryList(userId, pageable);
+        return orders.map(orderMapper::toOrderListResponseDto);
+    }
+
+    /**
+     * 주문 상세 내역 조회
+     * @param userId 사용자 ID
+     * @param orderId 주문 ID
+     * @return OrderDetailResponseDto
+     */
+    public OrderDetailResponseDto getOrderDetail(Long userId, Long orderId) {
+
+        Order order = marketSupport.findOrderWithDetails(orderId);
+        Long buyerId = order.getBuyBidding().getMarketUser().getId();
+        Long sellerId = order.getSellBidding().getMarketUser().getId();
+
+        if (!userId.equals(buyerId) && !userId.equals(sellerId)) {
+            throw new BadRequestException(FailureCode.ORDER_ACCESS_DENIED);
+        }
+        return orderMapper.toOrderDetailResponseDto(order);
+    }
+
+}

--- a/market/src/main/java/com/back/market/config/QueryDslConfig.java
+++ b/market/src/main/java/com/back/market/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.back.market.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/market/src/main/java/com/back/market/dto/response/OrderDetailResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/OrderDetailResponseDto.java
@@ -15,6 +15,6 @@ public record OrderDetailResponseDto(
         BigDecimal price,
         OrderStatus orderStatus,
         String address,
-        LocalDateTime paymentDate //결제 완료일(requestPaymentDate)
+        LocalDateTime paymentDate //결제 완료일(paymentDate)
 ) {
 }

--- a/market/src/main/java/com/back/market/dto/response/OrderDetailResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/OrderDetailResponseDto.java
@@ -1,0 +1,20 @@
+package com.back.market.dto.response;
+
+import com.back.market.domain.enums.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderDetailResponseDto(
+        Long orderId,
+        String productNumber,
+        String productName,
+        String productSize,
+        String brandName,
+        String thumbnailImage,
+        BigDecimal price,
+        OrderStatus orderStatus,
+        String address,
+        LocalDateTime paymentDate //결제 완료일(requestPaymentDate)
+) {
+}

--- a/market/src/main/java/com/back/market/dto/response/OrderListResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/OrderListResponseDto.java
@@ -1,0 +1,18 @@
+package com.back.market.dto.response;
+
+import com.back.market.domain.enums.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderListResponseDto(
+        Long orderId,
+        String productName,
+        String productImageUrl,
+        String size,
+        BigDecimal price,
+        OrderStatus orderStatus,
+        LocalDateTime orderDate //DB의 requestPaymentDate 컬럼
+) {
+
+}

--- a/market/src/main/java/com/back/market/dto/response/OrderListResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/OrderListResponseDto.java
@@ -12,7 +12,7 @@ public record OrderListResponseDto(
         String size,
         BigDecimal price,
         OrderStatus orderStatus,
-        LocalDateTime orderDate //DB의 requestPaymentDate 컬럼
+        LocalDateTime paymentDate //DB의 paymentDate 컬럼
 ) {
 
 }

--- a/market/src/main/java/com/back/market/mapper/OrderMapper.java
+++ b/market/src/main/java/com/back/market/mapper/OrderMapper.java
@@ -2,8 +2,11 @@ package com.back.market.mapper;
 
 import com.back.common.dto.settlement.SettlementTargetOrder;
 import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.OrderStatus;
+import com.back.market.dto.response.OrderDetailResponseDto;
+import com.back.market.dto.response.OrderListResponseDto;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -32,6 +35,38 @@ public class OrderMapper {
                 sellBid.getMarketUser().getName(),      // 판매자 이름
                 order.getPrice(),                       // 주문 가격
                 order.getLastModifiedAt()               // 구매 확정 일시(마지막으로 수정된 날짜)
+        );
+    }
+
+    // 주문 목록 조회용
+    public OrderListResponseDto toOrderListResponseDto(Order order) {
+        MarketProduct product = order.getBuyBidding().getMarketProduct();
+        return new OrderListResponseDto(
+                order.getId(),
+                product.getName(),
+                product.getThumbnailImage(),
+                product.getProductOption(),
+                order.getPrice(),
+                order.getOrderStatus(),
+                order.getRequestPaymentDate()
+        );
+    }
+
+    // 주문 상세 조회용
+    public OrderDetailResponseDto toOrderDetailResponseDto(Order order) {
+        // 구매 입찰이나 판매입찰이나 상품 정보는 동일하므로 구매 입찰로 조회
+        MarketProduct product = order.getBuyBidding().getMarketProduct();
+        return new OrderDetailResponseDto(
+                order.getId(),
+                product.getProductNumber(),
+                product.getName(),
+                product.getProductOption(),
+                product.getBrandName(),
+                product.getThumbnailImage(),
+                order.getPrice(),
+                order.getOrderStatus(),
+                order.getAddress(),
+                order.getRequestPaymentDate()
         );
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #234 

## 🔎 작업 내용

- 구매 내역, 판매 내역, 주문 상세 정보 조회 api 구현
- JPQL을 QueryDSL로 리팩토링, 리팩토링 후 정상 동작(리팩토링 전과 동일한 결과) 확인 완료
- 리팩토링 과정에서 400에러 반환하지 않고 쿼리로 처리하게끔 수정하였음

<br>

## 📷 테스트 결과
- 판매 내역 조회 api
  <img width="1566" height="826" alt="image" src="https://github.com/user-attachments/assets/8ff3aeb7-91cd-47c0-ae1a-a9dc1d2742e5" />

- 구매 내역 조회 api
   <img width="1533" height="753" alt="image" src="https://github.com/user-attachments/assets/db7f4867-9b3d-4ca4-81e2-5f063d3f14b7" />

- 주문 상세 조회 api 
   <img width="1520" height="893" alt="image" src="https://github.com/user-attachments/assets/b03c4558-69b6-4ad0-a33a-dc450f467fe6" />

- ~~주문 상세 조회 api에서 예외 상황: 타 사용자가 다른 사람의 주문 상세 내역을 조회하려고 할 경우 400에러 반환~~
   <img width="1512" height="1025" alt="image" src="https://github.com/user-attachments/assets/f1eea577-fc39-428c-a518-91a65fc61640" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
