### PR TITLE
[FIX] 제네릭 타입 소거 문제로 TypeReference 기반 역직렬화 전환 및 로컬 Stub 추가 (#273)

### DIFF
--- a/settlement/src/main/java/com/back/settlement/adapter/in/stub/CashPayoutStubListener.java
+++ b/settlement/src/main/java/com/back/settlement/adapter/in/stub/CashPayoutStubListener.java
@@ -1,0 +1,54 @@
+package com.back.settlement.adapter.in.stub;
+
+import com.back.common.event.Envelope;
+import com.back.common.event.KafkaEventPublisher;
+import com.back.settlement.app.event.payload.PayoutRequestPayload;
+import com.back.settlement.app.event.payload.PayoutResultPayload;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("local")
+public class CashPayoutStubListener {
+    private final KafkaEventPublisher kafkaEventPublisher;
+    private final ObjectMapper objectMapper;
+    private final String resultTopic;
+
+    public CashPayoutStubListener(KafkaEventPublisher kafkaEventPublisher, ObjectMapper objectMapper, @Value("${kafka.topic.cash-payout-completed}") String resultTopic) {
+        this.kafkaEventPublisher = kafkaEventPublisher;
+        this.objectMapper = objectMapper;
+        this.resultTopic = resultTopic;
+    }
+
+    @KafkaListener(
+            topics = "${kafka.topic.settlement-payout-request}",
+            groupId = "settlement-stub-group"
+    )
+    public void handlePayoutRequest(String message) {
+        Envelope<PayoutRequestPayload> event;
+        try {
+            event = objectMapper.readValue(message, new TypeReference<Envelope<PayoutRequestPayload>>(){});
+        } catch (Exception e) {
+            log.error("[LOCAL STUB] 캐시 지급 요청 메시지 역직렬화 실패. message={}", message, e);
+            return;
+        }
+
+        PayoutRequestPayload request = event.payload();
+        log.info("[LOCAL STUB] 캐시 지급 요청 수신. settlementId={}, payeeId={}, netAmount={}",
+                request.settlementId(), request.payeeId(), request.totalNetAmount());
+
+        Envelope<PayoutResultPayload> result = Envelope.of(
+                "cash.payout.completed",
+                new PayoutResultPayload(request.settlementId(), true, null)
+        );
+
+        kafkaEventPublisher.publish(resultTopic, result);
+        log.info("[LOCAL STUB] 캐시 지급 성공 응답 발행. settlementId={}", request.settlementId());
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListener.java
+++ b/settlement/src/main/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListener.java
@@ -5,6 +5,8 @@ import com.back.settlement.adapter.out.SettlementRepository;
 import com.back.settlement.app.event.payload.PayoutResultPayload;
 import com.back.settlement.app.support.DomainEventPublisher;
 import com.back.settlement.domain.Settlement;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -17,14 +19,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class CashPayoutResultKafkaListener {
     private final SettlementRepository settlementRepository;
     private final DomainEventPublisher domainEventPublisher;
+    private final ObjectMapper objectMapper;
 
     @KafkaListener(
             topics = "${kafka.topic.cash-payout-completed}",
-            groupId = "${kafka.consumer.group-id}",
-            properties = "spring.json.value.default.type=com.back.common.event.Envelope"
+            groupId = "${kafka.consumer.group-id}"
     )
     @Transactional
-    public void listen(Envelope<PayoutResultPayload> event) {
+    public void listen(String message) {
+        Envelope<PayoutResultPayload> event;
+        try {
+            event = objectMapper.readValue(message, new TypeReference<Envelope<PayoutResultPayload>>() {});
+        } catch (Exception e) {
+            log.error("캐시 지급 결과 메시지 역직렬화 실패. message={}", message, e);
+            return;
+        }
+
         PayoutResultPayload data = event.payload();
         log.info("캐시 지급 결과 수신. eventId={}, settlementId={}, success={}", event.header().eventId(), data.settlementId(), data.success());
 

--- a/settlement/src/main/java/com/back/settlement/config/ObjectMapperConfig.java
+++ b/settlement/src/main/java/com/back/settlement/config/ObjectMapperConfig.java
@@ -1,0 +1,15 @@
+package com.back.settlement.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+}

--- a/settlement/src/test/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListenerIntegrationTest.java
+++ b/settlement/src/test/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListenerIntegrationTest.java
@@ -94,6 +94,22 @@ class CashPayoutResultKafkaListenerIntegrationTest {
         }
     }
 
+    private String consumeRawMessage() {
+        try (KafkaConsumer<String, String> consumer = createStringConsumer()) {
+            consumer.subscribe(List.of(TOPIC));
+            log.info("[수신 대기] 토픽 '{}' 구독ing", TOPIC);
+
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
+            log.info("[수신 완료] 수신된 메시지 개수: {}", records.count());
+
+            assertThat(records.count()).isGreaterThanOrEqualTo(1);
+
+            ConsumerRecord<String, String> record = records.iterator().next();
+            log.info("[원본 JSON] {}", record.value());
+            return record.value();
+        }
+    }
+
     private KafkaConsumer<String, String> createStringConsumer() {
         Map<String, Object> props = new HashMap<>(KafkaTestUtils.consumerProps("test-listener-group", "true", embeddedKafka));
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -138,12 +154,12 @@ class CashPayoutResultKafkaListenerIntegrationTest {
             DomainEventPublisher eventPublisher = mock(DomainEventPublisher.class);
             given(repository.findById(settlementId)).willReturn(Optional.of(settlement));
 
-            CashPayoutResultKafkaListener listener = new CashPayoutResultKafkaListener(repository, eventPublisher);
+            CashPayoutResultKafkaListener listener = new CashPayoutResultKafkaListener(repository, eventPublisher, objectMapper);
             log.info("[테스트 시작] 캐시 지급 성공 메시지 처리 테스트");
 
             // when
             publishToKafka(new PayoutResultPayload(settlementId, true, null));
-            Envelope<PayoutResultPayload> received = consumeAndDeserialize();
+            String received = consumeRawMessage();
 
             log.info("[리스너 호출] listener.listen() 실행");
             listener.listen(received);
@@ -175,12 +191,12 @@ class CashPayoutResultKafkaListenerIntegrationTest {
             DomainEventPublisher eventPublisher = mock(DomainEventPublisher.class);
             given(repository.findById(settlementId)).willReturn(Optional.of(settlement));
 
-            CashPayoutResultKafkaListener listener = new CashPayoutResultKafkaListener(repository, eventPublisher);
+            CashPayoutResultKafkaListener listener = new CashPayoutResultKafkaListener(repository, eventPublisher, objectMapper);
             log.info("[테스트 시작] 캐시 지급 실패 메시지 처리 테스트");
 
             // when
             publishToKafka(new PayoutResultPayload(settlementId, false, failReason));
-            Envelope<PayoutResultPayload> received = consumeAndDeserialize();
+            String received = consumeRawMessage();
 
             log.info("[리스너 호출] listener.listen()");
             listener.listen(received);
@@ -211,12 +227,12 @@ class CashPayoutResultKafkaListenerIntegrationTest {
             DomainEventPublisher eventPublisher = mock(DomainEventPublisher.class);
             given(repository.findById(settlementId)).willReturn(Optional.empty());
 
-            CashPayoutResultKafkaListener listener = new CashPayoutResultKafkaListener(repository, eventPublisher);
+            CashPayoutResultKafkaListener listener = new CashPayoutResultKafkaListener(repository, eventPublisher, objectMapper);
             log.info("[테스트 시작] 정산서가 없는 경우 메시지 처리 테스트");
 
             // when
             publishToKafka(new PayoutResultPayload(settlementId, true, null));
-            Envelope<PayoutResultPayload> received = consumeAndDeserialize();
+            String received = consumeRawMessage();
 
             log.info("[리스너 호출] listener.listen() 실행...");
             listener.listen(received);

--- a/settlement/src/test/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListenerTest.java
+++ b/settlement/src/test/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListenerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,8 @@ class CashPayoutResultKafkaListenerTest {
 
     private CashPayoutResultKafkaListener listener;
 
-    private void setupListener() {
+    @BeforeEach
+    void setUp() {
         listener = new CashPayoutResultKafkaListener(settlementRepository, domainEventPublisher, objectMapper);
     }
 
@@ -68,7 +70,6 @@ class CashPayoutResultKafkaListenerTest {
             Long settlementId = 1L;
             Settlement settlement = createSettlement(settlementId, SettlementStatus.IN_PROGRESS);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
-            setupListener();
 
             // when
             listener.listen(successMessage(settlementId));
@@ -91,7 +92,6 @@ class CashPayoutResultKafkaListenerTest {
             String failReason = "잔액 부족";
             Settlement settlement = createSettlement(settlementId, SettlementStatus.IN_PROGRESS);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
-            setupListener();
 
             // when
             listener.listen(failureMessage(settlementId, failReason));
@@ -112,7 +112,6 @@ class CashPayoutResultKafkaListenerTest {
             // given
             Long settlementId = 999L;
             given(settlementRepository.findById(settlementId)).willReturn(Optional.empty());
-            setupListener();
 
             // when
             listener.listen(successMessage(settlementId));
@@ -133,7 +132,6 @@ class CashPayoutResultKafkaListenerTest {
             Long settlementId = 1L;
             Settlement settlement = createSettlement(settlementId, SettlementStatus.COMPLETED);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
-            setupListener();
 
             // when
             listener.listen(successMessage(settlementId));
@@ -150,7 +148,6 @@ class CashPayoutResultKafkaListenerTest {
             Long settlementId = 1L;
             Settlement settlement = createSettlement(settlementId, SettlementStatus.FAILED);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
-            setupListener();
 
             // when
             listener.listen(failureMessage(settlementId, "잔액 부족"));

--- a/settlement/src/test/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListenerTest.java
+++ b/settlement/src/test/java/com/back/settlement/app/event/handler/CashPayoutResultKafkaListenerTest.java
@@ -12,12 +12,14 @@ import com.back.settlement.app.support.DomainEventPublisher;
 import com.back.settlement.domain.Settlement;
 import com.back.settlement.domain.SettlementStatus;
 import com.back.settlement.fixture.SettlementFixture;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,30 +27,33 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayName("캐시 지급 요청 결과를 받는 단위 테스트")
 class CashPayoutResultKafkaListenerTest {
 
+    private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
     @Mock
     private SettlementRepository settlementRepository;
 
     @Mock
     private DomainEventPublisher domainEventPublisher;
 
-    @InjectMocks
     private CashPayoutResultKafkaListener listener;
+
+    private void setupListener() {
+        listener = new CashPayoutResultKafkaListener(settlementRepository, domainEventPublisher, objectMapper);
+    }
 
     private Settlement createSettlement(Long id, SettlementStatus status) {
         return SettlementFixture.createSettlement(id, 1L, "판매자", status);
     }
 
-    private Envelope<PayoutResultPayload> successEvent(Long settlementId) {
-        return Envelope.of(
-                "settlement.payout.result",
-                new PayoutResultPayload(settlementId, true, null)
+    private String successMessage(Long settlementId) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(
+                Envelope.of("settlement.payout.result", new PayoutResultPayload(settlementId, true, null))
         );
     }
 
-    private Envelope<PayoutResultPayload> failureEvent(Long settlementId, String reason) {
-        return Envelope.of(
-                "settlement.payout.result",
-                new PayoutResultPayload(settlementId, false, reason)
+    private String failureMessage(Long settlementId, String reason) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(
+                Envelope.of("settlement.payout.result", new PayoutResultPayload(settlementId, false, reason))
         );
     }
 
@@ -58,14 +63,15 @@ class CashPayoutResultKafkaListenerTest {
 
         @Test
         @DisplayName("정산 상태를 COMPLETED로 변경하고 도메인 이벤트를 발행한다")
-        void completesSettlementAndPublishesEvents() {
+        void completesSettlementAndPublishesEvents() throws Exception {
             // given
             Long settlementId = 1L;
             Settlement settlement = createSettlement(settlementId, SettlementStatus.IN_PROGRESS);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
+            setupListener();
 
             // when
-            listener.listen(successEvent(settlementId));
+            listener.listen(successMessage(settlementId));
 
             // then
             assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
@@ -79,15 +85,16 @@ class CashPayoutResultKafkaListenerTest {
 
         @Test
         @DisplayName("정산 상태를 FAILED로 변경하고 실패 사유와 함께 도메인 이벤트를 발행한다")
-        void failsSettlementWithReasonAndPublishesEvents() {
+        void failsSettlementWithReasonAndPublishesEvents() throws Exception {
             // given
             Long settlementId = 1L;
             String failReason = "잔액 부족";
             Settlement settlement = createSettlement(settlementId, SettlementStatus.IN_PROGRESS);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
+            setupListener();
 
             // when
-            listener.listen(failureEvent(settlementId, failReason));
+            listener.listen(failureMessage(settlementId, failReason));
 
             // then
             assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.FAILED);
@@ -101,13 +108,14 @@ class CashPayoutResultKafkaListenerTest {
 
         @Test
         @DisplayName("도메인 이벤트를 발행하지 않고 조기 종료한다")
-        void doesNothingWhenNotFound() {
+        void doesNothingWhenNotFound() throws Exception {
             // given
             Long settlementId = 999L;
             given(settlementRepository.findById(settlementId)).willReturn(Optional.empty());
+            setupListener();
 
             // when
-            listener.listen(successEvent(settlementId));
+            listener.listen(successMessage(settlementId));
 
             // then
             then(domainEventPublisher).should(never()).publishEvents(org.mockito.ArgumentMatchers.any());
@@ -120,14 +128,15 @@ class CashPayoutResultKafkaListenerTest {
 
         @Test
         @DisplayName("COMPLETED 상태 → 중복 처리 방지, 아무 변경 없이 종료한다")
-        void ignoresAlreadyCompletedSettlement() {
+        void ignoresAlreadyCompletedSettlement() throws Exception {
             // given
             Long settlementId = 1L;
             Settlement settlement = createSettlement(settlementId, SettlementStatus.COMPLETED);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
+            setupListener();
 
             // when
-            listener.listen(successEvent(settlementId));
+            listener.listen(successMessage(settlementId));
 
             // then
             assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.COMPLETED);
@@ -136,14 +145,15 @@ class CashPayoutResultKafkaListenerTest {
 
         @Test
         @DisplayName("FAILED 상태 → 중복 처리 방지, 아무 변경 없이 종료한다")
-        void ignoresAlreadyFailedSettlement() {
+        void ignoresAlreadyFailedSettlement() throws Exception {
             // given
             Long settlementId = 1L;
             Settlement settlement = createSettlement(settlementId, SettlementStatus.FAILED);
             given(settlementRepository.findById(settlementId)).willReturn(Optional.of(settlement));
+            setupListener();
 
             // when
-            listener.listen(failureEvent(settlementId, "잔액 부족"));
+            listener.listen(failureMessage(settlementId, "잔액 부족"));
 
             // then
             assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.FAILED);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #273 

## 🔎 작업 내용
- CashPayoutResultKafkaListener의 역직렬화 방식을 제네릭 타입 소거 문제 해결을 위해 TypeReference 기반 수동 역직렬화로 전환
- JavaTimeModule이 등록된 ObjectMapper 빈 등록
- 로컬 환경에서 Cash 모듈 없이 정산 플로우 테스트를 위한 CashPayoutStubListener 추가
- 역직렬화 방식 변경에 따른 단위/통합 테스트 코드 수정

## 트러블 슈팅 정리 내용
<img width="1000" height="528" alt="스크린샷 2026-02-09 오후 3 29 44" src="https://github.com/user-attachments/assets/c9324eeb-c854-4f0d-a07d-55635c7a1f15" />

- [Kafka Envelope 역직렬화 오류](https://www.notion.so/2f815a0120548011ab48e955d4207bd7)

<br>

## 📌 참고 사항

- 집중 리뷰
    - CashPayoutResultKafkaListener: String → TypeReference<Envelope<PayoutResultPayload>> 역직렬화 방식 변경
<br>

## 📷 테스트 결과
<img width="1701" height="799" alt="스크린샷 2026-02-09 오후 2 46 00" src="https://github.com/user-attachments/assets/7eb1bd1b-6d18-49e4-8d6d-c241b89bb752" width="50%" height="50%"/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
