### PR TITLE
[FEAT] AOP 기반 공통 로깅 기능(@Loggable) 도입 및 적용 (#285)

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,4 +13,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop:4.0.0-M2'
+    implementation 'org.aspectj:aspectjweaver'
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -15,6 +15,5 @@ dependencies {
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     // AOP
-    implementation 'org.springframework.boot:spring-boot-starter-aop:4.0.0-M2'
-    implementation 'org.aspectj:aspectjweaver'
+    implementation 'org.springframework.boot:spring-boot-starter-aspectj'
 }

--- a/common/src/main/java/com/back/common/annotation/LogLevel.java
+++ b/common/src/main/java/com/back/common/annotation/LogLevel.java
@@ -1,0 +1,5 @@
+package com.back.common.annotation;
+
+public enum LogLevel {
+    TRACE, DEBUG, INFO, WARN, ERROR
+}

--- a/common/src/main/java/com/back/common/annotation/Loggable.java
+++ b/common/src/main/java/com/back/common/annotation/Loggable.java
@@ -1,0 +1,46 @@
+package com.back.common.annotation;
+
+import com.back.common.aop.LoggingAspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 이 어노테이션은 메서드 실행 시 로깅을 적용할 메서드를 표시하는 데 사용됩니다.
+ * AOP {@link LoggingAspect} 에 의해 처리됩니다.
+ *
+ * 이 어노테이션의 속성을 통해 로깅 동작을 세밀하게 제어할 수 있습니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Loggable {
+
+    /**
+     * 해당 메서드의 로깅 레벨을 지정합니다.
+     * 기본값은 INFO입니다.
+     */
+    LogLevel level() default LogLevel.INFO;
+
+    /**
+     * 메서드 인자의 로깅 여부를 지정합니다.
+     * 민감한 정보가 포함된 메서드의 경우 false로 설정할 수 있습니다.
+     * 기본값은 true입니다.
+     */
+    boolean logArgs() default true;
+
+    /**
+     * 메서드 반환 값의 로깅 여부를 지정합니다.
+     * 민감한 정보나 너무 큰 객체를 반환하는 메서드의 경우 false로 설정할 수 있습니다.
+     * 기본값은 true입니다.
+     */
+    boolean logResult() default true;
+
+    /**
+     * 메서드 실행 시간이 이 임계값(밀리초)을 초과할 경우 WARN 레벨로 로그를 남깁니다.
+     * 0 이하의 값은 임계값을 사용하지 않음을 의미합니다.
+     * 기본값은 -1입니다.
+     */
+    long warnThresholdMillis() default -1;
+}

--- a/common/src/main/java/com/back/common/aop/LoggingAspect.java
+++ b/common/src/main/java/com/back/common/aop/LoggingAspect.java
@@ -1,0 +1,88 @@
+package com.back.common.aop;
+
+import com.back.common.annotation.LogLevel;
+import com.back.common.annotation.Loggable;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @Pointcut("@annotation(com.back.common.annotation.Loggable)")
+    public void loggableMethods() {}
+
+    @Around("loggableMethods()")
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Loggable loggable = method.getAnnotation(Loggable.class);
+
+        String className = signature.getDeclaringTypeName();
+        String methodName = signature.getName();
+        Object[] args = joinPoint.getArgs();
+
+        LogLevel logLevel = loggable.level();
+        boolean logArgs = loggable.logArgs();
+        boolean logResult = loggable.logResult();
+        long warnThresholdMillis = loggable.warnThresholdMillis();
+
+        String argsString = logArgs ? Arrays.toString(args) : "[인자 로깅 비활성화]";
+
+        logAtLevel(logLevel, log, ">>>> {}.{}() 호출. Args: {}", className, methodName, argsString);
+
+        Object result = null;
+        long startTime = System.currentTimeMillis();
+        try {
+            result = joinPoint.proceed(); // Execute the method
+            return result;
+        } catch (IllegalArgumentException e) {
+            log.error("#### {}.{}() 에서 잘못된 인자: {} in {}", className, methodName, argsString, e.getMessage());
+            throw e;
+        } catch (Throwable e) {
+            log.error("#### {}.{}() 에서 예외 발생: {}", className, methodName, e.getMessage());
+            throw e;
+        } finally {
+            long endTime = System.currentTimeMillis();
+            long executionTime = endTime - startTime;
+
+            String resultString = logResult ? String.valueOf(result) : "[반환 값 로깅 비활성화]";
+
+            logAtLevel(logLevel, log, "<<<< {}.{}() 종료. 실행 시간: {}ms. 반환 값: {}", className, methodName, executionTime, resultString);
+
+            if (warnThresholdMillis > 0 && executionTime > warnThresholdMillis) {
+                log.warn("#### {}.{}() 경고: 실행 시간이 임계값 {}ms를 초과했습니다 ({}ms).", className, methodName, warnThresholdMillis, executionTime);
+            }
+        }
+    }
+
+    private void logAtLevel(LogLevel level, Logger logger, String format, Object... arguments) {
+        switch (level) {
+            case TRACE:
+                if (logger.isTraceEnabled()) logger.trace(format, arguments);
+                break;
+            case DEBUG:
+                if (logger.isDebugEnabled()) logger.debug(format, arguments);
+                break;
+            case INFO:
+                if (logger.isInfoEnabled()) logger.info(format, arguments);
+                break;
+            case WARN:
+                if (logger.isWarnEnabled()) logger.warn(format, arguments);
+                break;
+            case ERROR:
+                if (logger.isErrorEnabled()) logger.error(format, arguments);
+                break;
+        }
+    }
+}

--- a/common/src/main/java/com/back/common/aop/LoggingAspect.java
+++ b/common/src/main/java/com/back/common/aop/LoggingAspect.java
@@ -47,10 +47,10 @@ public class LoggingAspect {
             result = joinPoint.proceed(); // Execute the method
             return result;
         } catch (IllegalArgumentException e) {
-            log.error("#### {}.{}() 에서 잘못된 인자: {} in {}", className, methodName, argsString, e.getMessage());
+            log.error("#### {}.{}() 에서 잘못된 인자: {} in {}", className, methodName, argsString, e.getMessage(), e);
             throw e;
         } catch (Throwable e) {
-            log.error("#### {}.{}() 에서 예외 발생: {}", className, methodName, e.getMessage());
+            log.error("#### {}.{}() 에서 예외 발생: {}", className, methodName, e.getMessage(), e);
             throw e;
         } finally {
             long endTime = System.currentTimeMillis();

--- a/image/src/main/java/com/back/image/app/ImageFacade.java
+++ b/image/src/main/java/com/back/image/app/ImageFacade.java
@@ -1,5 +1,6 @@
 package com.back.image.app;
 
+import com.back.common.annotation.Loggable;
 import com.back.image.app.usecase.ConvertImageUseCase;
 import com.back.image.app.usecase.FlushImageUseCase;
 import com.back.image.app.usecase.ResizeImageUseCase;
@@ -24,6 +25,7 @@ public class ImageFacade {
     private final UploadImageUseCase uploadImageUseCase;
     private final FlushImageUseCase flushImageUseCase;
 
+    @Loggable
     public ImageUploadResponseDto uploadImage(List<MultipartFile> images, ImageCategory category) {
         List<File> allTemporaryFiles = new ArrayList<>();
 

--- a/image/src/main/java/com/back/image/app/ImageFacade.java
+++ b/image/src/main/java/com/back/image/app/ImageFacade.java
@@ -25,7 +25,7 @@ public class ImageFacade {
     private final UploadImageUseCase uploadImageUseCase;
     private final FlushImageUseCase flushImageUseCase;
 
-    @Loggable
+    @Loggable(logArgs = false, logResult = false)
     public ImageUploadResponseDto uploadImage(List<MultipartFile> images, ImageCategory category) {
         List<File> allTemporaryFiles = new ArrayList<>();
 

--- a/image/src/main/java/com/back/image/app/usecase/ConvertImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ConvertImageUseCase.java
@@ -1,5 +1,6 @@
 package com.back.image.app.usecase;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.image.utils.ImageUtility;
@@ -20,6 +21,7 @@ import java.util.UUID;
 public class ConvertImageUseCase {
     private final ImageUtility imageUtility;
 
+    @Loggable
     public List<File> convertMultipleFile(List<MultipartFile> multipartFiles) {
         return multipartFiles.stream().map(mf -> {
             try {
@@ -31,6 +33,7 @@ public class ConvertImageUseCase {
         }).toList();
     }
 
+    @Loggable
     public File convertFile(MultipartFile multipartFile) {
         try {
             if (multipartFile == null || multipartFile.isEmpty()) {

--- a/image/src/main/java/com/back/image/app/usecase/ConvertImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ConvertImageUseCase.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class ConvertImageUseCase {
     private final ImageUtility imageUtility;
 
-    @Loggable
+    @Loggable(logArgs = false)
     public List<File> convertMultipleFile(List<MultipartFile> multipartFiles) {
         return multipartFiles.stream().map(mf -> {
             try {
@@ -33,7 +33,7 @@ public class ConvertImageUseCase {
         }).toList();
     }
 
-    @Loggable
+    @Loggable(logArgs = false)
     public File convertFile(MultipartFile multipartFile) {
         try {
             if (multipartFile == null || multipartFile.isEmpty()) {

--- a/image/src/main/java/com/back/image/app/usecase/FlushImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/FlushImageUseCase.java
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FlushImageUseCase {
 
-    @Loggable
+    @Loggable(logArgs = false)
     public void flushMultipleFile(List<File> tempFiles) {
         if (tempFiles == null || tempFiles.isEmpty()) {
             return;
@@ -34,7 +34,7 @@ public class FlushImageUseCase {
         }
     }
 
-    @Loggable
+    @Loggable(logArgs = false)
     public boolean flushFile(File tempFile) {
         if (tempFile == null) return true;
 

--- a/image/src/main/java/com/back/image/app/usecase/FlushImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/FlushImageUseCase.java
@@ -1,5 +1,6 @@
 package com.back.image.app.usecase;
 
+import com.back.common.annotation.Loggable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class FlushImageUseCase {
+
+    @Loggable
     public void flushMultipleFile(List<File> tempFiles) {
         if (tempFiles == null || tempFiles.isEmpty()) {
             return;
@@ -31,6 +34,7 @@ public class FlushImageUseCase {
         }
     }
 
+    @Loggable
     public boolean flushFile(File tempFile) {
         if (tempFile == null) return true;
 

--- a/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
@@ -1,5 +1,6 @@
 package com.back.image.app.usecase;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.image.config.ImageResizeProperties;
@@ -23,6 +24,7 @@ public class ResizeImageUseCase {
     private final ImageUtility imageUtility;
     private final ImageResizeProperties imageResizeProperties;
 
+    @Loggable
     public List<File> resizeMultipleImage(List<File> convertedImages) {
         return convertedImages.stream().map(f -> {
             try {
@@ -34,6 +36,7 @@ public class ResizeImageUseCase {
         }).toList();
     }
 
+    @Loggable
     public File resizeImage(File convertedImage) {
         try {
             if (convertedImage == null || !convertedImage.exists()) {

--- a/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
@@ -24,7 +24,7 @@ public class ResizeImageUseCase {
     private final ImageUtility imageUtility;
     private final ImageResizeProperties imageResizeProperties;
 
-    @Loggable
+    @Loggable(logArgs = false)
     public List<File> resizeMultipleImage(List<File> convertedImages) {
         return convertedImages.stream().map(f -> {
             try {
@@ -36,7 +36,7 @@ public class ResizeImageUseCase {
         }).toList();
     }
 
-    @Loggable
+    @Loggable(logArgs = false)
     public File resizeImage(File convertedImage) {
         try {
             if (convertedImage == null || !convertedImage.exists()) {

--- a/image/src/main/java/com/back/image/app/usecase/UploadImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/UploadImageUseCase.java
@@ -3,6 +3,7 @@ package com.back.image.app.usecase;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.image.config.AwsS3Properties;
@@ -25,6 +26,7 @@ public class UploadImageUseCase {
     private final AmazonS3Client amazonS3Client;
     private final AwsS3Properties awsS3Properties;
 
+    @Loggable
     public List<String> uploadMultipleImage(List<File> resizedFiles, String dirName) {
         return resizedFiles.stream().map(f -> {
             try {
@@ -36,6 +38,7 @@ public class UploadImageUseCase {
         }).toList();
     }
 
+    @Loggable
     public String uploadImage(File resizedFile, String dirName) {
         try {
             if (resizedFile == null || !resizedFile.exists()) {

--- a/image/src/main/java/com/back/image/app/usecase/UploadImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/UploadImageUseCase.java
@@ -26,7 +26,7 @@ public class UploadImageUseCase {
     private final AmazonS3Client amazonS3Client;
     private final AwsS3Properties awsS3Properties;
 
-    @Loggable
+    @Loggable(logArgs = false)
     public List<String> uploadMultipleImage(List<File> resizedFiles, String dirName) {
         return resizedFiles.stream().map(f -> {
             try {
@@ -38,7 +38,7 @@ public class UploadImageUseCase {
         }).toList();
     }
 
-    @Loggable
+    @Loggable(logArgs = false)
     public String uploadImage(File resizedFile, String dirName) {
         try {
             if (resizedFile == null || !resizedFile.exists()) {

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1BrandController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1BrandController.java
@@ -1,5 +1,6 @@
 package com.back.product.adapter.in.web.controller;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.adapter.in.web.api.BrandApiController;
@@ -21,6 +22,7 @@ public class ApiV1BrandController implements BrandApiController {
     private final ProductFacade productFacade;
 
     @Override
+    @Loggable
     @GetMapping
     public CommonResponse<BrandListResponseDto> getBrands() {
         BrandListResponseDto response = BrandListResponseDto.builder()
@@ -30,6 +32,7 @@ public class ApiV1BrandController implements BrandApiController {
     }
 
     @Override
+    @Loggable
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<BrandListResponseDto> createBrands(@RequestBody @Valid BrandListCreateRequestDto request) {
@@ -38,6 +41,7 @@ public class ApiV1BrandController implements BrandApiController {
     }
 
     @Override
+    @Loggable
     @PutMapping("/{brandId}")
     public CommonResponse<BrandResponseDto> modifyBrand(
             @PathVariable Long brandId,
@@ -47,6 +51,7 @@ public class ApiV1BrandController implements BrandApiController {
     }
 
     @Override
+    @Loggable
     @DeleteMapping("/{brandId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<?> deleteBrand(@PathVariable Long brandId) {

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1CategoryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1CategoryController.java
@@ -1,5 +1,6 @@
 package com.back.product.adapter.in.web.controller;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.adapter.in.web.api.CategoryApiController;
@@ -21,6 +22,7 @@ public class ApiV1CategoryController implements CategoryApiController {
     private final ProductFacade productFacade;
 
     @Override
+    @Loggable
     @GetMapping
     public CommonResponse<CategoryListResponseDto> getCategories() {
         CategoryListResponseDto response = CategoryListResponseDto.builder()
@@ -30,6 +32,7 @@ public class ApiV1CategoryController implements CategoryApiController {
     }
 
     @Override
+    @Loggable
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<CategoryListResponseDto> createCategories(@RequestBody @Valid CategoryListCreateRequestDto request) {
@@ -38,6 +41,7 @@ public class ApiV1CategoryController implements CategoryApiController {
     }
 
     @Override
+    @Loggable
     @PutMapping("/{categoryId}")
     public CommonResponse<CategoryResponseDto> modifyCategory(
             @PathVariable Long categoryId,
@@ -47,6 +51,7 @@ public class ApiV1CategoryController implements CategoryApiController {
     }
 
     @Override
+    @Loggable
     @DeleteMapping("/{categoryId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<?> deleteCategory(@PathVariable Long categoryId) {

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ImageController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ImageController.java
@@ -1,5 +1,6 @@
 package com.back.product.adapter.in.web.controller;
 
+import com.back.common.annotation.Loggable;
 import com.back.image.app.ImageFacade;
 import com.back.image.dto.enums.ImageCategory;
 import com.back.common.code.SuccessCode;
@@ -20,6 +21,7 @@ public class ApiV1ImageController implements ImageApiController {
     private final ImageFacade imageFacade;
 
     @Override
+    @Loggable
     @PostMapping(path = "/upload/{category}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CommonResponse<ImageUploadResponseDto> uploadImages(
             @PathVariable ImageCategory category,

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1OptionController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1OptionController.java
@@ -1,5 +1,6 @@
 package com.back.product.adapter.in.web.controller;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.adapter.in.web.api.OptionApiController;
@@ -25,6 +26,7 @@ public class ApiV1OptionController implements OptionApiController {
     private final ProductFacade productFacade;
 
     @Override
+    @Loggable
     @GetMapping
     public CommonResponse<OptionListResponseDto> getOptions() {
         OptionListResponseDto response = productFacade.getOptions();
@@ -32,6 +34,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
+    @Loggable
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<OptionListResponseDto> createOptions(@Valid @RequestBody OptionListCreateRequestDto request) {
@@ -40,6 +43,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
+    @Loggable
     @PostMapping(path = "/{optionGroupId}")
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<OptionResponseDto> appendOptions(
@@ -50,6 +54,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
+    @Loggable
     @PutMapping("/groups/{optionGroupId}")
     public CommonResponse<OptionGroupModifyResponseDto> modifyOptionGroup(
             @PathVariable Long optionGroupId,
@@ -59,6 +64,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
+    @Loggable
     @PutMapping("/values/{optionValueId}")
     public CommonResponse<OptionValueModifyResponseDto> modifyOptionValue(
             @PathVariable Long optionValueId,
@@ -68,6 +74,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
+    @Loggable
     @DeleteMapping("/groups/{optionGroupId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<?> deleteOptionGroup(@PathVariable Long optionGroupId) {
@@ -76,6 +83,7 @@ public class ApiV1OptionController implements OptionApiController {
     }
 
     @Override
+    @Loggable
     @DeleteMapping("/values/{optionValueId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<?> deleteOptionValue(@PathVariable Long optionValueId) {

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductCommandController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductCommandController.java
@@ -1,5 +1,6 @@
 package com.back.product.adapter.in.web.controller;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.adapter.in.web.api.ProductCommandApiController;
@@ -20,6 +21,7 @@ public class ApiV1ProductCommandController implements ProductCommandApiControlle
     private final ProductFacade productFacade;
 
     @Override
+    @Loggable
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<ProductDetailResponseDto> createProduct(@Valid @RequestBody ProductCreateRequestDto request) {
@@ -28,6 +30,7 @@ public class ApiV1ProductCommandController implements ProductCommandApiControlle
     }
 
     @Override
+    @Loggable
     @PutMapping("/{productInfoId}")
     public CommonResponse<ProductDetailResponseDto> updateProduct(
             @PathVariable Long productInfoId,
@@ -38,6 +41,7 @@ public class ApiV1ProductCommandController implements ProductCommandApiControlle
     }
 
     @Override
+    @Loggable
     @DeleteMapping("/{productInfoId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public CommonResponse<?> deleteProduct(@PathVariable Long productInfoId) {

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
@@ -1,5 +1,6 @@
 package com.back.product.adapter.in.web.controller;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.SuccessCode;
 import com.back.common.response.CommonResponse;
 import com.back.product.adapter.in.web.api.ProductQueryApiController;
@@ -21,6 +22,7 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     private final ProductFacade productFacade;
 
     @Override
+    @Loggable
     @GetMapping("/{productInfoId}")
     public CommonResponse<ProductDetailResponseDto> getProductDetail(@PathVariable Long productInfoId) {
         ProductDetailResponseDto response = productFacade.getProductDetail(productInfoId);
@@ -28,6 +30,7 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     }
 
     @Override
+    @Loggable
     @GetMapping
     public CommonResponse<ProductSearchResponseDto> searchProducts(
        @ModelAttribute @Valid ProductSearchRequestDto request,
@@ -39,6 +42,7 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     }
 
     @Override
+    @Loggable
     @GetMapping("/variants")
     public CommonResponse<ProductDetailListResponseDto> getProducts(@Valid @ModelAttribute ProductQueryRequestDto request) {
         ProductDetailListResponseDto response = productFacade.getProducts(request);

--- a/product/src/main/java/com/back/product/app/facade/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/facade/ProductFacade.java
@@ -1,5 +1,6 @@
 package com.back.product.app.facade;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.product.app.usecase.command.*;
@@ -47,11 +48,13 @@ public class ProductFacade {
     private final ProductVariantCreateCommandMapper productVariantCreateCommandMapper;
     private final ProductVariantUpdateCommandMapper productVariantUpdateCommandMapper;
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<BrandDto> getBrands() {
         return brandUseCase.getBrands();
     }
 
+    @Loggable
     @Transactional
     public BrandListResponseDto createBrands(@Valid BrandListCreateRequestDto request) {
         List<BrandDataCommand> brandsCommands = request.brands().stream().map(brandDataCommandMapper::toCommand).toList();
@@ -59,6 +62,7 @@ public class ProductFacade {
         return brandMapper.toListResponseDto(brandDtos);
     }
 
+    @Loggable
     @Transactional
     public BrandResponseDto modifyBrand(Long brandId, @Valid BrandDataRequestDto request) {
         BrandDataCommand brandCommand = brandDataCommandMapper.toCommand(request);
@@ -66,6 +70,7 @@ public class ProductFacade {
         return brandMapper.toResponseDto(brandDto);
     }
 
+    @Loggable
     @Transactional
     public void deleteBrand(Long brandId) {
         Boolean isUsed = productInfoUseCase.isBrandInUse(brandId);
@@ -77,11 +82,13 @@ public class ProductFacade {
         brandUseCase.deleteBrand(brandId);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<CategoryDto> getCategories() {
         return categoryUseCase.getCategories();
     }
 
+    @Loggable
     @Transactional
     public CategoryListResponseDto createCategories(@Valid CategoryListCreateRequestDto request) {
         List<CategoryDataCommand> categoryCommands = request.categories().stream().map(categoryDataCommandMapper::toCommand).toList();
@@ -89,6 +96,7 @@ public class ProductFacade {
         return categoryMapper.toListResponseDto(categoryDtos);
     }
 
+    @Loggable
     @Transactional
     public CategoryResponseDto modifyCategory(Long categoryId, @Valid CategoryDataRequestDto request) {
         CategoryDataCommand categoryCommand = categoryDataCommandMapper.toCommand(request);
@@ -96,6 +104,7 @@ public class ProductFacade {
         return categoryMapper.toResponseDto(categoryDto);
     }
 
+    @Loggable
     @Transactional
     public void deleteCategory(Long categoryId) {
         Boolean isUsed = productInfoUseCase.isCategoryInUse(categoryId);
@@ -107,12 +116,14 @@ public class ProductFacade {
         categoryUseCase.deleteCategory(categoryId);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public ProductDetailListResponseDto getProducts(@Valid ProductQueryRequestDto request) {
         List<ProductDetailDto> productDetailDtos = productUseCase.findMultipleProduct(request.productIds());
         return productMapper.toListResponseDto(productDetailDtos);
     }
 
+    @Loggable
     @Transactional
     public ProductDetailResponseDto createProduct(@Valid ProductCreateRequestDto request) {
         Brand brand = brandUseCase.findBrandExists(request.productInfo().brandId());
@@ -132,6 +143,7 @@ public class ProductFacade {
         return productMapper.toResponseDto(productInfoDto, productDtos);
     }
 
+    @Loggable
     @Transactional
     public ProductDetailResponseDto updateProduct(Long productInfoId, @Valid ProductUpdateRequestDto request) {
         Brand brand = brandUseCase.findBrandExists(request.productInfo().brandId());
@@ -151,6 +163,7 @@ public class ProductFacade {
         return productMapper.toResponseDto(productInfoDto, productDtos);
     }
 
+    @Loggable
     @Transactional
     public void deleteProduct(Long productInfoId) {
         productUseCase.deleteMultipleProduct(productInfoId);
@@ -160,6 +173,7 @@ public class ProductFacade {
         publishProductDeleteEvent(productInfoId);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public ProductDetailResponseDto getProductDetail(Long productInfoId) {
         ProductInfo productInfo = productInfoUseCase.findProductInfo(productInfoId);
@@ -171,12 +185,14 @@ public class ProductFacade {
         return productMapper.toResponseDto(productInfoDto, productDtos);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public ProductSearchResponseDto findProductPage(@Valid ProductSearchRequestDto request, Long page, Long size) {
         ProductSearchCommand productSearchCommand = productSearchCommandMapper.toCommand(request, page, size);
         return productDocumentUseCase.findProductPage(productSearchCommand);
     }
 
+    @Loggable
     @Transactional
     public OptionListResponseDto createOptions(@Valid OptionListCreateRequestDto request) {
         List<OptionCreateCommand> optionCreateCommands = request.options().stream().map(optionCreateCommandMapper::toCommand).toList();
@@ -184,22 +200,26 @@ public class ProductFacade {
         return optionMapper.toListResponseDto(optionDtos);
     }
 
+    @Loggable
     @Transactional
     public OptionResponseDto appendOptions(Long optionGroupId, @Valid OptionAppendRequestDto request) {
         OptionDto optionDto = optionUseCase.appendOptions(optionGroupId, request.values());
         return optionMapper.toResponseDto(optionDto);
     }
 
+    @Loggable
     @Transactional
     public OptionGroupModifyResponseDto modifyOptionGroup(Long optionGroupId, @Valid OptionGroupModifyRequestDto request) {
         return optionUseCase.modifyOptionGroup(optionGroupId, request.name());
     }
 
+    @Loggable
     @Transactional
     public OptionValueModifyResponseDto modifyOptionValue(Long optionValueId, @Valid OptionValueModifyRequestDto request) {
         return optionUseCase.modifyOptionValue(request.optionGroupId(), optionValueId, request.name());
     }
 
+    @Loggable
     @Transactional
     public void deleteOptionGroup(Long optionGroupId) {
         Boolean isUsed = productUseCase.isOptionGroupInUse(optionGroupId);
@@ -211,6 +231,7 @@ public class ProductFacade {
         optionUseCase.deleteOptions(optionGroupId);
     }
 
+    @Loggable
     @Transactional
     public void deleteOptionValue(Long optionValueId) {
         Boolean isUsed = productUseCase.isOptionValueInUse(optionValueId);
@@ -222,6 +243,7 @@ public class ProductFacade {
         optionUseCase.deleteOption(optionValueId);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public OptionListResponseDto getOptions() {
         List<OptionDto> optionDtos = optionUseCase.findAllOptions();

--- a/product/src/main/java/com/back/product/app/usecase/command/BrandUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/BrandUseCase.java
@@ -1,5 +1,6 @@
 package com.back.product.app.usecase.command;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.common.exception.InvalidValueException;
@@ -27,11 +28,13 @@ public class BrandUseCase {
     private final ProductSupport productSupport;
     private final BrandRepository brandRepository;
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<BrandDto> getBrands() {
         return productSupport.getAllBrands().stream().map(brandMapper::toDto).toList();
     }
 
+    @Loggable
     @Transactional
     public List<BrandDto> createBrands(List<BrandDataCommand> brands) {
         Map<String, Brand> existsBrands = productSupport.getAllBrands().stream()
@@ -52,12 +55,14 @@ public class BrandUseCase {
         return createdBrands.stream().map(brandMapper::toDto).toList();
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public Brand findBrandExists(Long brandId) {
         return productSupport.findBrandById(brandId)
                 .orElseThrow(() -> new CustomException(FailureCode.BRAND_NOT_FOUND));
     }
 
+    @Loggable
     @Transactional
     public BrandDto modifyBrand(Long brandId, BrandDataCommand brand) {
         Brand brandToModify = findBrandExists(brandId);
@@ -78,6 +83,7 @@ public class BrandUseCase {
         return brandMapper.toDto(brandToModify);
     }
 
+    @Loggable
     @Transactional
     public void deleteBrand(Long brandId) {
         brandRepository.deleteById(brandId);

--- a/product/src/main/java/com/back/product/app/usecase/command/CategoryUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/CategoryUseCase.java
@@ -1,5 +1,6 @@
 package com.back.product.app.usecase.command;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.common.exception.InvalidValueException;
@@ -27,11 +28,13 @@ public class CategoryUseCase {
     private final ProductSupport productSupport;
     private final CategoryRepository categoryRepository;
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<CategoryDto> getCategories() {
         return productSupport.getAllCategories().stream().map(categoryMapper::toDto).toList();
     }
 
+    @Loggable
     @Transactional
     public List<CategoryDto> createCategories(List<CategoryDataCommand> categories) {
         Map<String, Category> existsCategories = productSupport.getAllCategories().stream()
@@ -53,12 +56,14 @@ public class CategoryUseCase {
         return newCategories.stream().map(categoryMapper::toDto).toList();
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public Category findCategoryExists(Long categoryId) {
         return productSupport.findCategoryById(categoryId)
                 .orElseThrow(() -> new CustomException(FailureCode.CATEGORY_NOT_FOUND));
     }
 
+    @Loggable
     @Transactional
     public CategoryDto modifyCategory(Long categoryId, CategoryDataCommand category) {
         Category categoryToModify = findCategoryExists(categoryId);
@@ -79,6 +84,7 @@ public class CategoryUseCase {
         return categoryMapper.toDto(categoryToModify);
     }
 
+    @Loggable
     @Transactional
     public void deleteCategory(Long categoryId) {
         categoryRepository.deleteById(categoryId);

--- a/product/src/main/java/com/back/product/app/usecase/command/OptionUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/OptionUseCase.java
@@ -1,5 +1,6 @@
 package com.back.product.app.usecase.command;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.persistence.OptionGroupRepository;
@@ -41,6 +42,7 @@ public class OptionUseCase {
     private final OptionGroupRepository optionGroupRepository;
     private final OptionValueRepository optionValueRepository;
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<OptionDto> findAllOptions() {
         List<OptionGroup> optionGroups = productSupport.getAllProductOptionGroups();
@@ -58,6 +60,7 @@ public class OptionUseCase {
         }).toList();
     }
 
+    @Loggable
     @Transactional
     public List<OptionDto> createOptions(List<OptionCreateCommand> options) {
         return options.stream()
@@ -65,6 +68,7 @@ public class OptionUseCase {
                 .toList();
     }
 
+    @Loggable
     @Transactional
     public OptionDto createOption(String groupName, List<String> valueNames) {
         OptionGroup group = productSupport.getOptionGroupByName(groupName.toLowerCase());
@@ -80,6 +84,7 @@ public class OptionUseCase {
         return optionMapper.toDto(group, createdValues);
     }
 
+    @Loggable
     @Transactional
     public OptionDto appendOptions(Long optionGroupId, List<String> values) {
         OptionGroup group = productSupport.getOptionGroupById(optionGroupId)
@@ -92,6 +97,7 @@ public class OptionUseCase {
         return optionMapper.toDto(group, createdValues);
     }
 
+    @Loggable
     @Transactional
     public OptionGroupModifyResponseDto modifyOptionGroup(Long optionGroupId, String name) {
         OptionGroup existsGroup = productSupport.getOptionGroupById(optionGroupId)
@@ -102,6 +108,7 @@ public class OptionUseCase {
         return optionGroupMapper.toModifyResponseDto(existsGroup);
     }
 
+    @Loggable
     @Transactional
     public OptionValueModifyResponseDto modifyOptionValue(Long optionGroupId, Long optionValueId, String name) {
         OptionValue existsValue = productSupport.getOptionValueById(optionValueId)
@@ -119,6 +126,7 @@ public class OptionUseCase {
         return optionValueMapper.toModifyResponseDto(existsValue);
     }
 
+    @Loggable
     @Transactional
     public void deleteOptions(Long optionGroupId) {
         optionValueRepository.deleteAllByOptionGroup_Id(optionGroupId);
@@ -126,6 +134,7 @@ public class OptionUseCase {
         optionGroupRepository.deleteById(optionGroupId);
     }
 
+    @Loggable
     @Transactional
     public void deleteOption(Long optionValueId) {
         optionValueRepository.deleteById(optionValueId);

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -2,6 +2,7 @@ package com.back.product.app.usecase.command;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import com.back.common.annotation.Loggable;
 import com.back.product.adapter.out.document.ProductDocumentRepository;
 import com.back.product.app.usecase.query.ProductDocumentSupport;
 import com.back.product.document.ProductDocument;
@@ -31,6 +32,7 @@ public class ProductDocumentUseCase {
     private final ProductDocumentMapper productDocumentMapper;
     private final ProductDocumentRepository productDocumentRepository;
 
+    @Loggable
     @Transactional
     public void syncProduct(ProductInfoDto productInfoDto, List<OptionDto> optionDtos, String thumbnailUrl) {
         ProductDocument documentToSync = productDocumentMapper.toDocument(productInfoDto, optionDtos, thumbnailUrl);
@@ -40,11 +42,13 @@ public class ProductDocumentUseCase {
         productDocumentRepository.save(documentToSync);
     }
 
+    @Loggable
     @Transactional
     public void deleteProduct(Long productInfoId) {
         productDocumentRepository.deleteById(productInfoId.toString());
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public ProductSearchResponseDto findProductPage(ProductSearchCommand search) {
         Query query = buildSearchQuery(

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductInfoUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductInfoUseCase.java
@@ -1,16 +1,14 @@
 package com.back.product.app.usecase.command;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.persistence.ProductInfoRepository;
 import com.back.product.app.usecase.query.ProductSupport;
 import com.back.product.domain.Brand;
-import com.back.product.domain.Category;
 import com.back.product.domain.ProductInfo;
 import com.back.product.dto.command.ProductInfoDataCommand;
-import com.back.product.dto.request.ProductInfoDataRequestDto;
 import com.back.product.mapper.ProductInfoMapper;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +20,7 @@ public class ProductInfoUseCase {
     private final ProductInfoRepository productInfoRepository;
     private final ProductSupport productSupport;
 
+    @Loggable
     @Transactional
     public ProductInfo createProductInfo(ProductInfoDataCommand productInfo) {
         isDuplicateProductInfo(productInfo.brand(), productInfo.code());
@@ -37,6 +36,7 @@ public class ProductInfoUseCase {
         }
     }
 
+    @Loggable
     @Transactional
     public ProductInfo updateProductInfo(Long productInfoId, ProductInfoDataCommand productInfo) {
         ProductInfo productInfoToUpdate = productSupport.findProductInfoById(productInfoId)
@@ -47,6 +47,7 @@ public class ProductInfoUseCase {
         return productInfoToUpdate;
     }
 
+    @Loggable
     @Transactional
     public void deleteProductInfo(Long productInfoId) {
         ProductInfo productInfo = getProductInfoExists(productInfoId);
@@ -54,6 +55,7 @@ public class ProductInfoUseCase {
         productInfoRepository.delete(productInfo);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public ProductInfo findProductInfo(Long productInfoId) {
         return getProductInfoExists(productInfoId);
@@ -64,11 +66,13 @@ public class ProductInfoUseCase {
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
     }
 
+    @Loggable
     @Transactional
     public Boolean isBrandInUse(Long brandId) {
         return productSupport.existsProductInfoByBrand(brandId);
     }
 
+    @Loggable
     @Transactional
     public Boolean isCategoryInUse(Long categoryId) {
         return productSupport.existsProductInfoByCategory(categoryId);

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductUseCase.java
@@ -110,7 +110,7 @@ public class ProductUseCase {
     }
 
     @Loggable
-    private void handleCreations(ProductInfo productInfo, List<ProductVariantUpdateCommand> variantsToCreate, Map<Long, OptionValue> optionValueMap) {
+    public void handleCreations(ProductInfo productInfo, List<ProductVariantUpdateCommand> variantsToCreate, Map<Long, OptionValue> optionValueMap) {
         List<Product> createdProducts = new ArrayList<>();
         List<ProductOptionValues> createdProductOptionValues = new ArrayList<>();
         List<ProductImage> createdImages = new ArrayList<>();
@@ -136,7 +136,7 @@ public class ProductUseCase {
     }
 
     @Loggable
-    private void handleUpdates(ProductInfo productInfo, List<ProductVariantUpdateCommand> variantsToUpdate, Map<Long, OptionValue> optionValueMap, List<Product> existProducts) {
+    public void handleUpdates(ProductInfo productInfo, List<ProductVariantUpdateCommand> variantsToUpdate, Map<Long, OptionValue> optionValueMap, List<Product> existProducts) {
         Map<Long, Product> existProductsMap = existProducts.stream()
                 .collect(Collectors.toMap(Product::getId, p -> p));
 
@@ -166,7 +166,7 @@ public class ProductUseCase {
     }
 
     @Loggable
-    private void handleDeletes(List<Product> existProducts, List<ProductVariantUpdateCommand> variants) {
+    public void handleDeletes(List<Product> existProducts, List<ProductVariantUpdateCommand> variants) {
         Set<Long> requestIds = variants.stream()
                 .map(ProductVariantUpdateCommand::productId)
                 .filter(Objects::nonNull)

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductUseCase.java
@@ -1,5 +1,6 @@
 package com.back.product.app.usecase.command;
 
+import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.persistence.ProductImageRepository;
@@ -32,6 +33,7 @@ public class ProductUseCase {
     private final ProductImageRepository productImageRepository;
     private final ProductSupport productSupport;
 
+    @Loggable
     @Transactional
     public List<ProductDto> createMultipleProduct(ProductInfo productInfo, List<ProductVariantCreateCommand> variants) {
         List<Long> allOptionValueIds = variants.stream()
@@ -62,6 +64,7 @@ public class ProductUseCase {
         return buildProductDto(newProducts, newProductOptionValues, newProductImages);
     }
 
+    @Loggable
     @Transactional
     public List<ProductDto> updateMultipleProduct(ProductInfo productInfo, List<ProductVariantUpdateCommand> variants) {
         List<Product> existProducts = productSupport.getAllProductsByProductInfo(productInfo);
@@ -84,12 +87,14 @@ public class ProductUseCase {
         return findAllProduct(productInfo);
     }
 
+    @Loggable
     @Transactional
     public void deleteMultipleProduct(Long productInfoId) {
         List<Product> deletedProducts = productSupport.getAllProductsByProductInfoId(productInfoId);
         deleteProducts(deletedProducts);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<ProductDto> findAllProduct(ProductInfo productInfo) {
         List<Product> products = productSupport.getAllProductsByProductInfo(productInfo);
@@ -104,6 +109,7 @@ public class ProductUseCase {
         return buildProductDto(products, productOptionValues, productImages);
     }
 
+    @Loggable
     private void handleCreations(ProductInfo productInfo, List<ProductVariantUpdateCommand> variantsToCreate, Map<Long, OptionValue> optionValueMap) {
         List<Product> createdProducts = new ArrayList<>();
         List<ProductOptionValues> createdProductOptionValues = new ArrayList<>();
@@ -129,6 +135,7 @@ public class ProductUseCase {
         productImageRepository.saveAll(createdImages);
     }
 
+    @Loggable
     private void handleUpdates(ProductInfo productInfo, List<ProductVariantUpdateCommand> variantsToUpdate, Map<Long, OptionValue> optionValueMap, List<Product> existProducts) {
         Map<Long, Product> existProductsMap = existProducts.stream()
                 .collect(Collectors.toMap(Product::getId, p -> p));
@@ -158,6 +165,7 @@ public class ProductUseCase {
         productImageRepository.saveAll(updatedProductImages);
     }
 
+    @Loggable
     private void handleDeletes(List<Product> existProducts, List<ProductVariantUpdateCommand> variants) {
         Set<Long> requestIds = variants.stream()
                 .map(ProductVariantUpdateCommand::productId)
@@ -236,16 +244,19 @@ public class ProductUseCase {
         ).toList();
     }
 
+    @Loggable
     @Transactional
     public Boolean isOptionGroupInUse(Long optionGroupId) {
         return productSupport.existsProductByOptionGroupId(optionGroupId);
     }
 
+    @Loggable
     @Transactional
     public Boolean isOptionValueInUse(Long optionValueId) {
         return productSupport.existsProductByOptionValueId(optionValueId);
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public List<ProductDetailDto> findMultipleProduct(List<Long> productIds) {
         List<Product> products = productSupport.findMultipleProductByIds(productIds);


### PR DESCRIPTION
## ✨ 관련 이슈

* **Resolved:** #285

## 🔎 작업 내용

애플리케이션 전반의 실행 흐름 추적과 성능 모니터링을 위해 AOP를 활용한 공통 로깅 메커니즘을 구축했습니다.

### 1. AOP 기반 로깅 시스템 구축

* **`@Loggable` 커스텀 어노테이션 정의:** 메서드 레벨에 부여하여 로깅 여부를 선언적으로 제어할 수 있습니다.
* **`LogLevel` Enum 도입:** `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` 등 상황에 맞는 로그 레벨 지정이 가능합니다.
* **`LoggingAspect` 구현:** * 메서드 실행 전후의 인자(Args), 반환 값(Result), 실행 시간(Duration)을 자동으로 기록합니다.
* **임계값 기반 경고:** 실행 시간이 설정된 임계값(`warnThresholdMillis`)을 초과할 경우 경고 로그를 남겨 성능 병목 지점을 파악합니다.



### 2. 핵심 비즈니스 로직 적용

* **대상 모듈:** `image`, `product`
* **적용 범위:** 주요 `Facade`, `UseCase`, `Controller` 계층
* **기대 효과:** API 호출부터 내부 유스케이스 실행까지의 전체 흐름을 가시화하여 장애 대응 및 성능 최적화에 기여합니다.

---

## 📌 참고 사항

### 🎯 집중 리뷰 요청

* **`common` 모듈:** `Loggable` 어노테이션 정의와 `LoggingAspect` 내부 로직이 효율적으로 작성되었는지 확인 부탁드립니다.
* **세부 제어:** 민감한 정보 유출 방지를 위해 `logArgs = false` 또는 `logResult = false` 옵션이 필요한 지점에 적절히 적용되었는지 검토가 필요합니다.

### 💡 기타 안내 사항

* **성능 모니터링:** 실행 시간 로그를 통해 운영 중 병목 구간을 신속히 파악할 수 있습니다.
* **설정 변경:** `warnThresholdMillis` 값은 운영 환경의 요구사항에 따라 향후 `application.yml` 등을 통해 동적으로 조정할 수 있도록 확장성을 고려했습니다.

## 📷 테스트 결과

* AOP 로깅 기능이 정상적으로 인터셉트하여 로그를 출력하는지 확인을 완료했습니다.

<img width="1901" height="516" alt="메인페이지 조회 로그" src="https://github.com/user-attachments/assets/5b32ddc5-8b3d-41f3-8baf-1b410c2a5c45" />

<img width="1909" height="331" alt="이미지 업로드 로그" src="https://github.com/user-attachments/assets/37a4ab90-3c8a-4e60-a535-102bf25b8169" />

---

## ✅ Check List

* [x] 라벨 지정
* [x] 리뷰어 지정
* [x] 담당자 지정
* [x] 테스트 완료
* [x] 이슈 제목 컨벤션 준수
* [x] PR 제목 및 설명 작성
* [x] 커밋 메시지 컨벤션 준수