### PR TITLE
[REFACTOR] 회원가입 이벤트 수신 시 envelope 적용 (#289)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/kafka/MarketUserEventListener.java
@@ -1,13 +1,16 @@
 package com.back.market.adapter.in.kafka;
 
 import com.back.common.code.FailureCode;
+import com.back.common.event.Envelope;
 import com.back.common.exception.CustomException;
-import com.back.common.user.event.UserCreatedEvent;
 import com.back.market.app.MarketInternalFacade;
+import com.back.market.dto.payload.UserCreatedPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Component
@@ -15,29 +18,27 @@ import org.springframework.stereotype.Component;
 public class MarketUserEventListener {
 
     private final MarketInternalFacade marketInternalFacade;
+    private final JsonMapper jsonMapper;
 
     @KafkaListener(
             topics = "${custom.kafka.topic.user-account-created}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void consume(UserCreatedEvent event) {
-        log.info("[MarketUserEventListener] UserCreatedEvent 수신: {}", event.id());
+    public void consume(String message) {
+        log.info("[MarketUserEventListener] UserCreatedEvent 수신: {}", message);
+
+        Envelope<UserCreatedPayload> event;
 
         try {
-            if (event.id() == null || event.email() == null) {
-                log.error("[MarketUserEventListener] 잘못된 UserCreatedEvent 수신: id={}, email={}", event.id(), event.email());
-                throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
-            }
-            marketInternalFacade.handleUserCreatedEvent(event);
-            log.info("[MarketUserEventListener] UserCreatedEvent 처리 완료: id={}", event.id());
-        } catch (CustomException e) {
-            log.error("[MarketUserEventListener] 비즈니스 예외 발생: id={}, code={}, message={}", event.id(), e.getFailureCode().getCode(), e.getMessage());
-            throw e;
+            event = jsonMapper.readValue(message, new TypeReference<Envelope<UserCreatedPayload>>() {});
         } catch (Exception e) {
-            log.error("[MarketUserEventListener] UserCreatedEvent 처리 중 오류 발생: id={}, error={}", event.id(), e.getMessage());
+            log.error("[MarketUserEventListener] UserCreatedEvent 파싱 중 오류 발생: {}", e.getMessage());
             throw new CustomException(FailureCode.INTERNAL_SERVER_ERROR);
         }
 
+        UserCreatedPayload payload = event.payload();
+        marketInternalFacade.handleUserCreatedEvent(payload);
     }
 
 }
+

--- a/market/src/main/java/com/back/market/app/MarketInternalFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketInternalFacade.java
@@ -1,13 +1,14 @@
 package com.back.market.app;
 
 import com.back.common.dto.settlement.SettlementTargetOrder;
-import com.back.common.user.event.UserCreatedEvent;
 import com.back.market.app.usecase.ConfirmPaymentUseCase;
 import com.back.common.dto.cash.request.PaymentCompletedRequestDto;
 import com.back.market.app.usecase.CreateCartUseCase;
 import com.back.market.app.usecase.CreateMarketMemberUseCase;
 import com.back.market.app.usecase.GetSettlementDataUseCase;
 import com.back.market.domain.MarketUser;
+import com.back.market.dto.payload.UserCreatedPayload;
+import com.back.market.event.UserCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -50,7 +51,16 @@ public class MarketInternalFacade {
      * 회원 가입 이벤트 수신 시 market_member 복제와 cart 생성
      */
     @Transactional
-    public void handleUserCreatedEvent(UserCreatedEvent event) {
+    public void handleUserCreatedEvent(UserCreatedPayload payload) {
+        // payload의 값을 사용해 이벤트 생성
+        UserCreatedEvent event = new UserCreatedEvent(
+                payload.id(),
+                payload.name(),
+                payload.email(),
+                payload.address(),
+                payload.phone()
+        );
+
         // 회원 정보 복제
         MarketUser user = createMarketMemberUseCase.createMarketMember(event);
 

--- a/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CreateMarketMemberUseCase.java
@@ -2,10 +2,10 @@ package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.CustomException;
-import com.back.common.user.event.UserCreatedEvent;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.app.MarketSupport;
 import com.back.market.domain.MarketUser;
+import com.back.market.event.UserCreatedEvent;
 import com.back.market.mapper.MarketUserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/market/src/main/java/com/back/market/dto/payload/UserCreatedPayload.java
+++ b/market/src/main/java/com/back/market/dto/payload/UserCreatedPayload.java
@@ -1,0 +1,12 @@
+package com.back.market.dto.payload;
+
+import com.back.common.event.KafkaPayload;
+
+public record UserCreatedPayload(
+        Long id,
+        String name,
+        String email,
+        String address,
+        String phone
+) implements KafkaPayload {
+}

--- a/market/src/main/java/com/back/market/event/UserCreatedEvent.java
+++ b/market/src/main/java/com/back/market/event/UserCreatedEvent.java
@@ -1,0 +1,12 @@
+package com.back.market.event;
+
+import com.back.common.event.EventName;
+
+public record UserCreatedEvent(
+        Long id,
+        String name,
+        String email,
+        String address,
+        String phone
+) implements EventName {
+}

--- a/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
+++ b/market/src/test/java/com/back/market/event/KafkaIntegrationTest.java
@@ -1,9 +1,11 @@
 package com.back.market.event;
 
-import com.back.common.user.event.UserCreatedEvent;
+import com.back.common.event.Envelope;
 import com.back.market.adapter.out.CartRepository;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.domain.MarketUser;
+import com.back.market.dto.payload.UserCreatedPayload;
+import tools.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,26 +23,36 @@ public class KafkaIntegrationTest {
     private MarketUserRepository marketUserRepository;
     @Autowired
     private CartRepository cartRepository;
+    @Autowired
+    private JsonMapper jsonMapper;
 
     @Value("${custom.kafka.topic.user-account-created}")
     private String topic;
 
     @Test
-    void test1() throws InterruptedException {
+    void test1() throws Exception {
         long testId = 300L;
-        UserCreatedEvent event = new UserCreatedEvent(
+        
+        // 1. 페이로드 생성
+        UserCreatedPayload userCreatedPayload = new UserCreatedPayload(
                 testId,
-                "테스트유저2",
-                "김테스트",
-                "test2@example.com",
-                "서울시 강남구2",
-                "010-1234-5678",
-                "https://dummyimage.com/100x100/000/fff&text=Test2"
+                "김테스트", // 이름
+                "test2@example.com", // 이메일
+                "서울시 강남구2", // 주소
+                "010-1234-5678" // 전화번호
         );
-        kafkaTemplate.send(topic, event);
-        log.info("Event sent to Kafka topic: UserCreatedEvent (id: {})", testId);
 
-        Thread.sleep(3000);
+        // 2. 페이로드를 envelope에 담음
+        Envelope<UserCreatedPayload> envelope = Envelope.of("UserCreatedEvent", userCreatedPayload);
+
+        // 3. envelope를 json 문자열로 직렬화
+        String message = jsonMapper.writeValueAsString(envelope);
+        
+        // 4. kafka로 메시지 전송
+        kafkaTemplate.send(topic, message);
+        log.info("Event sent to Kafka topic: UserCreatedPayload (id: {})", testId);
+
+        Thread.sleep(3000); // 시간차 두기
 
         MarketUser user = marketUserRepository.findById(testId).orElse(null);
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #289

## 🔎 작업 내용

- 이벤트 수신, 발행 시 envelope를 적용한다

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - 작동 자체에는 문제가 없었는데 상의한 내용대로 잘 구현되었는지 확인 부탁드립니다.

<br>

## 📷 테스트 결과

- 기존에 회원가입 이벤트 수신하는 부분을 수정하였고, 동일하게 동작하는 것을 확인했습니다.

<img width="1214" height="374" alt="image" src="https://github.com/user-attachments/assets/05c62eaf-8c02-4b0f-8a32-83ab04db5152" /><br>
<img width="975" height="284" alt="image" src="https://github.com/user-attachments/assets/dbeb434a-6c17-4caf-8f81-9db928e3fe66" /><br>
<img width="518" height="201" alt="image" src="https://github.com/user-attachments/assets/b7651615-2f3e-467d-aa45-9c39c87c52f9" /><br>
<img width="1404" height="626" alt="image" src="https://github.com/user-attachments/assets/58e5f96f-2868-4cea-957a-3e54883e75af" /><br>
<img width="1032" height="343" alt="image" src="https://github.com/user-attachments/assets/72fab108-33d3-4328-972a-5d28d637be4a" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
