### PR TITLE
[FEAT] AI 기반 유사 상품 추천 및 하이브리드 검색 도입 (#281)

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -1,13 +1,5 @@
-ext {
-    springAiVersion = "2.0.0-M2"
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
-    }
-}
-
 dependencies {
+    implementation project(':common')
+
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 }

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -1,0 +1,13 @@
+ext {
+    springAiVersion = "2.0.0-M2"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+}

--- a/ai/src/main/java/com/back/ai/AiApplication.java
+++ b/ai/src/main/java/com/back/ai/AiApplication.java
@@ -1,0 +1,13 @@
+package com.back.ai;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AiApplication.class, args);
+    }
+
+}

--- a/ai/src/main/java/com/back/ai/app/usecase/EmbeddingUseCase.java
+++ b/ai/src/main/java/com/back/ai/app/usecase/EmbeddingUseCase.java
@@ -1,0 +1,17 @@
+package com.back.ai.app.usecase;
+
+import com.back.common.annotation.Loggable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmbeddingUseCase {
+    private final EmbeddingModel embeddingModel;
+
+    @Loggable
+    public float[] generateEmbeddings(String texts) {
+        return embeddingModel.embed(texts);
+    }
+}

--- a/ai/src/main/java/com/back/ai/app/usecase/EmbeddingUseCase.java
+++ b/ai/src/main/java/com/back/ai/app/usecase/EmbeddingUseCase.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
 @Service
 @RequiredArgsConstructor
 public class EmbeddingUseCase {
@@ -13,5 +16,12 @@ public class EmbeddingUseCase {
     @Loggable
     public float[] generateEmbeddings(String texts) {
         return embeddingModel.embed(texts);
+    }
+
+    @Loggable
+    public List<Float> convertArrayToList(float[] embedding) {
+        return IntStream.range(0, embedding.length)
+                        .mapToObj(i -> embedding[i])
+                        .toList();
     }
 }

--- a/ai/src/main/java/com/back/ai/config/AiConfig.java
+++ b/ai/src/main/java/com/back/ai/config/AiConfig.java
@@ -1,0 +1,22 @@
+package com.back.ai.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class AiConfig {
+    @Bean
+    @Profile("default")
+    public ChatClient openAiChatClient(ChatModel openAiChatModel) {
+        return ChatClient.builder(openAiChatModel).build();
+    }
+
+    @Bean
+    @Profile("test")
+    public ChatClient ollamaChatClient(ChatModel ollamaChatModel) {
+        return ChatClient.builder(ollamaChatModel).build();
+    }
+}

--- a/ai/src/main/resources/application-ai.yml
+++ b/ai/src/main/resources/application-ai.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: ai
+  config:
+    import: optional:file:.env[.properties]

--- a/ai/src/test/java/com/back/ai/app/usecase/EmbeddingUseCaseTest.java
+++ b/ai/src/test/java/com/back/ai/app/usecase/EmbeddingUseCaseTest.java
@@ -1,0 +1,130 @@
+package com.back.ai.app.usecase;
+
+import com.back.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EmbeddingUseCase 단위 테스트")
+class EmbeddingUseCaseTest {
+
+    @InjectMocks
+    private EmbeddingUseCase embeddingUseCase;
+
+    @Mock
+    private EmbeddingModel embeddingModel;
+
+    @Nested
+    @DisplayName("generateEmbeddings 메서드")
+    class GenerateEmbeddingsTest {
+
+        @Test
+        @DisplayName("성공: 주어진 텍스트에 대한 임베딩을 성공적으로 생성한다")
+        void generateEmbeddings_Success() {
+            // given
+            String inputText = "Hello, world!";
+            float[] expectedEmbedding = {0.1f, 0.2f, 0.3f};
+            given(embeddingModel.embed(inputText)).willReturn(expectedEmbedding);
+
+            // when
+            float[] result = embeddingUseCase.generateEmbeddings(inputText);
+
+            // then
+            assertThat(result).isEqualTo(expectedEmbedding);
+            verify(embeddingModel).embed(inputText);
+        }
+
+        @Test
+        @DisplayName("실패: 외부 API 호출 실패 시 예외가 발생한다")
+        void generateEmbeddings_ApiFailure() {
+            // given
+            String inputText = "This will fail.";
+            given(embeddingModel.embed(anyString())).willThrow(new RuntimeException("API Error"));
+
+            // when & then
+            assertThatThrownBy(() -> embeddingUseCase.generateEmbeddings(inputText))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("API Error");
+            verify(embeddingModel).embed(inputText);
+        }
+
+        @Test
+        @DisplayName("엣지 케이스: 빈 문자열이 주어졌을 때 정상적으로 처리한다")
+        void generateEmbeddings_EmptyString() {
+            // given
+            String inputText = "";
+            float[] expectedEmbedding = {0.0f, 0.0f, 0.0f}; // Assuming the model returns a zero vector for empty string
+            given(embeddingModel.embed(inputText)).willReturn(expectedEmbedding);
+
+            // when
+            float[] result = embeddingUseCase.generateEmbeddings(inputText);
+
+            // then
+            assertThat(result).isEqualTo(expectedEmbedding);
+            verify(embeddingModel).embed(inputText);
+        }
+        
+        @Test
+        @DisplayName("엣지 케이스: 매우 긴 텍스트가 주어졌을 때 정상적으로 처리한다")
+        void generateEmbeddings_LongString() {
+            // given
+            String longText = "a".repeat(10000);
+            float[] expectedEmbedding = {0.4f, 0.5f, 0.6f};
+            given(embeddingModel.embed(longText)).willReturn(expectedEmbedding);
+
+            // when
+            float[] result = embeddingUseCase.generateEmbeddings(longText);
+
+            // then
+            assertThat(result).isEqualTo(expectedEmbedding);
+            verify(embeddingModel).embed(longText);
+        }
+    }
+
+    @Nested
+    @DisplayName("convertArrayToList 메서드")
+    class ConvertArrayToListTest {
+
+        @Test
+        @DisplayName("성공: float 배열을 List<Float>로 성공적으로 변환한다")
+        void convertArrayToList_Success() {
+            // given
+            float[] inputArray = {0.1f, -0.2f, 3.14f};
+            List<Float> expectedList = List.of(0.1f, -0.2f, 3.14f);
+
+            // when
+            List<Float> result = embeddingUseCase.convertArrayToList(inputArray);
+
+            // then
+            assertThat(result).isEqualTo(expectedList);
+        }
+
+        @Test
+        @DisplayName("엣지 케이스: 빈 배열이 주어졌을 때 빈 리스트를 반환한다")
+        void convertArrayToList_EmptyArray() {
+            // given
+            float[] inputArray = {};
+
+            // when
+            List<Float> result = embeddingUseCase.convertArrayToList(inputArray);
+
+            // then
+            assertThat(result).isNotNull().isEmpty();
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ ext {
     set('jjwtVersion', '0.12.3')
     set('querydslVersion', '5.1.0')
     set('springdocVersion', '3.0.1')
+    set('springAiVersion', '2.0.0-M2')
 }
 
 allprojects {
@@ -42,6 +43,7 @@ subprojects {
     dependencyManagement {
         imports {
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+            mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
         }
     }
 
@@ -87,7 +89,7 @@ subprojects {
 }
 
 // common, security, image 모듈 bootJar 비활성화
-configure(subprojects.findAll { it.name in ['common', 'security', 'image', "ai"] }) {
+configure(subprojects.findAll { it.name in ['common', 'security', 'image', 'ai'] }) {
     bootJar.enabled = false
     jar.enabled = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
 }
 
 // common, security, image 모듈 bootJar 비활성화
-configure(subprojects.findAll { it.name in ['common', 'security', 'image'] }) {
+configure(subprojects.findAll { it.name in ['common', 'security', 'image', "ai"] }) {
     bootJar.enabled = false
     jar.enabled = true
 }

--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -76,6 +76,7 @@ public enum FailureCode {
     USER_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_SETTING_NOT_FOUND", "해당 유저의 알림 세팅을 찾을 수 없습니다."),
     OPTION_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_GROUP_NOT_FOUND", "옵션 그룹이 존재하지 않습니다."),
     CHAT_OUTBOX_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_OUTBOX_NOT_FOUND", "해당 아웃박스를 찾을 수 없습니다."),
+    EMBEDDING_NOT_FOUND(HttpStatus.NOT_FOUND, "EMBEDDING_NOT_FOUND", "상품의 임베딩을 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':common')
     implementation project(':security')
     implementation project(":image")
+    implementation project(":ai")
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'

--- a/product/src/main/java/com/back/product/ProductApplication.java
+++ b/product/src/main/java/com/back/product/ProductApplication.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
         "com.back.common",
         "com.back.security",
         "com.back.image",
-        "com.back.ai",
-        "com.back.security"
+        "com.back.ai"
 })
 public class ProductApplication {
 

--- a/product/src/main/java/com/back/product/ProductApplication.java
+++ b/product/src/main/java/com/back/product/ProductApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
         "com.back.common",
         "com.back.security",
         "com.back.image",
+        "com.back.ai",
         "com.back.security"
 })
 public class ProductApplication {

--- a/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
@@ -16,8 +16,6 @@ public interface ProductQueryApiController {
             ex. A 상품(ProductInfo)의 색상, 사이즈(ProductOptionValues)에 따른 개별 상품(Product) 조회
     """)
     @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공")
-    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
-    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> getProductDetail(Long productInfoId);
 
@@ -29,8 +27,6 @@ public interface ProductQueryApiController {
             5. 페이징 : page (페이지 번호), size (항목 개수)
     """)
     @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공")
-    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
-    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> searchProducts(ProductSearchRequestDto request, Long page, Long size);
 
@@ -41,8 +37,6 @@ public interface ProductQueryApiController {
             ex. 상품의 기본 정보 + 재고 + 옵션 (사이즈 + 색상 + ...) + ... 
     """)
     @ApiResponse(responseCode = "200", description = "단일 항목 상품 다중 조회 성공")
-    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
-    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> getProducts(ProductQueryRequestDto request);
 }

--- a/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
@@ -30,6 +30,15 @@ public interface ProductQueryApiController {
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     CommonResponse<?> searchProducts(ProductSearchRequestDto request, Long page, Long size);
 
+    @Operation(summary = "유사 상품 조회", description = """
+            특정 상품과 유사한 상품들을 조회합니다.
+            KNN 알고리즘을 활용하여 유사한 상품들을 추천합니다.
+            추천할 상품 수는 'count' 파라미터로 지정할 수 있습니다.
+    """)
+    @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공")
+    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    CommonResponse<?> findSimilarProducts(Long productInfoId, Long count);
+
     @Operation(summary = "단일 항목 상품 다중 조회", description = """
             단일 항목 상품의 정보를 다중 조회합니다.
             한 상품의 기본 정보(ProductInfo)를 포함한 단일 상품의 정보를 조회합니다.

--- a/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
@@ -34,7 +34,7 @@ public interface ProductQueryApiController {
     @Operation(summary = "유사 상품 조회", description = """
             특정 상품과 유사한 상품들을 조회합니다.
             KNN 알고리즘을 활용하여 유사한 상품들을 추천합니다.
-            추천할 상품 수는 'count' 파라미터로 지정할 수 있습니다.
+            추천할 상품 수는 'size' 파라미터로 지정할 수 있습니다.
     """)
     @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공")
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)

--- a/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/api/ProductQueryApiController.java
@@ -3,6 +3,7 @@ package com.back.product.adapter.in.web.api;
 import com.back.common.response.CommonResponse;
 import com.back.product.dto.request.ProductQueryRequestDto;
 import com.back.product.dto.request.ProductSearchRequestDto;
+import com.back.product.dto.request.PageRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,7 +29,7 @@ public interface ProductQueryApiController {
     """)
     @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공")
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> searchProducts(ProductSearchRequestDto request, Long page, Long size);
+    CommonResponse<?> searchProducts(ProductSearchRequestDto request);
 
     @Operation(summary = "유사 상품 조회", description = """
             특정 상품과 유사한 상품들을 조회합니다.
@@ -37,7 +38,7 @@ public interface ProductQueryApiController {
     """)
     @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공")
     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
-    CommonResponse<?> findSimilarProducts(Long productInfoId, Long count);
+    CommonResponse<?> findSimilarProducts(Long productInfoId, PageRequestDto request);
 
     @Operation(summary = "단일 항목 상품 다중 조회", description = """
             단일 항목 상품의 정보를 다중 조회합니다.

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
@@ -11,6 +11,7 @@ import com.back.product.dto.response.ProductDetailListResponseDto;
 import com.back.product.dto.response.ProductDetailResponseDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +36,7 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     public CommonResponse<ProductSearchResponseDto> searchProducts(
        @ModelAttribute @Valid ProductSearchRequestDto request,
        @RequestParam(defaultValue = "0") Long page,
-       @RequestParam(defaultValue = "10") Long size
+       @RequestParam(defaultValue = "10") @Max(50) Long size
      ) {
         ProductSearchResponseDto response = productFacade.findProductPage(request, page, size);
         return CommonResponse.success(SuccessCode.OK, response);

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
@@ -44,6 +44,17 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
 
     @Override
     @Loggable
+    @GetMapping("/{productInfoId}/similar")
+    public CommonResponse<ProductSearchResponseDto> findSimilarProducts(
+            @PathVariable Long productInfoId,
+            @RequestParam(defaultValue = "5") @Max(10) Long count
+    ) {
+        ProductSearchResponseDto response = productFacade.findSimilarProducts(productInfoId, count);
+        return CommonResponse.success(SuccessCode.OK, response);
+    }
+
+    @Override
+    @Loggable
     @GetMapping("/variants")
     public CommonResponse<ProductDetailListResponseDto> getProducts(@Valid @ModelAttribute ProductQueryRequestDto request) {
         ProductDetailListResponseDto response = productFacade.getProducts(request);

--- a/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
+++ b/product/src/main/java/com/back/product/adapter/in/web/controller/ApiV1ProductQueryController.java
@@ -7,11 +7,11 @@ import com.back.product.adapter.in.web.api.ProductQueryApiController;
 import com.back.product.app.facade.ProductFacade;
 import com.back.product.dto.request.ProductQueryRequestDto;
 import com.back.product.dto.request.ProductSearchRequestDto;
+import com.back.product.dto.request.PageRequestDto;
 import com.back.product.dto.response.ProductDetailListResponseDto;
 import com.back.product.dto.response.ProductDetailResponseDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -33,12 +33,8 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     @Override
     @Loggable
     @GetMapping
-    public CommonResponse<ProductSearchResponseDto> searchProducts(
-       @ModelAttribute @Valid ProductSearchRequestDto request,
-       @RequestParam(defaultValue = "0") Long page,
-       @RequestParam(defaultValue = "10") @Max(50) Long size
-     ) {
-        ProductSearchResponseDto response = productFacade.findProductPage(request, page, size);
+    public CommonResponse<ProductSearchResponseDto> searchProducts(@ModelAttribute @Valid ProductSearchRequestDto request) {
+        ProductSearchResponseDto response = productFacade.findProductPage(request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
 
@@ -47,9 +43,9 @@ public class ApiV1ProductQueryController implements ProductQueryApiController {
     @GetMapping("/{productInfoId}/similar")
     public CommonResponse<ProductSearchResponseDto> findSimilarProducts(
             @PathVariable Long productInfoId,
-            @RequestParam(defaultValue = "5") @Max(10) Long count
+            @Valid @ModelAttribute PageRequestDto request
     ) {
-        ProductSearchResponseDto response = productFacade.findSimilarProducts(productInfoId, count);
+        ProductSearchResponseDto response = productFacade.findSimilarProducts(productInfoId, request);
         return CommonResponse.success(SuccessCode.OK, response);
     }
 

--- a/product/src/main/java/com/back/product/app/facade/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/facade/ProductFacade.java
@@ -193,6 +193,12 @@ public class ProductFacade {
     }
 
     @Loggable
+    @Transactional(readOnly = true)
+    public ProductSearchResponseDto findSimilarProducts(Long productInfoId, Long count) {
+        return productDocumentUseCase.findSimilarProducts(productInfoId, count);
+    }
+
+    @Loggable
     @Transactional
     public OptionListResponseDto createOptions(@Valid OptionListCreateRequestDto request) {
         List<OptionCreateCommand> optionCreateCommands = request.options().stream().map(optionCreateCommandMapper::toCommand).toList();

--- a/product/src/main/java/com/back/product/app/facade/ProductFacade.java
+++ b/product/src/main/java/com/back/product/app/facade/ProductFacade.java
@@ -187,15 +187,15 @@ public class ProductFacade {
 
     @Loggable
     @Transactional(readOnly = true)
-    public ProductSearchResponseDto findProductPage(@Valid ProductSearchRequestDto request, Long page, Long size) {
-        ProductSearchCommand productSearchCommand = productSearchCommandMapper.toCommand(request, page, size);
+    public ProductSearchResponseDto findProductPage(@Valid ProductSearchRequestDto request) {
+        ProductSearchCommand productSearchCommand = productSearchCommandMapper.toCommand(request);
         return productDocumentUseCase.findProductPage(productSearchCommand);
     }
 
     @Loggable
     @Transactional(readOnly = true)
-    public ProductSearchResponseDto findSimilarProducts(Long productInfoId, Long count) {
-        return productDocumentUseCase.findSimilarProducts(productInfoId, count);
+    public ProductSearchResponseDto findSimilarProducts(Long productInfoId, PageRequestDto request) {
+        return productDocumentUseCase.findSimilarProducts(productInfoId, request.page(), request.size());
     }
 
     @Loggable

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -85,6 +85,9 @@ public class ProductDocumentUseCase {
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
 
         float[] embedding = targetProduct.getEmbedding();
+        if (embedding == null || embedding.length == 0) {
+            throw new CustomException(FailureCode.EMBEDDING_NOT_FOUND);
+        }
 
         KnnSearch knnSearch = buildKnnSearch(embedding, size + 1, size * 10L);
 

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -3,6 +3,7 @@ package com.back.product.app.usecase.command;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.KnnSearch;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import com.back.ai.app.usecase.EmbeddingUseCase;
 import com.back.common.annotation.Loggable;
 import com.back.common.code.FailureCode;
@@ -89,7 +90,13 @@ public class ProductDocumentUseCase {
             throw new CustomException(FailureCode.EMBEDDING_NOT_FOUND);
         }
 
-        KnnSearch knnSearch = buildKnnSearch(embedding, size + 1, size * 10L);
+        // 자기 자신을 제외하는 필터 생성
+        TermQuery excludeSelfFilter = new TermQuery.Builder()
+                .field("_id")
+                .value(productInfoId.toString())
+                .build();
+
+        KnnSearch knnSearch = buildKnnSearch(embedding, size, size * 10L, excludeSelfFilter);
 
         Pageable pageable = buildPageable(ProductSortType.LATEST, page, size);
 
@@ -100,14 +107,8 @@ public class ProductDocumentUseCase {
 
         PageImpl<ProductDocument> productPage = productDocumentSupport.findProductPage(query);
 
-        // 자기 자신 제외
-        List<ProductDocument> similarProducts = productPage.getContent().stream()
-                .filter(doc -> !Objects.requireNonNull(doc.getId()).equals(productInfoId.toString()))
-                .limit(size)
-                .toList();
-
         return convertToDto(
-                similarProducts,
+                productPage.getContent(),
                 (long) productPage.getTotalPages(),
                 productPage.getTotalElements(),
                 page
@@ -224,14 +225,24 @@ public class ProductDocumentUseCase {
     }
 
     private KnnSearch buildKnnSearch(float[] embedding, Long k, Long candidate) {
+        return buildKnnSearch(embedding, k, candidate, null);
+    }
+
+    private KnnSearch buildKnnSearch(float[] embedding, Long k, Long candidate, TermQuery mustNotFilter) {
         List<Float> vectors = embeddingUseCase.convertArrayToList(embedding);
 
-        return KnnSearch.of(knn -> knn
-                .queryVector(vectors)
-                .field("embedding")
-                .k(k.intValue()) // 최종 결과 수
-                .numCandidates(candidate.intValue()) // 후보 수 (k * 2 ~ k * 10 권장)
-        );
+        return KnnSearch.of(knn -> {
+            knn.queryVector(vectors)
+                    .field("embedding")
+                    .k(k.intValue()) // 최종 결과 수
+                    .numCandidates(candidate.intValue()); // 후보 수 (k * 2 ~ k * 10 권장)
+
+            if (mustNotFilter != null) {
+                knn.filter(f -> f.bool(b -> b.mustNot(mustNotFilter)));
+            }
+
+            return knn;
+        });
     }
 
     private ProductSearchResponseDto convertToDto(List<ProductDocument> productList, Long totalPages, Long totalElements, Long currentPage) {

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -80,6 +80,7 @@ public class ProductDocumentUseCase {
         );
     }
 
+    @Loggable
     @Transactional(readOnly = true)
     public ProductSearchResponseDto findSimilarProducts(Long productInfoId, Long page, Long size) {
         ProductDocument targetProduct = productDocumentRepository.findById(productInfoId.toString())

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -2,6 +2,7 @@ package com.back.product.app.usecase.command;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import com.back.ai.app.usecase.EmbeddingUseCase;
 import com.back.common.annotation.Loggable;
 import com.back.product.adapter.out.document.ProductDocumentRepository;
 import com.back.product.app.usecase.query.ProductDocumentSupport;
@@ -9,11 +10,9 @@ import com.back.product.document.ProductDocument;
 import com.back.product.dto.command.ProductSearchCommand;
 import com.back.product.dto.model.OptionDto;
 import com.back.product.dto.model.ProductInfoDto;
-import com.back.product.dto.request.ProductSearchRequestDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
 import com.back.product.dto.model.ProductSearchDto;
 import com.back.product.mapper.ProductDocumentMapper;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
@@ -23,19 +22,27 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ProductDocumentUseCase {
-    private final ProductDocumentSupport productDocumentSupport;
     private final ProductDocumentMapper productDocumentMapper;
+    private final ProductDocumentSupport productDocumentSupport;
     private final ProductDocumentRepository productDocumentRepository;
+
+    private final EmbeddingUseCase embeddingUseCase;
 
     @Loggable
     @Transactional
     public void syncProduct(ProductInfoDto productInfoDto, List<OptionDto> optionDtos, String thumbnailUrl) {
-        ProductDocument documentToSync = productDocumentMapper.toDocument(productInfoDto, optionDtos, thumbnailUrl);
+        String description = buildProductInfo(productInfoDto, optionDtos);
+
+        float[] embedding = embeddingUseCase.generateEmbeddings(description);
+
+        ProductDocument documentToSync = productDocumentMapper.toDocument(productInfoDto, optionDtos, thumbnailUrl, embedding);
 
         documentToSync.assignId(productInfoDto.productInfoId().toString());
 
@@ -150,5 +157,42 @@ public class ProductDocumentUseCase {
                 .totalPages(totalPages)
                 .currentPage(currentPage)
                 .build();
+    }
+
+    // ex. "Brand: Nike. Category: Shoes. Product Code: NK12345. Product Name: Air Max. Release Price: 199.99. Release Date: 2023/10/15. Color: Red, Blue, Green; Size: 8, 9, 10."
+    private String buildProductInfo(ProductInfoDto productInfoDto, List<OptionDto> optionDtos) {
+        StringBuilder productInfo = new StringBuilder();
+
+        productInfo.append("Brand: ").append(productInfoDto.brand().name()).append(". ");
+        productInfo.append("Category: ").append(productInfoDto.category().name()).append(". ");
+        productInfo.append("Product Code: ").append(productInfoDto.code()).append(". ");
+        productInfo.append("Product Name: ").append(productInfoDto.name()).append(". ");
+        productInfo.append("Release Price: ").append(productInfoDto.releasePrice()).append(". ");
+        productInfo.append("Release Date: ").append(
+                DateTimeFormatter.ofPattern("yyyy/MM/dd")
+                        .format(productInfoDto.releaseDate())
+        ).append(". ");
+
+        productInfo.append(
+                optionDtos.stream()
+                        .map(this::buildOptionInfo)
+                        .collect(Collectors.joining("; "))
+        ).append(". ");
+
+        return productInfo.toString().trim();
+    }
+
+    // ex. "Color: Red, Blue, Green."
+    private String buildOptionInfo(OptionDto optionDto) {
+        StringBuilder optionInfo = new StringBuilder();
+
+        optionInfo.append(optionDto.group().name()).append(": ");
+        optionInfo.append(
+                optionDto.values().stream()
+                        .map(OptionDto.ValueDto::name)
+                        .collect(Collectors.joining(", "))
+        ).append(". ");
+
+        return optionInfo.toString();
     }
 }

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -89,17 +89,19 @@ public class ProductDocumentUseCase {
         filterByMinPrice(boolQuery, search.minPrice());
         filterByMaxPrice(boolQuery, search.maxPrice());
 
-        // 3. 임베딩 유사도 검색 (should: 점수 기반 검색)
-        KnnSearch knnSearch = buildKnnSearchQuery(search.keyword(), search.size());
-
-        // 4. 페이징 및 정렬
+        // 3. 페이징 및 정렬
         Pageable pageable = buildPageable(search.sort(), search.page(), search.size());
 
         NativeQueryBuilder queryBuilder = NativeQuery.builder()
                 .withQuery(boolQuery.build()._toQuery())
                 .withPageable(pageable);
 
-        if (knnSearch != null) {
+        // 4. 임베딩 유사도 검색 (should: 점수 기반 검색)
+        if (StringUtils.hasText(search.keyword())) {
+            float[] embedding = embeddingUseCase.generateEmbeddings(search.keyword());
+
+            KnnSearch knnSearch = buildKnnSearch(embedding, search.size(), search.size() * 5L);
+
             queryBuilder.withKnnSearches(knnSearch);
         }
 
@@ -170,27 +172,6 @@ public class ProductDocumentUseCase {
         }
     }
 
-    private KnnSearch buildKnnSearchQuery(String keyword, Long size) {
-        KnnSearch knnSearch = null;
-
-        if (StringUtils.hasText(keyword)) {
-            float[] embedding = embeddingUseCase.generateEmbeddings(keyword);
-
-            List<Float> vectors = IntStream.range(0, embedding.length)
-                    .mapToObj(i -> embedding[i])
-                    .toList();
-
-            knnSearch = KnnSearch.of(knn -> knn
-                    .queryVector(vectors)
-                    .field("embedding")
-                    .k(size.intValue()) // 최종 결과 수
-                    .numCandidates(size.intValue() * 3) // 후보 수 (k * 2 ~ k * 10 권장)
-            );
-        }
-
-        return knnSearch;
-    }
-
     private Pageable buildPageable(ProductSortType sortType, Long page, Long size) {
         // 정렬 조건 (기본 정렬: 최신순)
         Sort sort = Sort.by(
@@ -203,6 +184,17 @@ public class ProductDocumentUseCase {
 
         // 페이징
         return PageRequest.of(page.intValue(), size.intValue(), sort);
+    }
+
+    private KnnSearch buildKnnSearch(float[] embedding, Long k, Long candidate) {
+        List<Float> vectors = embeddingUseCase.convertArrayToList(embedding);
+
+        return KnnSearch.of(knn -> knn
+                .queryVector(vectors)
+                .field("embedding")
+                .k(k.intValue()) // 최종 결과 수
+                .numCandidates(candidate.intValue()) // 후보 수 (k * 2 ~ k * 10 권장)
+        );
     }
 
     private ProductSearchResponseDto convertToDto(List<ProductDocument> productList, Long totalPages, Long totalElements, Long currentPage) {

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -1,13 +1,15 @@
 package com.back.product.app.usecase.command;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
-import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch._types.KnnSearch;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import com.back.ai.app.usecase.EmbeddingUseCase;
 import com.back.common.annotation.Loggable;
 import com.back.product.adapter.out.document.ProductDocumentRepository;
 import com.back.product.app.usecase.query.ProductDocumentSupport;
 import com.back.product.document.ProductDocument;
 import com.back.product.dto.command.ProductSearchCommand;
+import com.back.product.dto.enums.ProductSortType;
 import com.back.product.dto.model.OptionDto;
 import com.back.product.dto.model.ProductInfoDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
@@ -15,7 +17,11 @@ import com.back.product.dto.model.ProductSearchDto;
 import com.back.product.mapper.ProductDocumentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +31,7 @@ import java.math.BigDecimal;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -58,15 +65,9 @@ public class ProductDocumentUseCase {
     @Loggable
     @Transactional(readOnly = true)
     public ProductSearchResponseDto findProductPage(ProductSearchCommand search) {
-        Query query = buildSearchQuery(
-                search.keyword(),
-                search.brandIds(),
-                search.categoryIds(),
-                search.minPrice(),
-                search.maxPrice()
-        );
+        Query query = buildSearchQuery(search);
 
-        PageImpl<ProductDocument> productPage = productDocumentSupport.findProductPage(query, search.sort(), search.page(), search.size());
+        PageImpl<ProductDocument> productPage = productDocumentSupport.findProductPage(query);
 
         return convertToDto(
                 productPage.getContent(),
@@ -76,16 +77,37 @@ public class ProductDocumentUseCase {
         );
     }
 
-    private Query buildSearchQuery(
-            String keyword,
-            List<Long> brands,
-            List<Long> categories,
-            BigDecimal minPrice,
-            BigDecimal maxPrice
-    ) {
-        var boolQuery = new BoolQuery.Builder();
+    private Query buildSearchQuery(ProductSearchCommand search) {
+        BoolQuery.Builder boolQuery = new BoolQuery.Builder();
 
         // 1. 키워드 검색 (should: 점수 기반 검색)
+        buildKeywordSearchQuery(boolQuery, search.keyword());
+
+        // 2. 필터링 조건 (filter: 정확한 매칭, 캐싱 가능)
+        filterByBrands(boolQuery, search.brandIds());
+        filterByCategories(boolQuery, search.categoryIds());
+        filterByMinPrice(boolQuery, search.minPrice());
+        filterByMaxPrice(boolQuery, search.maxPrice());
+
+        // 3. 임베딩 유사도 검색 (should: 점수 기반 검색)
+        KnnSearch knnSearch = buildKnnSearchQuery(search.keyword(), search.size());
+
+        // 4. 페이징 및 정렬
+        Pageable pageable = buildPageable(search.sort(), search.page(), search.size());
+
+        NativeQueryBuilder queryBuilder = NativeQuery.builder()
+                .withQuery(boolQuery.build()._toQuery())
+                .withPageable(pageable);
+
+        if (knnSearch != null) {
+            queryBuilder.withKnnSearches(knnSearch);
+        }
+
+        return queryBuilder.build();
+    }
+
+    private void buildKeywordSearchQuery(BoolQuery.Builder boolQuery, String keyword) {
+
         if (StringUtils.hasText(keyword)) {
             // (1) 일반 및 MultiField 검색 경로
             boolQuery.should(m -> m.match(mt -> mt.field("productInfo.productName").query(keyword)));
@@ -112,40 +134,75 @@ public class ProductDocumentUseCase {
 
             boolQuery.minimumShouldMatch("1");
         }
+    }
 
-        // 2. 필터링 조건 (filter: 정확한 매칭, 캐싱 가능)
-
-        // 브랜드 ID 필터
+    private void filterByBrands(BoolQuery.Builder boolQuery, List<Long> brands) {
         if (brands != null && !brands.isEmpty()) {
             boolQuery.filter(f -> f.terms(t -> t
                     .field("productInfo.brand.brandId")
                     .terms(v -> v.value(brands.stream().map(FieldValue::of).toList()))
             ));
         }
+    }
 
-        // 카테고리 ID 필터
+    private void filterByCategories(BoolQuery.Builder boolQuery, List<Long> categories) {
         if (categories != null && !categories.isEmpty()) {
             boolQuery.filter(f -> f.terms(t -> t
                     .field("productInfo.category.categoryId")
                     .terms(v -> v.value(categories.stream().map(FieldValue::of).toList()))
             ));
         }
+    }
 
-        // 3. 가격 범위 필터 (컴파일 에러 해결 지점)
+    private void filterByMinPrice(BoolQuery.Builder boolQuery, BigDecimal minPrice) {
         if (minPrice != null) {
             boolQuery.filter(f -> f.range(r -> r
                     .number(n -> n.field("productInfo.releasePrice").gte(minPrice.doubleValue()))
             ));
         }
+    }
+
+    private void filterByMaxPrice(BoolQuery.Builder boolQuery, BigDecimal maxPrice) {
         if (maxPrice != null) {
             boolQuery.filter(f -> f.range(r -> r
                     .number(n -> n.field("productInfo.releasePrice").lte(maxPrice.doubleValue()))
             ));
         }
+    }
 
-        return NativeQuery.builder()
-                .withQuery(boolQuery.build()._toQuery())
-                .build();
+    private KnnSearch buildKnnSearchQuery(String keyword, Long size) {
+        KnnSearch knnSearch = null;
+
+        if (StringUtils.hasText(keyword)) {
+            float[] embedding = embeddingUseCase.generateEmbeddings(keyword);
+
+            List<Float> vectors = IntStream.range(0, embedding.length)
+                    .mapToObj(i -> embedding[i])
+                    .toList();
+
+            knnSearch = KnnSearch.of(knn -> knn
+                    .queryVector(vectors)
+                    .field("embedding")
+                    .k(size.intValue()) // 최종 결과 수
+                    .numCandidates(size.intValue() * 3) // 후보 수 (k * 2 ~ k * 10 권장)
+            );
+        }
+
+        return knnSearch;
+    }
+
+    private Pageable buildPageable(ProductSortType sortType, Long page, Long size) {
+        // 정렬 조건 (기본 정렬: 최신순)
+        Sort sort = Sort.by(
+                ProductSortType.LATEST.getDirection(),
+                ProductSortType.LATEST.getFieldName()
+        );
+        if (sortType != null) {
+            sort = Sort.by(sortType.getDirection(), sortType.getFieldName());
+        }
+
+        // 페이징
+        return PageRequest.of(page.intValue(), size.intValue(), sort);
     }
 
     private ProductSearchResponseDto convertToDto(List<ProductDocument> productList, Long totalPages, Long totalElements, Long currentPage) {

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -5,6 +5,8 @@ import co.elastic.clients.elasticsearch._types.KnnSearch;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import com.back.ai.app.usecase.EmbeddingUseCase;
 import com.back.common.annotation.Loggable;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.product.adapter.out.document.ProductDocumentRepository;
 import com.back.product.app.usecase.query.ProductDocumentSupport;
 import com.back.product.document.ProductDocument;
@@ -30,6 +32,7 @@ import org.springframework.util.StringUtils;
 import java.math.BigDecimal;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -74,6 +77,36 @@ public class ProductDocumentUseCase {
                 (long) productPage.getTotalPages(),
                 productPage.getTotalElements(),
                 search.page()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ProductSearchResponseDto findSimilarProducts(Long productInfoId, Long count) {
+        ProductDocument targetProduct = productDocumentRepository.findById(productInfoId.toString())
+                .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
+
+        float[] embedding = targetProduct.getEmbedding();
+
+        KnnSearch knnSearch = buildKnnSearch(embedding, count + 1, count * 10L);
+
+        NativeQuery query = NativeQuery.builder()
+                .withKnnSearches(knnSearch)
+                .withPageable(PageRequest.of(0, count.intValue() + 1))
+                .build();
+
+        PageImpl<ProductDocument> productPage = productDocumentSupport.findProductPage(query);
+
+        // 자기 자신 제외
+        List<ProductDocument> similarProducts = productPage.getContent().stream()
+                .filter(doc -> !Objects.requireNonNull(doc.getId()).equals(productInfoId.toString()))
+                .limit(count)
+                .toList();
+
+        return convertToDto(
+                similarProducts,
+                1L,
+                (long) similarProducts.size(),
+                0L
         );
     }
 

--- a/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
+++ b/product/src/main/java/com/back/product/app/usecase/command/ProductDocumentUseCase.java
@@ -34,7 +34,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -81,17 +80,19 @@ public class ProductDocumentUseCase {
     }
 
     @Transactional(readOnly = true)
-    public ProductSearchResponseDto findSimilarProducts(Long productInfoId, Long count) {
+    public ProductSearchResponseDto findSimilarProducts(Long productInfoId, Long page, Long size) {
         ProductDocument targetProduct = productDocumentRepository.findById(productInfoId.toString())
                 .orElseThrow(() -> new CustomException(FailureCode.PRODUCT_INFO_NOT_FOUND));
 
         float[] embedding = targetProduct.getEmbedding();
 
-        KnnSearch knnSearch = buildKnnSearch(embedding, count + 1, count * 10L);
+        KnnSearch knnSearch = buildKnnSearch(embedding, size + 1, size * 10L);
+
+        Pageable pageable = buildPageable(ProductSortType.LATEST, page, size);
 
         NativeQuery query = NativeQuery.builder()
                 .withKnnSearches(knnSearch)
-                .withPageable(PageRequest.of(0, count.intValue() + 1))
+                .withPageable(pageable)
                 .build();
 
         PageImpl<ProductDocument> productPage = productDocumentSupport.findProductPage(query);
@@ -99,14 +100,14 @@ public class ProductDocumentUseCase {
         // 자기 자신 제외
         List<ProductDocument> similarProducts = productPage.getContent().stream()
                 .filter(doc -> !Objects.requireNonNull(doc.getId()).equals(productInfoId.toString()))
-                .limit(count)
+                .limit(size)
                 .toList();
 
         return convertToDto(
                 similarProducts,
-                1L,
-                (long) similarProducts.size(),
-                0L
+                (long) productPage.getTotalPages(),
+                productPage.getTotalElements(),
+                page
         );
     }
 

--- a/product/src/main/java/com/back/product/app/usecase/query/ProductDocumentSupport.java
+++ b/product/src/main/java/com/back/product/app/usecase/query/ProductDocumentSupport.java
@@ -20,30 +20,15 @@ public class ProductDocumentSupport {
     private final ElasticsearchOperations elasticsearchOperations;
 
     @Transactional(readOnly = true)
-    public PageImpl<ProductDocument> findProductPage(Query searchQuery, ProductSortType sort, Long page, Long size) {
-        Pageable pageable = buildPageable(sort, page, size);
-
-        searchQuery.setPageable(pageable);
-
+    public PageImpl<ProductDocument> findProductPage(Query searchQuery) {
         SearchHits<ProductDocument> searchHits = elasticsearchOperations.search(searchQuery, ProductDocument.class);
 
-        List<ProductDocument> content = searchHits.getSearchHits() .stream()
+        List<ProductDocument> content = searchHits.getSearchHits().stream()
                 .map(SearchHit::getContent) .toList();
 
-        return new PageImpl<>(content, pageable, searchHits.getTotalHits());
-    }
+        Pageable pageable = searchQuery.getPageable();
+        long totalHits = searchHits.getTotalHits();
 
-    private Pageable buildPageable(ProductSortType sortType, Long page, Long size) {
-        // 정렬 조건 (기본 정렬: 최신순)
-        Sort sort = Sort.by(
-                ProductSortType.LATEST.getDirection(),
-                ProductSortType.LATEST.getFieldName()
-        );
-        if (sortType != null) {
-            sort = Sort.by(sortType.getDirection(), sortType.getFieldName());
-        }
-
-        // 페이징
-        return PageRequest.of(page.intValue(), size.intValue(), sort);
+        return new PageImpl<>(content, pageable, totalHits);
     }
 }

--- a/product/src/main/java/com/back/product/document/ProductDocument.java
+++ b/product/src/main/java/com/back/product/document/ProductDocument.java
@@ -25,6 +25,9 @@ public class ProductDocument extends BaseDocument<String> {
     @Field(type = FieldType.Nested)
     private List<Option> totalOptions;
 
+    @Field(type = FieldType.Dense_Vector, dims = 384)
+    private float[] embedding;
+
     @Getter
     @Builder
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/product/src/main/java/com/back/product/dto/request/PageRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/PageRequestDto.java
@@ -9,7 +9,7 @@ public record PageRequestDto(
         @Min(value = 0, message = "page는 0 이상의 값이어야 합니다.")
         Long page,
 
-        @Range(min = 1, max = 50, message = "count는 1에서 50 사이의 값이어야 합니다.")
+        @Range(min = 5, max = 50, message = "size는 5에서 50 사이의 값이어야 합니다.")
         Long size
 ) {
     // 기본값 설정 용 컴팩트 생성자

--- a/product/src/main/java/com/back/product/dto/request/PageRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/PageRequestDto.java
@@ -15,7 +15,7 @@ public record PageRequestDto(
     // 기본값 설정 용 컴팩트 생성자
     public PageRequestDto {
         if (size == null) {
-            size = 10L;
+            size = 5L;
         }
 
         if (page == null) {

--- a/product/src/main/java/com/back/product/dto/request/PageRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/PageRequestDto.java
@@ -1,0 +1,25 @@
+package com.back.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import org.hibernate.validator.constraints.Range;
+
+@Builder
+public record PageRequestDto(
+        @Min(value = 0, message = "page는 0 이상의 값이어야 합니다.")
+        Long page,
+
+        @Range(min = 1, max = 50, message = "count는 1에서 50 사이의 값이어야 합니다.")
+        Long size
+) {
+    // 기본값 설정 용 컴팩트 생성자
+    public PageRequestDto {
+        if (size == null) {
+            size = 10L;
+        }
+
+        if (page == null) {
+            page = 0L;
+        }
+    }
+}

--- a/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
@@ -42,14 +42,6 @@ public record ProductSearchRequestDto(
         Long size
 ) {
     public ProductSearchRequestDto {
-        if (minPrice == null) {
-            minPrice = BigDecimal.ZERO;
-        }
-
-        if (maxPrice == null) {
-            maxPrice = BigDecimal.ZERO;
-        }
-
         if (brandIds == null) {
             brandIds = List.of();
         }

--- a/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
@@ -1,8 +1,10 @@
 package com.back.product.dto.request;
 
 import com.back.product.dto.enums.ProductSortType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -30,6 +32,10 @@ public record ProductSearchRequestDto(
 
         // 4. 정렬 조건
         @NotNull(message = "Sort cannot be null")
-        ProductSortType sort
+        ProductSortType sort,
+
+        // 5. 페이징
+        @Valid
+        PageRequestDto pageRequest
 ) {
 }

--- a/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
@@ -3,7 +3,6 @@ package com.back.product.dto.request;
 import com.back.product.dto.enums.ProductSortType;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
@@ -37,7 +37,7 @@ public record ProductSearchRequestDto(
         @Min(value = 0, message = "Page must be greater than or equal to 0")
         Long page,
 
-        @Min(value = 10, message = "Size must be greater than or equal to 10")
+        @Min(value = 5, message = "Size must be greater than or equal to 5")
         @Max(value = 50, message = "Size must be less than or equal to 50")
         Long size
 ) {

--- a/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
+++ b/product/src/main/java/com/back/product/dto/request/ProductSearchRequestDto.java
@@ -1,7 +1,6 @@
 package com.back.product.dto.request;
 
 import com.back.product.dto.enums.ProductSortType;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,7 +34,40 @@ public record ProductSearchRequestDto(
         ProductSortType sort,
 
         // 5. 페이징
-        @Valid
-        PageRequestDto pageRequest
+        @Min(value = 0, message = "Page must be greater than or equal to 0")
+        Long page,
+
+        @Min(value = 10, message = "Size must be greater than or equal to 10")
+        @Max(value = 50, message = "Size must be less than or equal to 50")
+        Long size
 ) {
+    public ProductSearchRequestDto {
+        if (minPrice == null) {
+            minPrice = BigDecimal.ZERO;
+        }
+
+        if (maxPrice == null) {
+            maxPrice = BigDecimal.ZERO;
+        }
+
+        if (brandIds == null) {
+            brandIds = List.of();
+        }
+
+        if (categoryIds == null) {
+            categoryIds = List.of();
+        }
+
+        if (page == null) {
+            page = 0L;
+        }
+
+        if (size == null) {
+            size = 20L;
+        }
+
+        if (sort == null) {
+            sort = ProductSortType.LATEST;
+        }
+    }
 }

--- a/product/src/main/java/com/back/product/mapper/ProductDocumentMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductDocumentMapper.java
@@ -27,7 +27,7 @@ public class ProductDocumentMapper {
                 .build();
     }
     
-    public ProductDocument toDocument(ProductInfoDto productInfoDto, List<OptionDto>optionDtos, String thumbnailUrl) {
+    public ProductDocument toDocument(ProductInfoDto productInfoDto, List<OptionDto>optionDtos, String thumbnailUrl, float[] embedding) {
         ProductDocument.ProductInfo productInfoDocument = toProductInfoDocument(productInfoDto);
 
         List<ProductDocument.Option> optionDocuments = optionDtos.stream()
@@ -38,6 +38,7 @@ public class ProductDocumentMapper {
                 .productInfo(productInfoDocument)
                 .totalOptions(optionDocuments)
                 .thumbnailUrl(thumbnailUrl)
+                .embedding(embedding)
                 .build();
     }
 

--- a/product/src/main/java/com/back/product/mapper/ProductSearchCommandMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductSearchCommandMapper.java
@@ -14,8 +14,8 @@ public class ProductSearchCommandMapper {
                 .minPrice(request.minPrice())
                 .maxPrice(request.maxPrice())
                 .sort(request.sort())
-                .page(request.pageRequest().page())
-                .size(request.pageRequest().size())
+                .page(request.page())
+                .size(request.size())
                 .build();
     }
 }

--- a/product/src/main/java/com/back/product/mapper/ProductSearchCommandMapper.java
+++ b/product/src/main/java/com/back/product/mapper/ProductSearchCommandMapper.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ProductSearchCommandMapper {
-    public ProductSearchCommand toCommand(ProductSearchRequestDto request, Long page, Long size) {
+    public ProductSearchCommand toCommand(ProductSearchRequestDto request) {
         return ProductSearchCommand.builder()
                 .keyword(request.keyword())
                 .categoryIds(request.categoryIds())
@@ -14,8 +14,8 @@ public class ProductSearchCommandMapper {
                 .minPrice(request.minPrice())
                 .maxPrice(request.maxPrice())
                 .sort(request.sort())
-                .page(page)
-                .size(size)
+                .page(request.pageRequest().page())
+                .size(request.pageRequest().size())
                 .build();
     }
 }

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     import:
       - optional:file:.env[.properties]
       - optional:classpath:application-image.yml
+      - optional:classpath:application-ai.yml
   profiles:
     active: local
   output:

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
@@ -1,12 +1,14 @@
 package com.back.product.adapter.in;
 
 import com.back.common.code.FailureCode;
+import com.back.common.code.SuccessCode;
 import com.back.common.exception.CustomException;
 import com.back.product.adapter.in.web.controller.ApiV1ProductQueryController;
 import com.back.product.app.facade.ProductFacade;
 import com.back.product.dto.model.*;
 import com.back.product.dto.request.ProductQueryRequestDto;
 import com.back.product.dto.request.ProductSearchRequestDto;
+import com.back.product.dto.request.PageRequestDto;
 import com.back.product.dto.response.ProductDetailListResponseDto;
 import com.back.product.dto.response.ProductDetailResponseDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
@@ -28,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.BDDMockito.*;
@@ -123,7 +126,7 @@ class ApiV1ProductQueryControllerTest {
                     .products(List.of(productSearchDto))
                     .build();
 
-            given(productFacade.findProductPage(any(ProductSearchRequestDto.class), anyLong(), anyLong())).willReturn(responseDto);
+            given(productFacade.findProductPage(any(ProductSearchRequestDto.class))).willReturn(responseDto);
 
             // when & then
             mockMvc.perform(
@@ -142,7 +145,7 @@ class ApiV1ProductQueryControllerTest {
                     .andExpect(jsonPath("$.code").value("OK"))
                     .andExpect(jsonPath("$.data.products[0].productName").value("Test Product"));
 
-            verify(productFacade).findProductPage(any(ProductSearchRequestDto.class), eq(0L), eq(10L));
+            verify(productFacade).findProductPage(any(ProductSearchRequestDto.class));
         }
 
         @Test
@@ -152,13 +155,119 @@ class ApiV1ProductQueryControllerTest {
             // when & then
             mockMvc.perform(
                             get("/api/v1/products")
+                                    .param("brandIds", "")
+                                    .param("categoryIds", "")
                                     .param("sort", "INVALID_SORT")
                                     .param("page", "0")
                                     .param("size", "10")
                     ).andDo(print())
                     .andExpect(status().isBadRequest());
 
-            verify(productFacade, never()).findProductPage(any(), anyLong(), anyLong());
+            verify(productFacade, never()).findProductPage(any());
+        }
+
+        @Test
+        @DisplayName("페이지 크기가 최대값을 초과할 경우 400 Bad Request를 반환한다")
+        @WithMockUser
+        void searchProducts_Fail_PageSizeExceedsMax() throws Exception {
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/products")
+                                    .param("brandIds", "")
+                                    .param("categoryIds", "")
+                                    .param("sort", "LATEST")
+                                    .param("pageRequest.page", "0")
+                                    .param("pageRequest.size", "100") // Exceeds max size of 50
+                    ).andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(productFacade, never()).findProductPage(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/products/{productInfoId}/similar")
+    class FindSimilarProductsTest {
+
+        private final Long PRODUCT_INFO_ID = 1L;
+        private final Long DEFAULT_COUNT = 10L;
+        private final Long CUSTOM_COUNT = 8L;
+        private final Long INVALID_COUNT = 51L;
+
+        private ProductSearchResponseDto createMockProductSearchResponseDto(Long count) {
+            return ProductSearchResponseDto.builder()
+                    .products(Collections.singletonList(ProductSearchDto.builder().productName("Similar Product").build()))
+                    .totalElements(count)
+                    .totalPages(1L)
+                    .currentPage(0L)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("성공: count 파라미터 없이 유사 상품을 조회한다 (기본값 사용)")
+        void findSimilarProducts_success_defaultCount() throws Exception {
+            PageRequestDto request = PageRequestDto.builder()
+                    .page(0L)
+                    .size(DEFAULT_COUNT)
+                    .build();
+
+            // given
+            ProductSearchResponseDto mockResponseDto = createMockProductSearchResponseDto(DEFAULT_COUNT);
+            given(productFacade.findSimilarProducts(PRODUCT_INFO_ID, request))
+                    .willReturn(mockResponseDto);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/products/{productInfoId}/similar", PRODUCT_INFO_ID)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessCode.OK.getCode()))
+                    .andExpect(jsonPath("$.data.totalElements").value(DEFAULT_COUNT));
+
+            verify(productFacade).findSimilarProducts(PRODUCT_INFO_ID, request);
+        }
+
+        @Test
+        @DisplayName("성공: count 파라미터를 지정하여 유사 상품을 조회한다")
+        void findSimilarProducts_success_customCount() throws Exception {
+            PageRequestDto request = PageRequestDto.builder()
+                    .page(0L)
+                    .size(CUSTOM_COUNT)
+                    .build();
+
+            // given
+            ProductSearchResponseDto mockResponseDto = createMockProductSearchResponseDto(CUSTOM_COUNT);
+            given(productFacade.findSimilarProducts(PRODUCT_INFO_ID, request))
+                    .willReturn(mockResponseDto);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/products/{productInfoId}/similar", PRODUCT_INFO_ID)
+                            .param("size", String.valueOf(CUSTOM_COUNT))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessCode.OK.getCode()))
+                    .andExpect(jsonPath("$.data.totalElements").value(CUSTOM_COUNT));
+
+            verify(productFacade).findSimilarProducts(PRODUCT_INFO_ID, request);
+        }
+
+        @Test
+        @DisplayName("실패: count 파라미터가 @Max(10)을 초과하면 400 Bad Request를 반환한다")
+        void findSimilarProducts_failure_invalidCount() throws Exception {
+            // given - no need to mock facade as validation happens before facade call
+            PageRequestDto request = PageRequestDto.builder()
+                    .page(0L)
+                    .size(INVALID_COUNT)
+                    .build();
+
+            // when & then
+            mockMvc.perform(get("/api/v1/products/{productInfoId}/similar", PRODUCT_INFO_ID)
+                            .param("page", "0")
+                            .param("size", String.valueOf(INVALID_COUNT))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest());
+
+
+            verify(productFacade, never()).findSimilarProducts(PRODUCT_INFO_ID, request);
         }
     }
 

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
@@ -204,7 +204,7 @@ class ApiV1ProductQueryControllerTest {
         }
 
         @Test
-        @DisplayName("성공: count 파라미터 없이 유사 상품을 조회한다 (기본값 사용)")
+        @DisplayName("성공: size 파라미터 없이 유사 상품을 조회한다 (기본값 사용)")
         void findSimilarProducts_success_defaultCount() throws Exception {
             PageRequestDto request = PageRequestDto.builder()
                     .page(0L)
@@ -227,7 +227,7 @@ class ApiV1ProductQueryControllerTest {
         }
 
         @Test
-        @DisplayName("성공: count 파라미터를 지정하여 유사 상품을 조회한다")
+        @DisplayName("성공: size 파라미터를 지정하여 유사 상품을 조회한다")
         void findSimilarProducts_success_customCount() throws Exception {
             PageRequestDto request = PageRequestDto.builder()
                     .page(0L)
@@ -251,7 +251,7 @@ class ApiV1ProductQueryControllerTest {
         }
 
         @Test
-        @DisplayName("실패: count 파라미터가 @Max(10)을 초과하면 400 Bad Request를 반환한다")
+        @DisplayName("실패: size 파라미터가 @Max(10)을 초과하면 400 Bad Request를 반환한다")
         void findSimilarProducts_failure_invalidCount() throws Exception {
             // given - no need to mock facade as validation happens before facade call
             PageRequestDto request = PageRequestDto.builder()

--- a/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
+++ b/product/src/test/java/com/back/product/adapter/in/ApiV1ProductQueryControllerTest.java
@@ -176,8 +176,8 @@ class ApiV1ProductQueryControllerTest {
                                     .param("brandIds", "")
                                     .param("categoryIds", "")
                                     .param("sort", "LATEST")
-                                    .param("pageRequest.page", "0")
-                                    .param("pageRequest.size", "100") // Exceeds max size of 50
+                                    .param("page", "0")
+                                    .param("size", "100") // Exceeds max size of 50
                     ).andDo(print())
                     .andExpect(status().isBadRequest());
 
@@ -190,7 +190,7 @@ class ApiV1ProductQueryControllerTest {
     class FindSimilarProductsTest {
 
         private final Long PRODUCT_INFO_ID = 1L;
-        private final Long DEFAULT_COUNT = 10L;
+        private final Long DEFAULT_COUNT = 5L;
         private final Long CUSTOM_COUNT = 8L;
         private final Long INVALID_COUNT = 51L;
 

--- a/product/src/test/java/com/back/product/app/usecase/ProductDocumentUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductDocumentUseCaseTest.java
@@ -1,6 +1,9 @@
 package com.back.product.app.usecase;
 
 import com.back.ai.app.usecase.EmbeddingUseCase;
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.product.adapter.out.document.ProductDocumentRepository;
 import com.back.product.app.usecase.command.ProductDocumentUseCase;
 import com.back.product.app.usecase.query.ProductDocumentSupport;
 import com.back.product.document.ProductDocument;
@@ -36,6 +39,9 @@ class ProductDocumentUseCaseTest {
 
     @InjectMocks
     private ProductDocumentUseCase productDocumentUseCase;
+
+    @Mock
+    private ProductDocumentRepository productDocumentRepository;
 
     @Mock
     private ProductDocumentSupport productDocumentSupport;
@@ -143,5 +149,170 @@ class ProductDocumentUseCaseTest {
             assertThat(result.totalPages()).isEqualTo(1);
             assertThat(result.currentPage()).isEqualTo(0);
         }
+        }
+
+    @Nested
+    @DisplayName("findSimilarProducts 메서드")
+    class FindSimilarProductsTest {
+        private final Long PRODUCT_INFO_ID = 1L;
+        private final Long OTHER_PRODUCT_INFO_ID_1 = 2L;
+        private final Long OTHER_PRODUCT_INFO_ID_2 = 3L;
+        private final float[] DUMMY_EMBEDDING = {0.1f, 0.2f, 0.3f};
+
+        @Test
+        @DisplayName("성공: 유사 상품을 정상적으로 조회한다 (자기 자신 제외)")
+        void findSimilarProducts_Success_ExcludesSelf() {
+            // given
+            Long page = 0L;
+            Long size = 5L;
+
+            ProductDocument targetProduct = ProductDocument.builder()
+                    .productInfo(
+                            ProductDocument.ProductInfo.builder()
+                                    .productInfoId(PRODUCT_INFO_ID)
+                                    .build()
+                    )
+                    .embedding(DUMMY_EMBEDDING)
+                    .productInfo(ProductDocument.ProductInfo.builder().productName("Target Product").build())
+                    .build();
+
+            ProductDocument similarProduct1 = ProductDocument.builder()
+                    .productInfo(
+                            ProductDocument.ProductInfo.builder()
+                                    .productInfoId(OTHER_PRODUCT_INFO_ID_1)
+                                    .build()
+                    )
+                    .productInfo(ProductDocument.ProductInfo.builder().productName("Similar Product 1").build())
+                    .build();
+            ProductDocument similarProduct2 = ProductDocument.builder()
+                    .productInfo(
+                            ProductDocument.ProductInfo.builder()
+                                    .productInfoId(OTHER_PRODUCT_INFO_ID_2)
+                                    .build()
+                    )
+                    .productInfo(ProductDocument.ProductInfo.builder().productName("Similar Product 2").build())
+                    .build();
+
+            List<ProductDocument> searchResults = List.of(similarProduct1, similarProduct2); // Expect only similar products
+            PageImpl<ProductDocument> productPage = new PageImpl<>(searchResults, PageRequest.of(page.intValue(), size.intValue()), searchResults.size());
+
+            ProductSearchDto dto1 = ProductSearchDto.builder().productName("Similar Product 1").build();
+            ProductSearchDto dto2 = ProductSearchDto.builder().productName("Similar Product 2").build();
+
+
+            given(productDocumentSupport.findProductPage(any(Query.class))).willReturn(productPage);
+            given(productDocumentRepository.findById(PRODUCT_INFO_ID.toString())).willReturn(java.util.Optional.of(targetProduct));
+            given(productDocumentMapper.toDto(similarProduct1)).willReturn(dto1);
+            given(productDocumentMapper.toDto(similarProduct2)).willReturn(dto2);
+
+            // when
+            ProductSearchResponseDto result = productDocumentUseCase.findSimilarProducts(PRODUCT_INFO_ID, page, size);
+
+            // then
+            ArgumentCaptor<NativeQuery> queryCaptor = ArgumentCaptor.forClass(NativeQuery.class);
+            verify(productDocumentSupport).findProductPage(queryCaptor.capture());
+            verify(productDocumentRepository).findById(PRODUCT_INFO_ID.toString());
+            verify(productDocumentMapper).toDto(similarProduct1);
+            verify(productDocumentMapper).toDto(similarProduct2);
+
+            NativeQuery capturedQuery = queryCaptor.getValue();
+            assertThat(capturedQuery.getKnnSearches()).hasSize(1);
+            // Verify that the filter to exclude self was applied
+            assertThat(capturedQuery.getKnnSearches().getFirst().filter()).isNotNull();
+            // A more detailed check for the filter would involve parsing the query, which is complex for unit tests.
+            // Rely on integration tests for full query verification.
+
+            assertThat(result).isNotNull();
+            assertThat(result.products()).hasSize(2); // Should not include the target product itself
+            assertThat(result.products().getFirst().productName()).isEqualTo("Similar Product 1");
+            assertThat(result.totalElements()).isEqualTo(2);
+            assertThat(result.totalPages()).isEqualTo(1);
+            assertThat(result.currentPage()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("실패: 대상 상품의 임베딩이 없을 경우 CustomException 발생")
+        void findSimilarProducts_Fail_EmbeddingNotFound() {
+            // given
+            Long page = 0L;
+            Long size = 5L;
+
+            ProductDocument targetProduct = ProductDocument.builder()
+                    .productInfo(
+                            ProductDocument.ProductInfo.builder()
+                                    .productInfoId(PRODUCT_INFO_ID)
+                                    .build()
+                    )
+                    .embedding(new float[]{}) // Empty embedding
+                    .productInfo(ProductDocument.ProductInfo.builder().productName("Target Product").build())
+                    .build();
+
+            given(productDocumentRepository.findById(PRODUCT_INFO_ID.toString())).willReturn(java.util.Optional.of(targetProduct));
+
+            // when
+            org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                            productDocumentUseCase.findSimilarProducts(PRODUCT_INFO_ID, page, size))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(FailureCode.EMBEDDING_NOT_FOUND.getMessage());
+
+            // then
+            verify(productDocumentRepository).findById(PRODUCT_INFO_ID.toString());
+            verify(productDocumentSupport, org.mockito.Mockito.never()).findProductPage(any(Query.class));
+        }
+
+        @Test
+        @DisplayName("실패: 대상 상품을 찾을 수 없을 경우 CustomException 발생")
+        void findSimilarProducts_Fail_ProductNotFound() {
+            // given
+            Long page = 0L;
+            Long size = 5L;
+
+            given(productDocumentRepository.findById(PRODUCT_INFO_ID.toString())).willReturn(java.util.Optional.empty());
+
+            // when
+            org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                            productDocumentUseCase.findSimilarProducts(PRODUCT_INFO_ID, page, size))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(FailureCode.PRODUCT_INFO_NOT_FOUND.getMessage());
+
+            // then
+            verify(productDocumentRepository).findById(PRODUCT_INFO_ID.toString());
+            verify(productDocumentSupport, org.mockito.Mockito.never()).findProductPage(any(Query.class));
+        }
+        
+        @Test
+        @DisplayName("성공: 유사 상품이 없을 경우 빈 리스트 반환")
+        void findSimilarProducts_Success_NoSimilarProducts() {
+            // given
+            Long page = 0L;
+            Long size = 5L;
+
+            ProductDocument targetProduct = ProductDocument.builder()
+                    .productInfo(
+                            ProductDocument.ProductInfo.builder()
+                                    .productInfoId(PRODUCT_INFO_ID)
+                                    .build()
+                    )
+                    .embedding(DUMMY_EMBEDDING)
+                    .productInfo(ProductDocument.ProductInfo.builder().productName("Target Product").build())
+                    .build();
+            
+            List<ProductDocument> searchResults = List.of(); // No similar products found
+            PageImpl<ProductDocument> productPage = new PageImpl<>(searchResults, PageRequest.of(page.intValue(), size.intValue()), 0);
+
+            given(productDocumentSupport.findProductPage(any(Query.class))).willReturn(productPage);
+            given(productDocumentRepository.findById(PRODUCT_INFO_ID.toString())).willReturn(java.util.Optional.of(targetProduct));
+
+            // when
+            ProductSearchResponseDto result = productDocumentUseCase.findSimilarProducts(PRODUCT_INFO_ID, page, size);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.products()).isEmpty();
+            assertThat(result.totalElements()).isEqualTo(0);
+            assertThat(result.totalPages()).isEqualTo(0);
+            assertThat(result.currentPage()).isEqualTo(0);
+        }
     }
 }
+

--- a/product/src/test/java/com/back/product/app/usecase/ProductDocumentUseCaseTest.java
+++ b/product/src/test/java/com/back/product/app/usecase/ProductDocumentUseCaseTest.java
@@ -1,11 +1,11 @@
 package com.back.product.app.usecase;
 
+import com.back.ai.app.usecase.EmbeddingUseCase;
 import com.back.product.app.usecase.command.ProductDocumentUseCase;
 import com.back.product.app.usecase.query.ProductDocumentSupport;
 import com.back.product.document.ProductDocument;
 import com.back.product.dto.command.ProductSearchCommand;
 import com.back.product.dto.enums.ProductSortType;
-import com.back.product.dto.request.ProductSearchRequestDto;
 import com.back.product.dto.response.ProductSearchResponseDto;
 import com.back.product.dto.model.ProductSearchDto;
 import com.back.product.mapper.ProductDocumentMapper;
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 
 import java.math.BigDecimal;
@@ -42,13 +43,16 @@ class ProductDocumentUseCaseTest {
     @Mock
     private ProductDocumentMapper productDocumentMapper;
 
+    @Mock
+    private EmbeddingUseCase embeddingUseCase;
+
     @Nested
     @DisplayName("findProductPage 메서드")
     class FindProductPageTest {
 
         @Test
-        @DisplayName("성공: 검색 조건으로 상품 페이지를 조회한다")
-        void findProductPage_Success() {
+        @DisplayName("성공: 하이브리드 검색 조건으로 상품 페이지를 조회한다")
+        void findProductPage_HybridSearch_Success() {
             // given
             ProductSearchCommand command = ProductSearchCommand.builder()
                     .keyword("Test")
@@ -61,24 +65,37 @@ class ProductDocumentUseCaseTest {
                     .size(20L)
                     .build();
 
+            // Dummy data for mocking
+            float[] dummyEmbedding = new float[]{0.1f, 0.2f, 0.3f};
             ProductDocument document = ProductDocument.builder().productInfo(ProductDocument.ProductInfo.builder().productName("Test Product").build()).build();
             List<ProductDocument> documents = List.of(document);
             PageImpl<ProductDocument> productPage = new PageImpl<>(documents, PageRequest.of(Math.toIntExact(command.page()), Math.toIntExact(command.size())), documents.size());
-
             ProductSearchDto dto = ProductSearchDto.builder().productName("Test Product").build();
 
-            given(productDocumentSupport.findProductPage(any(Query.class), any(ProductSortType.class), any(Long.class), any(Long.class)))
-                    .willReturn(productPage);
+            // Mocking dependencies
+            given(embeddingUseCase.generateEmbeddings(command.keyword())).willReturn(dummyEmbedding);
+            given(productDocumentSupport.findProductPage(any(Query.class))).willReturn(productPage);
             given(productDocumentMapper.toDto(document)).willReturn(dto);
 
             // when
             ProductSearchResponseDto result = productDocumentUseCase.findProductPage(command);
 
             // then
+            // 1. Verify that dependent methods were called with the correct arguments
+            verify(embeddingUseCase).generateEmbeddings(command.keyword());
             ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-            verify(productDocumentSupport).findProductPage(queryCaptor.capture(), any(ProductSortType.class), any(Long.class), any(Long.class));
-
+            verify(productDocumentSupport).findProductPage(queryCaptor.capture());
             verify(productDocumentMapper).toDto(document);
+
+            // 2. Assert the captured query to check for hybrid search components
+            Query capturedQuery = queryCaptor.getValue();
+            assertThat(capturedQuery).isInstanceOf(NativeQuery.class);
+            NativeQuery nativeQuery = (NativeQuery) capturedQuery;
+            assertThat(nativeQuery.getKnnSearches()).isNotNull();
+            assertThat(nativeQuery.getKnnSearches()).hasSize(1);
+            assertThat(nativeQuery.getQuery()).isNotNull(); // Check that the bool query part also exists
+
+            // 3. Assert the final response DTO
             assertThat(result).isNotNull();
             assertThat(result.products()).hasSize(1);
             assertThat(result.products().getFirst().productName()).isEqualTo("Test Product");
@@ -88,8 +105,8 @@ class ProductDocumentUseCaseTest {
         }
 
         @Test
-        @DisplayName("성공: 조건이 없는 경우에도 정상적으로 동작한다")
-        void findProductPage_Success_NoConditions() {
+        @DisplayName("성공: 조건이 없는 경우(키워드 없음)에도 정상적으로 동작한다")
+        void findProductPage_Success_NoKeyword() {
             // given
             ProductSearchCommand command = ProductSearchCommand.builder()
                     .sort(ProductSortType.LATEST)
@@ -100,11 +117,9 @@ class ProductDocumentUseCaseTest {
             ProductDocument document = ProductDocument.builder().productInfo(ProductDocument.ProductInfo.builder().productName("Another Product").build()).build();
             List<ProductDocument> documents = List.of(document);
             PageImpl<ProductDocument> productPage = new PageImpl<>(documents, PageRequest.of(Math.toIntExact(command.page()), Math.toIntExact(command.size())), documents.size());
-
             ProductSearchDto dto = ProductSearchDto.builder().productName("Another Product").build();
 
-            given(productDocumentSupport.findProductPage(any(Query.class), any(ProductSortType.class), any(Long.class), any(Long.class)))
-                    .willReturn(productPage);
+            given(productDocumentSupport.findProductPage(any(Query.class))).willReturn(productPage);
             given(productDocumentMapper.toDto(document)).willReturn(dto);
 
             // when
@@ -112,7 +127,13 @@ class ProductDocumentUseCaseTest {
 
             // then
             ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-            verify(productDocumentSupport).findProductPage(queryCaptor.capture(), any(ProductSortType.class), any(Long.class), any(Long.class));
+            verify(productDocumentSupport).findProductPage(queryCaptor.capture());
+
+            // Assert that KNN search is NOT present
+            Query capturedQuery = queryCaptor.getValue();
+            assertThat(capturedQuery).isInstanceOf(NativeQuery.class);
+            NativeQuery nativeQuery = (NativeQuery) capturedQuery;
+            assertThat(nativeQuery.getKnnSearches()).isNullOrEmpty(); // Check that KNN part does not exist
 
             // Verify result
             assertThat(result).isNotNull();

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,5 +11,6 @@ include(
         "image",
         "settlement",
         "detector",
-        "security"
+        "security",
+        "ai"
 )


### PR DESCRIPTION
## ✨ 관련 이슈

* **Resolved:** #281

## 🔎 작업 내용

### 1. AI 기반 상품 추천 및 검색 고도화

* **유사 상품 추천 API 구현:** AI 임베딩(Vector)을 활용하여 특정 상품과 유사한 아이템을 추천하는 기능을 추가했습니다.
* **하이브리드 검색(Hybrid Search) 도입:** 기존의 키워드 기반 풀텍스트 검색과 벡터 유사도 검색을 결합하여, 자연어 쿼리에 대한 검색 정확도를 획기적으로 개선했습니다.
* **AI 모듈 신설:** `spring-ai` 의존성을 추가하고 OpenAI 외부 모델 연동을 위한 인프라 설정을 마쳤습니다. 이를 `product` 모듈과 통합했습니다.

## 📷 테스트 결과
- 단위 테스트
  <img width="649" height="247" alt="image" src="https://github.com/user-attachments/assets/bac8cbca-4dd2-44a5-9128-ad39eb62cf6a" />


## ✅ Check List

* [x] 라벨 지정
* [x] 리뷰어 지정
* [x] 담당자 지정
* [x] 테스트 완료
* [x] 이슈 제목 컨벤션 준수
* [x] PR 제목 및 설명 작성
* [x] 커밋 메시지 컨벤션 준수
