### PR TITLE
[FEAT] 알림 모듈에 전송할 event publisher 구현(#180)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/event/MarketSpringEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/event/MarketSpringEventListener.java
@@ -2,6 +2,7 @@ package com.back.market.adapter.in.event;
 
 import com.back.market.adapter.out.event.MarketKafkaEventPublisher;
 import com.back.market.event.OrderCompletedEvent;
+import com.back.market.event.SellBiddingCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,5 +19,10 @@ public class MarketSpringEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderCompletedEvent(OrderCompletedEvent springEvent) {
         marketKafkaEventPublisher.sendOrderConfirmed(springEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSellBiddingCreatedEvent(SellBiddingCreatedEvent springEvent) {
+        marketKafkaEventPublisher.sendSellBiddingCreated(springEvent);
     }
 }

--- a/market/src/main/java/com/back/market/adapter/in/event/MarketSpringEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/event/MarketSpringEventListener.java
@@ -2,6 +2,7 @@ package com.back.market.adapter.in.event;
 
 import com.back.market.adapter.out.event.MarketKafkaEventPublisher;
 import com.back.market.event.OrderCompletedEvent;
+import com.back.market.event.OrderCreatedEvent;
 import com.back.market.event.SellBiddingCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,4 +26,10 @@ public class MarketSpringEventListener {
     public void handleSellBiddingCreatedEvent(SellBiddingCreatedEvent springEvent) {
         marketKafkaEventPublisher.sendSellBiddingCreated(springEvent);
     }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreatedEvent(OrderCreatedEvent springEvent) {
+        marketKafkaEventPublisher.sendOrderCreated(springEvent);
+    }
+
 }

--- a/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
+++ b/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
@@ -72,7 +72,7 @@ public class MarketKafkaEventPublisher {
     public void sendSellBiddingCreated(SellBiddingCreatedEvent event) {
         //검증 및 예외처리
         if (event.biddingId() == null || event.sellerUserId() == null) {
-            log.error("[MarketKafkaEventPublisher] 필수 데이터 누락: biddingId={}, sellerId={}", event.biddingId(), event.sellerUserId());
+            log.error("[MarketKafkaEventPublisher] 필수 데이터 누락: orderId={}, sellerId={}", event.biddingId(), event.sellerUserId());
             throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
         }
 
@@ -99,16 +99,16 @@ public class MarketKafkaEventPublisher {
     public void sendOrderCreated(OrderCreatedEvent event) {
 
         // 검증
-        if (event.biddingId() == null || event.buyerUserId() == null || event.sellerUserId() == null || event.productName() == null) {
+        if (event.orderId() == null || event.buyerUserId() == null || event.sellerUserId() == null || event.productName() == null) {
 
             log.error("[MarketKafkaEventPublisher] 주문 생성 이벤트 필수 데이터 누락: orderId={}, buyer={}, seller={}, product={}",
-                    event.biddingId(), event.buyerUserId(), event.sellerUserId(), event.productName());
+                    event.orderId(), event.buyerUserId(), event.sellerUserId(), event.productName());
             throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
         }
 
         // 페이로드 생성 및 전송
         OrderCreatedPayload payload = OrderCreatedPayload.of(
-                event.biddingId(),
+                event.orderId(),
                 event.buyerUserId(),
                 event.sellerUserId(),
                 event.productId(),

--- a/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
+++ b/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
@@ -5,9 +5,11 @@ import com.back.common.event.Envelope;
 import com.back.common.event.KafkaEventPublisher;
 import com.back.common.event.KafkaPayload;
 import com.back.common.exception.CustomException;
+import com.back.market.event.OrderCreatedEvent;
 import com.back.market.event.SellBiddingCreatedEvent;
 import com.back.market.event.payload.OrderCompletedPayload;
 import com.back.market.event.OrderCompletedEvent;
+import com.back.market.event.payload.OrderCreatedPayload;
 import com.back.market.event.payload.SellBiddingCreatedPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,8 @@ public class MarketKafkaEventPublisher {
     private String orderCompletedTopic;
     @Value("${custom.kafka.topic.market-bidding-sell-created}")
     private String sellBiddingCreatedTopic;
+    @Value("${custom.kafka.topic.market-order-created}")
+    private String orderCreatedTopic;
 
     // 공통 실행 템플릿 메서드
     private <T extends KafkaPayload> void publishWithErrorHandler(String topic, Envelope<T> envelope, Runnable publishTask) {
@@ -64,6 +68,7 @@ public class MarketKafkaEventPublisher {
         publishWithErrorHandler(orderCompletedTopic, envelope, () -> kafkaEventPublisher.publish(orderCompletedTopic, envelope));
     }
 
+    // 판매 입찰 생성 이벤트
     public void sendSellBiddingCreated(SellBiddingCreatedEvent event) {
         //검증 및 예외처리
         if (event.biddingId() == null || event.sellerUserId() == null) {
@@ -88,5 +93,35 @@ public class MarketKafkaEventPublisher {
         Envelope<SellBiddingCreatedPayload> envelope = Envelope.of(sellBiddingCreatedTopic, payload);
 
         publishWithErrorHandler(sellBiddingCreatedTopic, envelope, () -> kafkaEventPublisher.publish(sellBiddingCreatedTopic, envelope));
+    }
+
+    // 주문 생성 이벤트
+    public void sendOrderCreated(OrderCreatedEvent event) {
+
+        // 검증
+        if (event.biddingId() == null || event.buyerUserId() == null || event.sellerUserId() == null || event.productName() == null) {
+
+            log.error("[MarketKafkaEventPublisher] 주문 생성 이벤트 필수 데이터 누락: orderId={}, buyer={}, seller={}, product={}",
+                    event.biddingId(), event.buyerUserId(), event.sellerUserId(), event.productName());
+            throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
+        }
+
+        // 페이로드 생성 및 전송
+        OrderCreatedPayload payload = OrderCreatedPayload.of(
+                event.biddingId(),
+                event.buyerUserId(),
+                event.sellerUserId(),
+                event.productId(),
+                event.productName(),
+                event.productSize(),
+                event.thumbnailImage(),
+                event.brandName(),
+                event.price(),
+                event.biddingPosition()
+        );
+
+        Envelope<OrderCreatedPayload> envelope = Envelope.of(orderCreatedTopic, payload);
+
+        publishWithErrorHandler(orderCreatedTopic, envelope, () -> kafkaEventPublisher.publish(orderCreatedTopic, envelope));
     }
 }

--- a/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
+++ b/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
@@ -3,9 +3,12 @@ package com.back.market.adapter.out.event;
 import com.back.common.code.FailureCode;
 import com.back.common.event.Envelope;
 import com.back.common.event.KafkaEventPublisher;
+import com.back.common.event.KafkaPayload;
 import com.back.common.exception.CustomException;
+import com.back.market.event.SellBiddingCreatedEvent;
 import com.back.market.event.payload.OrderCompletedPayload;
 import com.back.market.event.OrderCompletedEvent;
+import com.back.market.event.payload.SellBiddingCreatedPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,47 +19,74 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MarketKafkaEventPublisher {
 
-    @Value("${custom.kafka.topic.market-order-completed}")
-    private String orderCompletedTopic;
     private final KafkaEventPublisher kafkaEventPublisher;
 
-    public void sendOrderConfirmed(OrderCompletedEvent event) {
+    @Value("${custom.kafka.topic.market-order-completed}")
+    private String orderCompletedTopic;
+    @Value("${custom.kafka.topic.market-bidding-sell-created}")
+    private String sellBiddingCreatedTopic;
+
+    // 공통 실행 템플릿 메서드
+    private <T extends KafkaPayload> void publishWithErrorHandler(String topic, Envelope<T> envelope, Runnable publishTask) {
         try {
-            // 1. 데이터 검증 및 예외 처리
-            if(event.orderId() == null || event.sellerId() == null) {
-                log.error("[MarketKafkaEventPublisher] 필수 데이터 누락: orderId={}, sellerId={}", event.orderId(), event.sellerId());
-                throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
-            }
-
-            // 2. 페이로드 생성 및 전송
-            OrderCompletedPayload payload = OrderCompletedPayload.of(
-                    event.orderId(),
-                    event.productId(),
-                    event.buyerId(),
-                    event.sellerId(),
-                    event.sellerName(),
-                    event.price(),
-                    event.orderStatus(),
-                    event.confirmedAt()
-            );
-
-            Envelope<OrderCompletedPayload> envelope = Envelope.of(orderCompletedTopic, payload);
-
-            kafkaEventPublisher.publish(orderCompletedTopic, envelope);
-
-            log.info("[MarketKafkaEventPublisher] 카프카 이벤트 발행 완료. | Topic: {} | OrderID: {} | Seller: {} | Price: {} | EventID: {}",
-                    orderCompletedTopic,
-                    event.orderId(),
-                    event.sellerId(),
-                    event.price(),
-                    envelope.header().eventId());
+            publishTask.run();
+            log.info("[MarketKafkaEventPublisher] 카프카 이벤트 발행 완료. | Topic: {}, Data: {}, eventId: {}", topic, envelope.payload(), envelope.header().eventId());
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            // 직렬화 오류나 네트워크 오류 등 예상치 못한 시스템 예외 처리
-            log.error("[MarketKafkaEventPublisher] 카프카 발행 중 시스템 오류 발생: {}", e.getMessage());
+            log.error("[MarketKafkaEventPublisher] 카프카 발행 중 시스템 오류 발생. | Topic: {}, Data: {}, , eventId: {}, Error: {}", topic, envelope.payload(), envelope.header().eventId(), e.getMessage());
             throw new CustomException(FailureCode.INTERNAL_SERVER_ERROR);
         }
     }
 
+    // 구매 확정 이벤트
+    public void sendOrderConfirmed(OrderCompletedEvent event) {
+        // 1. 데이터 검증 및 예외 처리
+        if(event.orderId() == null || event.sellerId() == null) {
+            log.error("[MarketKafkaEventPublisher] 필수 데이터 누락: orderId={}, sellerId={}", event.orderId(), event.sellerId());
+            throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
+        }
+
+        // 2. 페이로드 생성 및 전송
+        OrderCompletedPayload payload = OrderCompletedPayload.of(
+                event.orderId(),
+                event.productId(),
+                event.buyerId(),
+                event.sellerId(),
+                event.sellerName(),
+                event.price(),
+                event.orderStatus(),
+                event.confirmedAt()
+        );
+
+        Envelope<OrderCompletedPayload> envelope = Envelope.of(orderCompletedTopic, payload);
+
+        publishWithErrorHandler(orderCompletedTopic, envelope, () -> kafkaEventPublisher.publish(orderCompletedTopic, envelope));
+    }
+
+    public void sendSellBiddingCreated(SellBiddingCreatedEvent event) {
+        //검증 및 예외처리
+        if (event.biddingId() == null || event.sellerUserId() == null) {
+            log.error("[MarketKafkaEventPublisher] 필수 데이터 누락: biddingId={}, sellerId={}", event.biddingId(), event.sellerUserId());
+            throw new CustomException(FailureCode.MISSING_REQUIRED_FIELD);
+        }
+
+        // 페이로드 생성 및 전송
+        SellBiddingCreatedPayload payload = SellBiddingCreatedPayload.of(
+                event.biddingId(),
+                event.sellerUserId(),
+                event.productId(),
+                event.productName(),
+                event.productNumber(),
+                event.productOption(),
+                event.brandName(),
+                event.categoryName(),
+                event.thumbnailImage(),
+                event.currentPrice()
+        );
+
+        Envelope<SellBiddingCreatedPayload> envelope = Envelope.of(sellBiddingCreatedTopic, payload);
+
+        publishWithErrorHandler(sellBiddingCreatedTopic, envelope, () -> kafkaEventPublisher.publish(sellBiddingCreatedTopic, envelope));
+    }
 }

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -1,9 +1,8 @@
 package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
-import com.back.common.event.KafkaEventPublisher;
 import com.back.common.exception.BadRequestException;
-import com.back.common.market.event.BiddingCompletedEvent;
+import com.back.market.event.OrderCreatedEvent;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.OrderRepository;
 import com.back.market.adapter.out.cash.MarketCashAdapter;
@@ -25,6 +24,7 @@ import com.back.market.mapper.CashRequestMapper;
 import com.back.market.mapper.OrderMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +40,7 @@ public class MatchInstantTradeUseCase {
     private final BiddingMapper biddingMapper;
     private final CashRequestMapper cashRequestMapper;
     private final MarketCashAdapter marketCashAdapter;
-    private final KafkaEventPublisher kafkaEventPublisher;
+    private final ApplicationEventPublisher eventPublisher;
     private final MarketSupport marketSupport;
 
     /**
@@ -136,9 +136,8 @@ public class MatchInstantTradeUseCase {
                 // 결제 완료 -> 주문 상태 변경
                 log.info("[MatchInstantTrade] 결제 완료 (PAID) - OrderId: {}", savedOrder.getId());
                 savedOrder.changeStatus(OrderStatus.PAID);
-                
-                // TODO 즉시 구매 완료 이벤트 발행
-                publishBiddingCompletedEvent(myBid, targetBid, BiddingPosition.BUY);
+
+                publishOrderCreatedEvent(savedOrder, BiddingPosition.BUY);
             } else if (resultData.status() == PayAndHoldStatus.REQUIRES_PG) {
                 // PG 결제 필요 -> 주문은 대기 상태 유지 (HOLD)
                 // (Order 생성 시 기본값이 HOLD이므로 별도 상태 변경 불필요)
@@ -154,9 +153,8 @@ public class MatchInstantTradeUseCase {
             // 내가 판매자라면 홀딩할 필요가 없음(이미 구매자가 홀딩한 금액 존재)
             log.info("[MatchTrade] 즉시 판매 체결 (결제 불필요) - OrderId: {}", savedOrder.getId());
             savedOrder.changeStatus(OrderStatus.PAID);
-            
-            // TODO 즉시 판매 완료 이벤트 발행
-            publishBiddingCompletedEvent(targetBid, myBid, BiddingPosition.SELL);
+
+            publishOrderCreatedEvent(savedOrder, BiddingPosition.SELL);
 
             PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(
                     PayAndHoldStatus.PAID,
@@ -176,27 +174,13 @@ public class MatchInstantTradeUseCase {
         }
     }
 
-    /** TODO 시현님이 만들어 둔 부분 어떻게 옮길지 생각해보기
-     * 입찰 체결 완료 이벤트 발행
-     * @param buyBid 구매 입찰
-     * @param sellBid 판매 입찰
+    /**
+     * 주문 생성 이벤트 발행
+     * @param order 주문
      * @param triggerPosition 어떤 포지션(구매/판매)에서 트리거되었는지
      */
-    private void publishBiddingCompletedEvent(Bidding buyBid, Bidding sellBid, BiddingPosition triggerPosition) {
-        BiddingCompletedEvent event = new BiddingCompletedEvent(
-                triggerPosition == BiddingPosition.BUY ? buyBid.getId() : sellBid.getId(),
-                buyBid.getMarketUser().getId(),
-                sellBid.getMarketUser().getId(),
-                buyBid.getMarketProduct().getId(),
-                buyBid.getMarketProduct().getName(),
-                buyBid.getMarketProduct().getProductOption(),
-                buyBid.getMarketProduct().getThumbnailImage(),
-                buyBid.getMarketProduct().getBrandName(),
-                buyBid.getPrice(),
-                triggerPosition.name()
-        );
-        
-        kafkaEventPublisher.publish(event);
+    private void publishOrderCreatedEvent(Order order, BiddingPosition triggerPosition) {
+       eventPublisher.publishEvent(OrderCreatedEvent.of(order, triggerPosition));
     }
 
 }

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -115,18 +115,7 @@ public class RegisterBidUseCase {
         Bidding savedBidding = biddingRepository.save(bidding);
 
         // 엔티티 정보로 스프링 이벤트 발행
-        eventPublisher.publishEvent(SellBiddingCreatedEvent.of(
-                savedBidding.getId(),
-                savedBidding.getMarketUser().getId(),
-                savedBidding.getMarketProduct().getId(),
-                savedBidding.getMarketProduct().getName(),
-                savedBidding.getMarketProduct().getProductNumber(),
-                savedBidding.getMarketProduct().getProductOption(),
-                savedBidding.getMarketProduct().getBrandName(),
-                savedBidding.getMarketProduct().getCategoryName(),
-                savedBidding.getMarketProduct().getThumbnailImage(),
-                savedBidding.getPrice()
-        ));
+        eventPublisher.publishEvent(SellBiddingCreatedEvent.of(savedBidding));
 
         // 가짜 Cash 응답 생성 (판매는 결제 완료 상태이므로 cash 모듈과 통신 필요없음)
         PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -16,10 +16,12 @@ import com.back.market.dto.request.BiddingRequestDto;
 import com.back.common.dto.cash.request.PayAndHoldRequestDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;
 import com.back.market.dto.response.MarketPaymentResponseDto;
+import com.back.market.event.SellBiddingCreatedEvent;
 import com.back.market.mapper.BiddingMapper;
 import com.back.market.mapper.CashRequestMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,7 @@ public class RegisterBidUseCase {
     private final CashRequestMapper cashRequestMapper;
     private final MarketCashAdapter marketCashAdapter;
     private final MarketSupport marketSupport;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -109,6 +112,20 @@ public class RegisterBidUseCase {
         Bidding bidding = biddingMapper.toEntity(requestDto, user, product, BiddingPosition.SELL);
         bidding.changeStatus(BiddingStatus.PROCESS); // 판매 입찰은 결제 과정이 없으므로 즉시 활성화
         Bidding savedBidding = biddingRepository.save(bidding);
+
+        // 엔티티 정보로 스프링 이벤트 발행
+        eventPublisher.publishEvent(SellBiddingCreatedEvent.of(
+                savedBidding.getId(),
+                savedBidding.getMarketUser().getId(),
+                savedBidding.getMarketProduct().getId(),
+                savedBidding.getMarketProduct().getName(),
+                savedBidding.getMarketProduct().getProductNumber(),
+                savedBidding.getMarketProduct().getProductOption(),
+                savedBidding.getMarketProduct().getBrandName(),
+                savedBidding.getMarketProduct().getCategoryName(),
+                savedBidding.getMarketProduct().getThumbnailImage(),
+                savedBidding.getPrice()
+        ));
 
         // 가짜 Cash 응답 생성 (판매는 결제 완료 상태이므로 cash 모듈과 통신 필요없음)
         PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -92,7 +92,6 @@ public class RegisterBidUseCase {
      * @param requestDto BiddingRequestDto
      * @return 저장된 판매 입찰의 PK
      */
-    @Transactional
     public MarketPaymentResponseDto registerSellBid(Long userId, BiddingRequestDto requestDto) {
         // 가격 유효성 검사(1000원단위인지 아닌지)
         validatePriceUnit(requestDto.price());

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -95,6 +95,7 @@ public class RegisterBidUseCase {
      * @param requestDto BiddingRequestDto
      * @return 저장된 판매 입찰의 PK
      */
+    @Transactional
     public MarketPaymentResponseDto registerSellBid(Long userId, BiddingRequestDto requestDto) {
         // 가격 유효성 검사(1000원단위인지 아닌지)
         validatePriceUnit(requestDto.price());

--- a/market/src/main/java/com/back/market/event/OrderCreatedEvent.java
+++ b/market/src/main/java/com/back/market/event/OrderCreatedEvent.java
@@ -1,0 +1,35 @@
+package com.back.market.event;
+
+import com.back.common.event.EventName;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.BiddingPosition;
+
+import java.math.BigDecimal;
+
+public record OrderCreatedEvent(
+        Long biddingId,
+        Long buyerUserId,
+        Long sellerUserId,
+        Long productId,
+        String productName,
+        String productSize,
+        String thumbnailImage,
+        String brandName,
+        BigDecimal price,
+        String biddingPosition  // 판매입찰 / 구매입찰
+) implements EventName {
+    public static OrderCreatedEvent of(Order order, BiddingPosition position) {
+        return new OrderCreatedEvent(
+                order.getId(),
+                order.getBuyBidding().getMarketUser().getId(),
+                order.getSellBidding().getMarketUser().getId(),
+                order.getBuyBidding().getMarketProduct().getId(),
+                order.getBuyBidding().getMarketProduct().getName(),
+                order.getBuyBidding().getMarketProduct().getProductOption(),
+                order.getBuyBidding().getMarketProduct().getThumbnailImage(),
+                order.getBuyBidding().getMarketProduct().getBrandName(),
+                order.getPrice(),
+                position.name()
+        );
+    }
+}

--- a/market/src/main/java/com/back/market/event/OrderCreatedEvent.java
+++ b/market/src/main/java/com/back/market/event/OrderCreatedEvent.java
@@ -7,7 +7,7 @@ import com.back.market.domain.enums.BiddingPosition;
 import java.math.BigDecimal;
 
 public record OrderCreatedEvent(
-        Long biddingId,
+        Long orderId,
         Long buyerUserId,
         Long sellerUserId,
         Long productId,

--- a/market/src/main/java/com/back/market/event/SellBiddingCreatedEvent.java
+++ b/market/src/main/java/com/back/market/event/SellBiddingCreatedEvent.java
@@ -1,6 +1,7 @@
 package com.back.market.event;
 
 import com.back.common.event.EventName;
+import com.back.market.domain.Bidding;
 
 import java.math.BigDecimal;
 
@@ -16,7 +17,18 @@ public record SellBiddingCreatedEvent(
         String thumbnailImage,
         BigDecimal currentPrice
 ) implements EventName {
-    public static SellBiddingCreatedEvent of(Long biddingId, Long sellerUserId, Long productId, String productName, String productNumber, String productOption, String brandName, String categoryName, String thumbnailImage, BigDecimal currentPrice) {
-        return new SellBiddingCreatedEvent(biddingId, sellerUserId, productId, productName, productNumber, productOption, brandName, categoryName, thumbnailImage, currentPrice);
+    public static SellBiddingCreatedEvent of(Bidding bidding) {
+        return new SellBiddingCreatedEvent(
+                bidding.getId(),
+                bidding.getMarketUser().getId(),
+                bidding.getMarketProduct().getId(),
+                bidding.getMarketProduct().getName(),
+                bidding.getMarketProduct().getProductNumber(),
+                bidding.getMarketProduct().getProductOption(),
+                bidding.getMarketProduct().getBrandName(),
+                bidding.getMarketProduct().getCategoryName(),
+                bidding.getMarketProduct().getThumbnailImage(),
+                bidding.getPrice()
+        );
     }
 }

--- a/market/src/main/java/com/back/market/event/SellBiddingCreatedEvent.java
+++ b/market/src/main/java/com/back/market/event/SellBiddingCreatedEvent.java
@@ -1,0 +1,22 @@
+package com.back.market.event;
+
+import com.back.common.event.EventName;
+
+import java.math.BigDecimal;
+
+public record SellBiddingCreatedEvent(
+        Long biddingId,
+        Long sellerUserId,
+        Long productId,
+        String productName,
+        String productNumber,
+        String productOption,
+        String brandName,
+        String categoryName,
+        String thumbnailImage,
+        BigDecimal currentPrice
+) implements EventName {
+    public static SellBiddingCreatedEvent of(Long biddingId, Long sellerUserId, Long productId, String productName, String productNumber, String productOption, String brandName, String categoryName, String thumbnailImage, BigDecimal currentPrice) {
+        return new SellBiddingCreatedEvent(biddingId, sellerUserId, productId, productName, productNumber, productOption, brandName, categoryName, thumbnailImage, currentPrice);
+    }
+}

--- a/market/src/main/java/com/back/market/event/payload/OrderCreatedPayload.java
+++ b/market/src/main/java/com/back/market/event/payload/OrderCreatedPayload.java
@@ -1,0 +1,22 @@
+package com.back.market.event.payload;
+
+import com.back.common.event.KafkaPayload;
+
+import java.math.BigDecimal;
+
+public record OrderCreatedPayload (
+        Long biddingId,
+        Long buyerUserId,
+        Long sellerUserId,
+        Long productId,
+        String productName,
+        String productSize,
+        String thumbnailImage,
+        String brandName,
+        BigDecimal price,
+        String biddingPosition  // 판매입찰 / 구매입찰
+) implements KafkaPayload {
+    public static OrderCreatedPayload of(Long biddingId, Long buyerUserId, Long sellerUserId, Long productId, String productName, String productSize, String thumbnailImage, String brandName, BigDecimal price, String biddingPosition) {
+        return new OrderCreatedPayload(biddingId, buyerUserId, sellerUserId, productId, productName, productSize, thumbnailImage, brandName, price, biddingPosition);
+    }
+}

--- a/market/src/main/java/com/back/market/event/payload/OrderCreatedPayload.java
+++ b/market/src/main/java/com/back/market/event/payload/OrderCreatedPayload.java
@@ -5,7 +5,7 @@ import com.back.common.event.KafkaPayload;
 import java.math.BigDecimal;
 
 public record OrderCreatedPayload (
-        Long biddingId,
+        Long orderId,
         Long buyerUserId,
         Long sellerUserId,
         Long productId,
@@ -16,7 +16,7 @@ public record OrderCreatedPayload (
         BigDecimal price,
         String biddingPosition  // 판매입찰 / 구매입찰
 ) implements KafkaPayload {
-    public static OrderCreatedPayload of(Long biddingId, Long buyerUserId, Long sellerUserId, Long productId, String productName, String productSize, String thumbnailImage, String brandName, BigDecimal price, String biddingPosition) {
-        return new OrderCreatedPayload(biddingId, buyerUserId, sellerUserId, productId, productName, productSize, thumbnailImage, brandName, price, biddingPosition);
+    public static OrderCreatedPayload of(Long orderId, Long buyerUserId, Long sellerUserId, Long productId, String productName, String productSize, String thumbnailImage, String brandName, BigDecimal price, String biddingPosition) {
+        return new OrderCreatedPayload(orderId, buyerUserId, sellerUserId, productId, productName, productSize, thumbnailImage, brandName, price, biddingPosition);
     }
 }

--- a/market/src/main/java/com/back/market/event/payload/SellBiddingCreatedPayload.java
+++ b/market/src/main/java/com/back/market/event/payload/SellBiddingCreatedPayload.java
@@ -1,0 +1,22 @@
+package com.back.market.event.payload;
+
+import com.back.common.event.KafkaPayload;
+
+import java.math.BigDecimal;
+
+public record SellBiddingCreatedPayload(
+        Long biddingId,
+        Long sellerUserId,
+        Long productId,
+        String productName,
+        String productNumber,
+        String productOption,
+        String brandName,
+        String categoryName,
+        String thumbnailImage,
+        BigDecimal currentPrice
+) implements KafkaPayload {
+    public static SellBiddingCreatedPayload of(Long biddingId, Long sellerUserId, Long productId, String productName, String productNumber, String productOption, String brandName, String categoryName, String thumbnailImage, BigDecimal currentPrice) {
+        return new SellBiddingCreatedPayload(biddingId, sellerUserId, productId, productName, productNumber, productOption, brandName, categoryName, thumbnailImage, currentPrice);
+    }
+}

--- a/market/src/test/java/com/back/market/event/NotificationEventPublishTests.java
+++ b/market/src/test/java/com/back/market/event/NotificationEventPublishTests.java
@@ -1,0 +1,59 @@
+package com.back.market.event;
+
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.app.MarketFacade;
+import com.back.market.domain.MarketUser;
+import com.back.market.dto.request.BiddingRequestDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+public class NotificationEventPublishTests {
+
+    @Autowired
+    private MarketFacade marketFacade;
+    @Autowired
+    private MarketUserRepository userRepository;
+
+    @Test
+    @Transactional
+    @Rollback(false)
+    @DisplayName("판매 입찰 등록 시 카프카로 알림 이벤트가 발행되는지 확인")
+    void registerSellBid_PublishKafkaMessage() throws InterruptedException {
+        Long testUserId = 999L;
+        Long testProductId = 200L;
+
+        userRepository.deleteById(testUserId);
+        userRepository.save(MarketUser.builder()
+                .id(testUserId)
+                .name("테스트판매자")
+                .email("test-seller@example.com")
+                .build());
+
+        BigDecimal bidPrice = new BigDecimal("1000000"); // 100만원
+        BiddingRequestDto requestDto = BiddingRequestDto.of(testProductId, bidPrice, "270");
+
+        marketFacade.registerSellBid(testUserId, requestDto);
+
+        log.info(">>>> 트랜잭션 커밋을 시작합니다.");
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        log.info(">>>> 트랜잭션 커밋 완료.");
+
+        log.info(">>>> 유저의 입찰 등록 완료. 메시지를 기다립니다...");
+        Thread.sleep(5000);
+
+        log.info(">>>> [테스트 최종 성공] 로그를 확인하세요..");
+    }
+}

--- a/market/src/test/java/com/back/market/event/NotificationEventPublishTests.java
+++ b/market/src/test/java/com/back/market/event/NotificationEventPublishTests.java
@@ -1,8 +1,18 @@
 package com.back.market.event;
 
+import com.back.common.dto.cash.enums.PayAndHoldStatus;
+import com.back.common.dto.cash.enums.RelType;
+import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
 import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.adapter.out.cash.MarketCashAdapter;
 import com.back.market.app.MarketFacade;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
 import com.back.market.domain.MarketUser;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
 import com.back.market.dto.request.BiddingRequestDto;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -11,10 +21,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @Slf4j
 @SpringBootTest
@@ -25,6 +39,12 @@ public class NotificationEventPublishTests {
     private MarketFacade marketFacade;
     @Autowired
     private MarketUserRepository userRepository;
+    @Autowired
+    private BiddingRepository biddingRepository;
+    @Autowired
+    private MarketProductRepository productRepository;
+    @MockitoBean
+    private MarketCashAdapter marketCashAdapter;
 
     @Test
     @Transactional
@@ -34,7 +54,6 @@ public class NotificationEventPublishTests {
         Long testUserId = 999L;
         Long testProductId = 200L;
 
-        userRepository.deleteById(testUserId);
         userRepository.save(MarketUser.builder()
                 .id(testUserId)
                 .name("테스트판매자")
@@ -55,5 +74,131 @@ public class NotificationEventPublishTests {
         Thread.sleep(5000);
 
         log.info(">>>> [테스트 최종 성공] 로그를 확인하세요..");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(false)
+    @DisplayName("즉시 구매 체결 시 카프카로 주문 생성 이벤트(OrderCreated)가 발행되는지 확인")
+    public void buyNow_PublishKafkaMessage() throws InterruptedException {
+        Long sellerId = 999L;
+        Long buyerId = 998L;
+        Long productId = 999L;
+
+        MarketUser seller = userRepository.save(MarketUser.builder()
+                .id(sellerId)
+                .name("판매자")
+                .email("seller@test.com")
+                .phone("010-1234-5678") // 테스트 통과를 위한 더미 연락처
+                .address("서울시 강남구 역삼동") // 테스트 통과를 위한 더미 주소
+                .build());
+
+        MarketUser buyer = userRepository.save(MarketUser.builder()
+                .id(buyerId)
+                .name("구매자")
+                .email("buyer@test.com")
+                .phone("010-9876-5432") // 테스트 통과를 위한 더미 연락처
+                .address("서울시 서초구 서초동") // 테스트 통과를 위한 더미 주소
+                .build());
+
+        MarketProduct testProduct = productRepository.save(MarketProduct.builder()
+                .id(productId)
+                .name("테스트용 신발")
+                .brandName("TestBrand")
+                .categoryName("Sneakers")
+                .productNumber("TEST-001")
+                .productOption("270")
+                .releasePrice(new BigDecimal("100000"))
+                .thumbnailImage("test_image_url")
+                .build());
+
+        // 2. 매칭용 판매 입찰(Bidding) 더미 데이터 생성
+        BigDecimal matchPrice = new BigDecimal("500000");
+        biddingRepository.save(Bidding.builder()
+                .marketUser(seller)
+                .marketProduct(productRepository.findById(productId).orElseThrow())
+                .price(matchPrice)
+                .position(BiddingPosition.SELL)
+                .status(BiddingStatus.PROCESS)
+                .build());
+
+        // 구매 요청 DTO
+        BiddingRequestDto requestDto = BiddingRequestDto.of(productId, matchPrice, "270");
+
+        // When: 즉시 구매 실행
+        log.info(">>>> 즉시 구매 시작");
+        given(marketCashAdapter.getPayAndHoldResult(any()))
+                .willReturn(PayAndHoldResponseDto.of(
+                        PayAndHoldStatus.PAID,
+                        RelType.ORDER,
+                        1L,
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO,
+                        null
+                ));
+        marketFacade.purchaseNow(buyerId, requestDto);
+
+        // Then: 트랜잭션 종료 후 카프카 발행 로그 확인
+        log.info(">>>> 트랜잭션 커밋 시작");
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        log.info(">>>> 5초 대기하며 로그를 확인하세요...");
+        Thread.sleep(5000);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(false)
+    @DisplayName("즉시 판매 체결 시 카프카로 주문 생성 이벤트가 발행되는지 확인")
+    void sellNow_PublishKafkaMessage() throws InterruptedException {
+        // 1. Given: 신규 유저 및 신규 상품 준비
+        Long sellerId = 888L;
+        Long buyerId = 887L;
+        Long productId = 888L;
+
+        // 판매자/구매자 생성 (전화번호, 주소 필수)
+        MarketUser seller = userRepository.save(MarketUser.builder()
+                .id(sellerId).name("즉시판매자").email("seller888@test.com")
+                .phone("010-1111-8888").address("서울").build());
+        MarketUser buyer = userRepository.save(MarketUser.builder()
+                .id(buyerId).name("즉시구매자").email("buyer887@test.com")
+                .phone("010-2222-8887").address("경기").build());
+
+        // 상품 생성
+        MarketProduct product = productRepository.save(MarketProduct.builder()
+                .id(productId).name("판매테스트신발").brandName("Nike").categoryName("Sneakers")
+                .productNumber("SELL-TEST-888").productOption("260").releasePrice(new BigDecimal("150000"))
+                .thumbnailImage("image_url").build());
+
+        // 미리 등록된 '구매 입찰'이 있어야 즉시 판매가 가능함
+        BigDecimal matchPrice = new BigDecimal("200000");
+        biddingRepository.save(Bidding.builder()
+                .marketUser(buyer)
+                .marketProduct(product)
+                .price(matchPrice)
+                .position(BiddingPosition.BUY) // 이번엔 BUY 입찰을 먼저 생성
+                .status(BiddingStatus.PROCESS)
+                .build());
+
+        // Cash 서비스 응답 Mocking (에러 방지)
+        given(marketCashAdapter.getPayAndHoldResult(any()))
+                .willReturn(PayAndHoldResponseDto.of(
+                        PayAndHoldStatus.PAID, RelType.ORDER, 1L, BigDecimal.ZERO, BigDecimal.ZERO, null));
+
+        // 즉시 판매 요청 DTO
+        BiddingRequestDto requestDto = BiddingRequestDto.of(productId, matchPrice, "260");
+
+        // 2. When: 즉시 판매 실행
+        log.info(">>>> 즉시 판매 시작 (판매자 ID: {})", sellerId);
+        marketFacade.sellNow(sellerId, requestDto);
+
+        // 3. Then: 트랜잭션 종료 및 카프카 로그 확인
+        log.info(">>>> 트랜잭션 커밋 시작");
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        log.info(">>>> 5초 대기하며 [OrderCreatedPayload] 로그를 확인하세요 (biddingPosition=SELL 예상)");
+        Thread.sleep(5000);
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #180

## 🔎 작업 내용

알림 모듈에 이벤트를 전송하는 로직을 구현합니다.
- 판매 입찰 등록 시
- 즉시구매, 즉시판매 시(주문 테이블에 insert되는 시점)
<br>


## 📌 참고 사항
- 알림 모듈에 전송해야 하는 이벤트가 2가지 더 남았는데(입찰 만료, 주문 취소 시) 해당 api가 없어서 일단은 있는 api에 대해서만 구현했습니다

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 판매 입찰 등록 시 이벤트 발행
  <img width="733" height="323" alt="image" src="https://github.com/user-attachments/assets/0955ba98-066b-40b4-881e-5b6e8554abe0" /><br>
  <img width="748" height="518" alt="image" src="https://github.com/user-attachments/assets/27993158-ac22-40e5-9c8c-41f3ef181fa6" />
- 주문 생성 시 이벤트 발행
  <img width="756" height="612" alt="image" src="https://github.com/user-attachments/assets/5e604e6b-d1f2-4cd7-85d0-3970be614993" /><br>
  <img width="787" height="616" alt="image" src="https://github.com/user-attachments/assets/d6ca7382-c9ba-4a8a-9fb8-54cac55d54ce" />




<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
