### PR TITLE
[REFACTOR] 회원 가입 이벤트 수신 시 멱등성 보장 로직 추가 (#301)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/event/MarketKafkaEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/event/MarketKafkaEventListener.java
@@ -25,7 +25,7 @@ public class MarketKafkaEventListener {
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consumeUserCreatedEvent(String message) {
-        log.info("[MarketUserEventListener] UserCreatedEvent 수신: {}", message);
+        log.info("[MarketKafkaEventListener] UserCreatedEvent 수신: {}", message);
 
         Envelope<UserCreatedPayload> event;
 
@@ -33,7 +33,7 @@ public class MarketKafkaEventListener {
             event = jsonMapper.readValue(message, new TypeReference<>() {
             });
         } catch (Exception e) {
-            log.error("[MarketUserEventListener] UserCreatedEvent 파싱 중 오류 발생: {}", e.getMessage());
+            log.error("[MarketKafkaEventListener] UserCreatedEvent 파싱 중 오류 발생: {}", e.getMessage());
             throw new CustomException(FailureCode.INTERNAL_SERVER_ERROR);
         }
 

--- a/market/src/main/java/com/back/market/app/MarketInternalFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketInternalFacade.java
@@ -1,6 +1,7 @@
 package com.back.market.app;
 
 import com.back.common.dto.settlement.SettlementTargetOrder;
+import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.app.usecase.ConfirmPaymentUseCase;
 import com.back.common.dto.cash.request.PaymentCompletedRequestDto;
 import com.back.market.app.usecase.CreateCartUseCase;
@@ -25,6 +26,7 @@ public class MarketInternalFacade {
     private final GetSettlementDataUseCase getSettlementDataUseCase;
     private final CreateMarketMemberUseCase createMarketMemberUseCase;
     private final CreateCartUseCase createCartUseCase;
+    private final MarketUserRepository userRepository;
 
     /**
      * Cash 모듈로부터 결제 완료(입금 확인) 통지를 수신하여 주문 상태를 확정
@@ -52,6 +54,13 @@ public class MarketInternalFacade {
      */
     @Transactional
     public void handleUserCreatedEvent(UserCreatedPayload payload) {
+
+        // 이미 존재하는 유저인지 확인 (멱등성 체크)
+        if (userRepository.existsById(payload.id())) {
+            log.warn("[MarketInternalFacade] 이미 존재하는 유저입니다. UserId: {}", payload.id());
+            return;
+        }
+
         // payload의 값을 사용해 이벤트 생성
         UserCreatedResultPayload command = UserCreatedResultPayload.of(
                 payload.id(),


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #301

## 🔎 작업 내용

-MarketKafkaEventListener 로그 메시지의 클래스명 수정
- MarketInternalFacade에 MarketUserRepository DI 추가
- UserCreatedEvent 처리 시 멱등성 체크 로직 추가
- 기존 유저 존재 시 로그 경고 후 처리 중단

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
