### PR TITLE
[FEAT] user 업데이트 이벤트 컨슈머 구현 (#343)

### DIFF
--- a/common/src/main/java/com/back/common/event/KafkaEventParser.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventParser.java
@@ -28,10 +28,17 @@ public class KafkaEventParser {
             String message,
             TypeReference<Envelope<T>> typeReference
     ) {
+        String maskedMessage = maskSensitiveInfo(message);
         try {
-            return jsonMapper.readValue(message, typeReference).payload();
+            // 메시지 전체(Envelope) 역직렬화
+            Envelope<T> envelope = jsonMapper.readValue(message, typeReference);
+
+            // 성공 로그: 헤더의 정보를 활용 (예: user-account-updated)
+            log.info("[KafkaEventParser] {} 수신 성공: {}",
+                    envelope.header().eventType(), maskedMessage);
+
+            return envelope.payload();
         } catch (Exception e) {
-            String maskedMessage = maskSensitiveInfo(message);
             log.error("[KafkaEventParser] Payload 역직렬화 실패. 메시지: {}", maskedMessage, e);
             // 역직렬화 실패는 재시도해도 해결되지 않을 가능성이 높으므로, 예외를 던져서 DLT로 전송(MessageConversionException은 Kafka에서 재시도 없이 바로 DLT로 전송됨)
             throw new MessageConversionException("[KafkaEventParser] envelope에서 payload 역직렬화 실패", e);
@@ -42,7 +49,7 @@ public class KafkaEventParser {
         if (json == null) return null;
         // 1. 마스킹할 패턴 정의 (Case Insensitive 적용)
         // 이메일, 전화번호, 주소 키에 대해 마스킹
-        String regex = "\" (email|phoneNumber|address) \"\\s*:\\s*\"[^\"]+\"";
+        String regex = "\" (email|phoneNumber|phone|address) \"\\s*:\\s*\"[^\"]+\"";
         Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.COMMENTS);
 
         Matcher matcher = pattern.matcher(json);

--- a/common/src/main/java/com/back/common/event/KafkaEventParser.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventParser.java
@@ -50,11 +50,11 @@ public class KafkaEventParser {
      * @param json 마스킹할 JSON 문자열
      * @return 민감한 정보가 마스킹된 JSON 문자열
      */
-    private String maskSensitiveInfo(String json) {
+    public String maskSensitiveInfo(String json) {
         if (json == null) return null;
         // 1. 마스킹할 패턴 정의 (Case Insensitive 적용)
         // 이메일, 전화번호, 주소 키에 대해 마스킹
-        String regex = "\" (email|phoneNumber|phone|address) \"\\s*:\\s*\"[^\"]+\"";
+        String regex = "\" (email|phoneNumber|phone|address|sellerName|buyerName|name) \"\\s*:\\s*\"[^\"]+\"";
         Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.COMMENTS);
 
         Matcher matcher = pattern.matcher(json);

--- a/common/src/main/java/com/back/common/event/KafkaEventParser.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventParser.java
@@ -54,8 +54,8 @@ public class KafkaEventParser {
         if (json == null) return null;
         // 1. 마스킹할 패턴 정의 (Case Insensitive 적용)
         // 이메일, 전화번호, 주소 키에 대해 마스킹
-        String regex = "\" (email|phoneNumber|phone|address|sellerName|buyerName|name) \"\\s*:\\s*\"[^\"]+\"";
-        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.COMMENTS);
+        String regex = "\"(email|phoneNumber|phone|address|sellerName|buyerName|name)\"\\s*:\\s*\"[^\"]+\"";
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
 
         Matcher matcher = pattern.matcher(json);
         StringBuilder sb = new StringBuilder();

--- a/common/src/main/java/com/back/common/event/KafkaEventParser.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventParser.java
@@ -34,7 +34,7 @@ public class KafkaEventParser {
             Envelope<T> envelope = jsonMapper.readValue(message, typeReference);
 
             // 성공 로그: 헤더의 정보를 활용 (예: user-account-updated)
-            log.info("[KafkaEventParser] {} 수신 성공: {}",
+            log.info("[KafkaEventParser] {} 이벤트 수신 성공: {}",
                     envelope.header().eventType(), maskedMessage);
 
             return envelope.payload();
@@ -45,6 +45,11 @@ public class KafkaEventParser {
         }
     }
 
+    /**
+     * JSON 메시지에서 민감한 정보를 마스킹하는 메서드
+     * @param json 마스킹할 JSON 문자열
+     * @return 민감한 정보가 마스킹된 JSON 문자열
+     */
     private String maskSensitiveInfo(String json) {
         if (json == null) return null;
         // 1. 마스킹할 패턴 정의 (Case Insensitive 적용)
@@ -57,8 +62,8 @@ public class KafkaEventParser {
 
         // 2. 매칭되는 부분을 찾아서 교체
         while (matcher.find()) {
-            // matcher.group(1)은 email, phoneNumber 등 매칭된 키값입니다.
-            // 키값은 유지하고 값 부분만 "***"로 마스킹합니다.
+            // matcher.group(1)은 email, phoneNumber 등 매칭된 키값
+            // 키값은 유지하고 값 부분만 "***"로 마스킹
             matcher.appendReplacement(sb, "\"" + matcher.group(1) + "\":\"***\"");
         }
         matcher.appendTail(sb);

--- a/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
@@ -1,9 +1,12 @@
 package com.back.common.event;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Service
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class KafkaEventPublisher {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final KafkaEventParser kafkaEventParser;
+    private final JsonMapper jsonMapper;
 
     public void publish(EventName event) {
         kafkaTemplate.send(event.getEventName(), event);
@@ -25,21 +29,21 @@ public class KafkaEventPublisher {
      */
     public <T extends KafkaPayload> void publish(String topic, Envelope<T> envelope) {
         try {
-            // 1. 이벤트 발행
+
+
+            // 로그 마스킹 처리 (toString 대신 jsonMapper 사용)
+            String jsonString = jsonMapper.writeValueAsString(envelope);
+            String maskedLog = kafkaEventParser.maskSensitiveInfo(jsonString);
+
+            // 카프카 전송 (예전처럼 객체 그대로 가볍게 던지기)
             kafkaTemplate.send(topic, envelope);
 
-            // 2. 로그 마스킹 처리 (개인정보 보호)
-            // envelope.toString() 결과물 내의 PII를 KafkaEventParser의 로직으로 마스킹합니다.
-            String maskedLog = kafkaEventParser.maskSensitiveInfo(envelope.toString());
-            log.info("[KafkaEventPublisher] 이벤트 발행 성공 - Topic: {}, Message: {}", topic, maskedLog);
+            log.info("[KafkaEventPublisher] 이벤트 발행 - Topic: {}, Message: {}", topic, maskedLog);
 
         } catch (Exception e) {
-            String maskedErrorLog = kafkaEventParser.maskSensitiveInfo(envelope.toString());
-            log.error("[KafkaEventPublisher] 이벤트 발행 실패 - Topic: {}, Message: {}, 사유: {}",
-                    topic, maskedErrorLog, e.getMessage());
-
-            // 여기서 공통 예외를 던지거나 런타임 예외로 래핑합니다.
-            throw new RuntimeException("Kafka 발행 중 오류 발생", e);
+            // 실패 시 원본 로그 없이 심플하게 에러 메시지만 남김
+            log.error("[KafkaEventPublisher] 이벤트 발행 실패 - Topic: {}, 사유: {}", topic, e.getMessage(), e);
+            throw new CustomException(FailureCode.EVENT_PUBLISH_FAILED);
         }
     }
 }

--- a/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/back/common/event/KafkaEventPublisher.java
@@ -1,13 +1,16 @@
 package com.back.common.event;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KafkaEventPublisher {
     private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaEventParser kafkaEventParser;
 
     public void publish(EventName event) {
         kafkaTemplate.send(event.getEventName(), event);
@@ -15,5 +18,28 @@ public class KafkaEventPublisher {
 
     public void publish(String topic, EventName event) {
         kafkaTemplate.send(topic, event);
+    }
+
+    /**
+     * 마스킹 및 에러 핸들링을 포함한 공통 발행 템플릿 메서드
+     */
+    public <T extends KafkaPayload> void publish(String topic, Envelope<T> envelope) {
+        try {
+            // 1. 이벤트 발행
+            kafkaTemplate.send(topic, envelope);
+
+            // 2. 로그 마스킹 처리 (개인정보 보호)
+            // envelope.toString() 결과물 내의 PII를 KafkaEventParser의 로직으로 마스킹합니다.
+            String maskedLog = kafkaEventParser.maskSensitiveInfo(envelope.toString());
+            log.info("[KafkaEventPublisher] 이벤트 발행 성공 - Topic: {}, Message: {}", topic, maskedLog);
+
+        } catch (Exception e) {
+            String maskedErrorLog = kafkaEventParser.maskSensitiveInfo(envelope.toString());
+            log.error("[KafkaEventPublisher] 이벤트 발행 실패 - Topic: {}, Message: {}, 사유: {}",
+                    topic, maskedErrorLog, e.getMessage());
+
+            // 여기서 공통 예외를 던지거나 런타임 예외로 래핑합니다.
+            throw new RuntimeException("Kafka 발행 중 오류 발생", e);
+        }
     }
 }

--- a/market/src/main/java/com/back/market/adapter/in/event/MarketKafkaEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/event/MarketKafkaEventListener.java
@@ -22,7 +22,6 @@ public class MarketKafkaEventListener {
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consumeUserCreatedEvent(String message) {
-        log.info("[MarketKafkaEventListener] UserCreatedEvent 수신: {}", message);
         UserCreatedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
         marketInternalFacade.handleUserCreatedEvent(payload);
     }
@@ -32,7 +31,6 @@ public class MarketKafkaEventListener {
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consumeUserUpdatedEvent(String message) {
-        log.info("[MarketKafkaEventListener] UserUpdatedEvent 수신: {}", message);
         UserUpdatedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
         marketInternalFacade.handleUserUpdatedEvent(payload);
     }
@@ -42,7 +40,6 @@ public class MarketKafkaEventListener {
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consumeProductCreatedEvent(String message) {
-        log.info("[MarketKafkaEventListener] product-item-created 수신: {}", message);
         ProductCreatedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
         marketInternalFacade.handleProductCreatedEvent(payload);
     }
@@ -52,7 +49,6 @@ public class MarketKafkaEventListener {
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consumeProductUpdatedEvent(String message) {
-        log.info("[MarketKafkaEventListener] product-item-updated 수신: {}", message);
         ProductUpdatedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
         marketInternalFacade.handleProductUpdatedEvent(payload);
     }
@@ -62,7 +58,6 @@ public class MarketKafkaEventListener {
             groupId = "${spring.kafka.consumer.group-id}"
     )
     public void consumeProductDeletedEvent(String message) {
-        log.info("[MarketKafkaEventListener] product-item-deleted 수신: {}", message);
         ProductDeletedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
         marketInternalFacade.handleProductDeletedEvent(payload);
     }

--- a/market/src/main/java/com/back/market/adapter/in/event/MarketKafkaEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/event/MarketKafkaEventListener.java
@@ -2,10 +2,7 @@ package com.back.market.adapter.in.event;
 
 import com.back.common.event.KafkaEventParser;
 import com.back.market.app.MarketInternalFacade;
-import com.back.market.event.payload.ProductCreatedPayload;
-import com.back.market.event.payload.ProductDeletedPayload;
-import com.back.market.event.payload.ProductUpdatedPayload;
-import com.back.market.event.payload.UserCreatedPayload;
+import com.back.market.event.payload.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -28,6 +25,16 @@ public class MarketKafkaEventListener {
         log.info("[MarketKafkaEventListener] UserCreatedEvent 수신: {}", message);
         UserCreatedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
         marketInternalFacade.handleUserCreatedEvent(payload);
+    }
+
+    @KafkaListener(
+            topics = "${custom.kafka.topic.user-account-updated}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void consumeUserUpdatedEvent(String message) {
+        log.info("[MarketKafkaEventListener] UserUpdatedEvent 수신: {}", message);
+        UserUpdatedPayload payload = kafkaEventParser.extractPayload(message, new TypeReference<>() {});
+        marketInternalFacade.handleUserUpdatedEvent(payload);
     }
 
     @KafkaListener(

--- a/market/src/main/java/com/back/market/adapter/in/event/MarketSpringEventListener.java
+++ b/market/src/main/java/com/back/market/adapter/in/event/MarketSpringEventListener.java
@@ -19,7 +19,7 @@ public class MarketSpringEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderCompletedEvent(OrderCompletedEvent springEvent) {
-        marketKafkaEventPublisher.sendOrderConfirmed(springEvent);
+        marketKafkaEventPublisher.sendOrderCompleted(springEvent);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
+++ b/market/src/main/java/com/back/market/adapter/out/event/MarketKafkaEventPublisher.java
@@ -3,7 +3,6 @@ package com.back.market.adapter.out.event;
 import com.back.common.code.FailureCode;
 import com.back.common.event.Envelope;
 import com.back.common.event.KafkaEventPublisher;
-import com.back.common.event.KafkaPayload;
 import com.back.common.exception.CustomException;
 import com.back.market.event.OrderCreatedEvent;
 import com.back.market.event.SellBiddingCreatedEvent;
@@ -30,21 +29,9 @@ public class MarketKafkaEventPublisher {
     @Value("${custom.kafka.topic.market-order-created}")
     private String orderCreatedTopic;
 
-    // 공통 실행 템플릿 메서드
-    private <T extends KafkaPayload> void publishWithErrorHandler(String topic, Envelope<T> envelope, Runnable publishTask) {
-        try {
-            publishTask.run();
-            log.info("[MarketKafkaEventPublisher] 카프카 이벤트 발행 완료. | Topic: {}, Data: {}, eventId: {}", topic, envelope.payload(), envelope.header().eventId());
-        } catch (CustomException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("[MarketKafkaEventPublisher] 카프카 발행 중 시스템 오류 발생. | Topic: {}, Data: {}, , eventId: {}, Error: {}", topic, envelope.payload(), envelope.header().eventId(), e.getMessage());
-            throw new CustomException(FailureCode.INTERNAL_SERVER_ERROR);
-        }
-    }
 
     // 구매 확정 이벤트
-    public void sendOrderConfirmed(OrderCompletedEvent event) {
+    public void sendOrderCompleted(OrderCompletedEvent event) {
         // 1. 데이터 검증 및 예외 처리
         if(event.orderId() == null || event.sellerId() == null) {
             log.error("[MarketKafkaEventPublisher] 필수 데이터 누락: orderId={}, sellerId={}", event.orderId(), event.sellerId());
@@ -65,7 +52,7 @@ public class MarketKafkaEventPublisher {
 
         Envelope<OrderCompletedPayload> envelope = Envelope.of(orderCompletedTopic, payload);
 
-        publishWithErrorHandler(orderCompletedTopic, envelope, () -> kafkaEventPublisher.publish(orderCompletedTopic, envelope));
+        kafkaEventPublisher.publish(orderCompletedTopic, envelope);
     }
 
     // 판매 입찰 생성 이벤트
@@ -92,7 +79,7 @@ public class MarketKafkaEventPublisher {
 
         Envelope<SellBiddingCreatedPayload> envelope = Envelope.of(sellBiddingCreatedTopic, payload);
 
-        publishWithErrorHandler(sellBiddingCreatedTopic, envelope, () -> kafkaEventPublisher.publish(sellBiddingCreatedTopic, envelope));
+        kafkaEventPublisher.publish(sellBiddingCreatedTopic, envelope);
     }
 
     // 주문 생성 이벤트
@@ -122,6 +109,6 @@ public class MarketKafkaEventPublisher {
 
         Envelope<OrderCreatedPayload> envelope = Envelope.of(orderCreatedTopic, payload);
 
-        publishWithErrorHandler(orderCreatedTopic, envelope, () -> kafkaEventPublisher.publish(orderCreatedTopic, envelope));
+        kafkaEventPublisher.publish(orderCreatedTopic, envelope);
     }
 }

--- a/market/src/main/java/com/back/market/app/MarketInternalFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketInternalFacade.java
@@ -92,16 +92,11 @@ public class MarketInternalFacade {
 
     @Transactional
     public void handleUserUpdatedEvent(UserUpdatedPayload payload) {
-        try {
-            log.info("[MarketInternalFacade] 유저 업데이트 이벤트 처리 시작 - ID: {}", payload.id());
-            UserUpdatedResultPayload resultPayload = UserUpdatedResultPayload.of(
-                    payload.id(), payload.name(), payload.address(), payload.phone()
-            );
-            updateMarketUserUseCase.updateMarketUser(resultPayload);
-        } catch (Exception e) {
-            log.error("[MarketInternalFacade] 유저 업데이트 처리 중 예외 발생 - ID: {}, 사유: {}", payload.id(), e.getMessage(), e);
-            throw e;
-        }
+        log.info("[MarketInternalFacade] 유저 업데이트 이벤트 처리 시작 - ID: {}", payload.id());
+        UserUpdatedResultPayload resultPayload = UserUpdatedResultPayload.of(
+                payload.id(), payload.name(), payload.address(), payload.phone()
+        );
+        updateMarketUserUseCase.updateMarketUser(resultPayload);
     }
 
     @Transactional

--- a/market/src/main/java/com/back/market/app/MarketInternalFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketInternalFacade.java
@@ -5,13 +5,11 @@ import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.app.usecase.*;
 import com.back.common.dto.cash.request.PaymentCompletedRequestDto;
 import com.back.market.domain.MarketUser;
-import com.back.market.event.payload.ProductCreatedPayload;
-import com.back.market.event.payload.ProductDeletedPayload;
-import com.back.market.event.payload.ProductUpdatedPayload;
-import com.back.market.event.payload.UserCreatedPayload;
+import com.back.market.event.payload.*;
 import com.back.market.event.resultpayload.ProductCreatedResultPayload;
 import com.back.market.event.resultpayload.ProductUpdatedResultPayload;
 import com.back.market.event.resultpayload.UserCreatedResultPayload;
+import com.back.market.event.resultpayload.UserUpdatedResultPayload;
 import com.back.market.mapper.MarketProductMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +35,7 @@ public class MarketInternalFacade {
     private final CreateProductUseCase createProductUseCase;
     private final UpdateProductUseCase updateProductUseCase;
     private final DeleteProductUseCase deleteProductUseCase;
+    private final UpdateMarketUserUseCase updateMarketUserUseCase;
 
     /**
      * Cash 모듈로부터 결제 완료(입금 확인) 통지를 수신하여 주문 상태를 확정
@@ -92,6 +91,20 @@ public class MarketInternalFacade {
     }
 
     @Transactional
+    public void handleUserUpdatedEvent(UserUpdatedPayload payload) {
+        try {
+            log.info("[MarketInternalFacade] 유저 업데이트 이벤트 처리 시작 - ID: {}", payload.id());
+            UserUpdatedResultPayload resultPayload = UserUpdatedResultPayload.of(
+                    payload.id(), payload.name(), payload.address(), payload.phone()
+            );
+            updateMarketUserUseCase.updateMarketUser(resultPayload);
+        } catch (Exception e) {
+            log.error("[MarketInternalFacade] 유저 업데이트 처리 중 예외 발생 - ID: {}, 사유: {}", payload.id(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Transactional
     public void handleProductCreatedEvent(@Valid ProductCreatedPayload payload) {
         try {
             log.info("[MarketInternalFacade] 상품 생성 이벤트 수신, 처리 시작");
@@ -111,7 +124,7 @@ public class MarketInternalFacade {
                         payload.productInfo().name());
             }
         } catch (Exception e) {
-            log.error("[MarketInternalFacade] 상품 처리 중 예외 발생! - 상품명: {}, 사유: {}",
+            log.error("[MarketInternalFacade] 상품 처리 중 예외 발생 - 상품명: {}, 사유: {}",
                     payload.productInfo().name(), e.getMessage(), e);
             throw e;
         }

--- a/market/src/main/java/com/back/market/app/usecase/UpdateMarketUserUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/UpdateMarketUserUseCase.java
@@ -1,0 +1,25 @@
+package com.back.market.app.usecase;
+
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.domain.MarketUser;
+import com.back.market.event.resultpayload.UserUpdatedResultPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateMarketUserUseCase {
+    private final MarketUserRepository marketUserRepository;
+
+    public void updateMarketUser(UserUpdatedResultPayload payload) {
+        MarketUser user = marketUserRepository.findById(payload.id()).orElse(null);
+        if (user != null) {
+            user.update(payload.name(), payload.address(), payload.phone());
+            log.info("[UpdateMarketUserUseCase] 유저 정보 업데이트 완료 - ID: {}", payload.id());
+        } else {
+            log.warn("[UpdateMarketUserUseCase] 업데이트 대상 유저를 찾을 수 없음 - ID: {}", payload.id());
+        }
+    }
+}

--- a/market/src/main/java/com/back/market/app/usecase/UpdateMarketUserUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/UpdateMarketUserUseCase.java
@@ -1,5 +1,7 @@
 package com.back.market.app.usecase;
 
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
 import com.back.market.adapter.out.MarketUserRepository;
 import com.back.market.domain.MarketUser;
 import com.back.market.event.resultpayload.UserUpdatedResultPayload;
@@ -19,7 +21,8 @@ public class UpdateMarketUserUseCase {
             user.update(payload.name(), payload.address(), payload.phone());
             log.info("[UpdateMarketUserUseCase] 유저 정보 업데이트 완료 - ID: {}", payload.id());
         } else {
-            log.warn("[UpdateMarketUserUseCase] 업데이트 대상 유저를 찾을 수 없음 - ID: {}", payload.id());
+            log.error("[UpdateMarketUserUseCase] 업데이트 대상 유저를 찾을 수 없음 - ID: {}", payload.id());
+            throw new CustomException(FailureCode.USER_NOT_FOUND);
         }
     }
 }

--- a/market/src/main/java/com/back/market/domain/MarketUser.java
+++ b/market/src/main/java/com/back/market/domain/MarketUser.java
@@ -40,4 +40,10 @@ public class MarketUser extends BaseTimeEntity {
 
     @Column(name = "phone", length = 20)
     private String phone;           // 연락처
+
+    public void update(String name, String address, String phone) {
+        this.name = name;
+        this.address = address;
+        this.phone = phone;
+    }
 }

--- a/market/src/main/java/com/back/market/event/payload/UserUpdatedPayload.java
+++ b/market/src/main/java/com/back/market/event/payload/UserUpdatedPayload.java
@@ -1,0 +1,12 @@
+package com.back.market.event.payload;
+
+import com.back.common.event.KafkaPayload;
+
+public record UserUpdatedPayload(
+        Long id,
+        String name,
+        String email,
+        String address,
+        String phone
+) implements KafkaPayload {
+}

--- a/market/src/main/java/com/back/market/event/resultpayload/UserUpdatedResultPayload.java
+++ b/market/src/main/java/com/back/market/event/resultpayload/UserUpdatedResultPayload.java
@@ -1,0 +1,14 @@
+package com.back.market.event.resultpayload;
+
+import com.back.common.event.EventName;
+
+public record UserUpdatedResultPayload(
+        Long id,
+        String name,
+        String address,
+        String phone
+) implements EventName {
+    public static UserUpdatedResultPayload of(Long id, String name, String address, String phone) {
+        return new UserUpdatedResultPayload(id, name, address, phone);
+    }
+}

--- a/market/src/test/java/com/back/market/event/MarketKafkaEventPublisherTests.java
+++ b/market/src/test/java/com/back/market/event/MarketKafkaEventPublisherTests.java
@@ -38,15 +38,15 @@ public class MarketKafkaEventPublisherTests {
 
     @Test
     @DisplayName("성공: 올바른 데이터가 주어지면 카프카로 Envelope 메시지를 발행한다.")
-    void sendOrderConfirmed_success() {
+    void sendOrderCompleted_success() {
         OrderCompletedEvent event = new OrderCompletedEvent(1L, 1L, 100L, 500L, "판매자A", new BigDecimal("50000.00"), OrderStatus.COMPLETED, LocalDateTime.now());
-        marketKafkaEventPublisher.sendOrderConfirmed(event);
+        marketKafkaEventPublisher.sendOrderCompleted(event);
         verify(kafkaEventPublisher).publish(eq("market.order.completed"), any(Envelope.class));
     }
 
     @Test
     @DisplayName("실패: 필수 값(orderId)이 누락되면 MISSING_REQUIRED_FIELD 예외가 발생한다")
-    void sendOrderConfirmed_Fail_MissingField() {
+    void sendOrderCompleted_Fail_MissingField() {
         // Given: orderId가 null인 비정상 이벤트
         OrderCompletedEvent invalidEvent = new OrderCompletedEvent(
                 null, 100L, 500L, 600L, "판매자A", new BigDecimal("50000.00"), OrderStatus.COMPLETED, LocalDateTime.now()
@@ -54,7 +54,7 @@ public class MarketKafkaEventPublisherTests {
 
         // When & Then: 예외 발생 여부 검증
         assertThrows(CustomException.class, () -> {
-            marketKafkaEventPublisher.sendOrderConfirmed(invalidEvent);
+            marketKafkaEventPublisher.sendOrderCompleted(invalidEvent);
         });
     }
 }

--- a/market/src/test/java/com/back/market/event/UserCreatedEventConsumeTests.java
+++ b/market/src/test/java/com/back/market/event/UserCreatedEventConsumeTests.java
@@ -46,10 +46,10 @@ public class UserCreatedEventConsumeTests {
         Envelope<UserCreatedPayload> envelope = Envelope.of("UserCreatedEvent", userCreatedPayload);
 
         // 3. envelope를 json 문자열로 직렬화
-        String message = jsonMapper.writeValueAsString(envelope);
+        //String message = jsonMapper.writeValueAsString(envelope);
         
         // 4. kafka로 메시지 전송
-        kafkaTemplate.send(topic, message);
+        kafkaTemplate.send(topic, envelope);
         log.info("Event sent to Kafka topic: UserCreatedPayload (id: {})", testId);
 
         Thread.sleep(3000); // 시간차 두기

--- a/market/src/test/java/com/back/market/event/UserCreatedEventConsumeTests.java
+++ b/market/src/test/java/com/back/market/event/UserCreatedEventConsumeTests.java
@@ -15,7 +15,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 @Slf4j
 @SpringBootTest
-public class KafkaIntegrationTest {
+public class UserCreatedEventConsumeTests {
 
     @Autowired
     private KafkaTemplate<String, Object> kafkaTemplate;

--- a/market/src/test/java/com/back/market/event/UserUpdatedEventConsumeTests.java
+++ b/market/src/test/java/com/back/market/event/UserUpdatedEventConsumeTests.java
@@ -1,0 +1,91 @@
+package com.back.market.event;
+
+import com.back.market.adapter.in.event.MarketKafkaEventListener;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.domain.MarketUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class UserUpdatedEventConsumeTests {
+
+    @Autowired
+    private MarketKafkaEventListener listener;
+
+    @Autowired
+    private MarketUserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 기존 유저 저장
+        MarketUser existingUser = MarketUser.builder()
+                .id(1L)
+                .name("Old Name")
+                .email("old@example.com")
+                .address("Old Address")
+                .phone("010-0000-0000")
+                .build();
+        userRepository.save(existingUser);
+    }
+
+    @Test
+    @DisplayName("유저 수정 이벤트 수신 시 실제 DB의 사용자 정보가 변경되는지 검증한다")
+    void consumeUserUpdatedEvent_Success() {
+        // 1. 수정용 JSON 메시지 준비 (일부러 대소문자를 섞어서 마스킹 로직도 고려)
+        String updateMessage = """
+        {
+          "header": { "eventId": "user-upd-001", "eventType": "user-account-updated" },
+          "payload": {
+            "id": 1,
+            "name": "New Name",
+            "email": "new@example.com",
+            "address": "New Seoul Address",
+            "phone": "010-1234-5678"
+          }
+        }
+        """;
+
+        // 2. 이벤트 컨슈밍
+        listener.consumeUserUpdatedEvent(updateMessage);
+
+        // 3. 결과 검증
+        MarketUser updatedUser = userRepository.findById(1L).orElseThrow();
+
+        assertThat(updatedUser.getName()).isEqualTo("New Name");
+        assertThat(updatedUser.getAddress()).isEqualTo("New Seoul Address");
+        assertThat(updatedUser.getPhone()).isEqualTo("010-1234-5678");
+
+        // 이메일은 비즈니스 로직상 업데이트 대상이 아니므로 기존 값 유지 확인
+        assertThat(updatedUser.getEmail()).isEqualTo("old@example.com");
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 유저 메시지 수신 시 PII가 마스킹되어 로그에 남는지 확인 (콘솔 출력 확인용)")
+    void consumeUserUpdatedEvent_MaskingCheck() {
+        // 일부러 JSON 구조를 깨뜨려서 역직렬화 예외 발생 유도
+        String brokenMessage = """
+        {
+          "header": { "eventId": "mask-test-001" },
+          "payload": {
+            "id": 1,
+            "email": "secret-user@naver.com",
+            "address": "서울시 민감한 주소"
+          }
+        -- 강제 에러 유발 --
+        """;
+
+        // 실행 시 KafkaEventParser에서 마스킹된 로그가 찍히는지 콘솔 확인
+        try {
+            listener.consumeUserUpdatedEvent(brokenMessage);
+        } catch (Exception e) {
+            System.out.println("예외 발생(정상): " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #343 

## 🔎 작업 내용

- UserUpdatedEvent 처리 로직 추가
- 공통모듈에 이벤트 발행 공통 메서드 추가
   - MarketKafkaEventPublisher에서 공통 템플릿 제거 및 KafkaEventPublisher 메서드 호출로 대체
- 이벤트 수신 및 업데이트 처리 테스트 진행
<br>

## 📷 테스트 결과
- user update 이벤트 처리 테스트
  <img width="830" height="438" alt="image" src="https://github.com/user-attachments/assets/c92abee4-0e75-4b5e-8165-79f319ce4670" />
<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
