### PR TITLE
[FIX] 이미지 리사이징 로직 변경을 통한 성능 개선 (#351)

### DIFF
--- a/image/build.gradle
+++ b/image/build.gradle
@@ -3,5 +3,13 @@ dependencies {
     implementation project(':security')
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // 원본 색상을 제대로 읽기 위한 플러그인
+    implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.9.4'
+    implementation 'com.twelvemonkeys.imageio:imageio-tiff:3.9.4'
+
+    // 고품질 리사이징 라이브러리
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }

--- a/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
@@ -12,9 +12,6 @@ import net.coobird.thumbnailator.resizers.configurations.Antialiasing;
 import net.coobird.thumbnailator.resizers.configurations.Rendering;
 import org.springframework.stereotype.Service;
 
-import javax.imageio.ImageIO;
-import java.awt.*;
-import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -46,63 +43,19 @@ public class ResizeImageUseCase {
                 throw new CustomException("[ImageProcessingFailed] 리사이즈할 파일이 존재하지 않습니다.", FailureCode.IMAGE_PROCESSING_FAILED);
             }
 
-            BufferedImage originalImage = ImageIO.read(convertedImage);
-            if (originalImage == null) {
-                log.error("[ImageProcessingFailed] 이미지 파일을 읽을 수 없습니다: {}", convertedImage.getName());
-                throw new CustomException("[ImageProcessingFailed] 이미지 파일을 읽을 수 없습니다: " + convertedImage.getName(), FailureCode.IMAGE_PROCESSING_FAILED);
-            }
+            File resizedImage = new File(System.getProperty("java.io.tmpdir") + "/resized_" + convertedImage.getName());
 
-            int originWidth = originalImage.getWidth();
-            int originHeight = originalImage.getHeight();
+            Thumbnails.of(convertedImage)
+                    .size(imageResizeProperties.getWidth(), imageResizeProperties.getHeight())
+                    .rendering(Rendering.QUALITY)
+                    .antialiasing(Antialiasing.ON)
+                    .outputQuality(0.9)
+                    .toFile(resizedImage);
 
-            if (isResizeUnnecessary(originWidth, originHeight)) {
-                return convertedImage;
-            }
-
-            BufferedImage resizedImage = handleResizeImage(originalImage, originWidth, originHeight);
-
-            return buildImageFile(resizedImage, convertedImage);
+            return resizedImage;
         } catch (IOException e) {
             log.error("[ImageProcessingFailed] 이미지 리사이징 중 IOException 발생: {}", e.getMessage(), e);
             throw new CustomException("[ImageProcessingFailed] 이미지 리사이지 중 IOException 발생 : " + e.getMessage(), FailureCode.IMAGE_PROCESSING_FAILED);
         }
-    }
-
-    private boolean isResizeUnnecessary(int originWidth, int originHeight) {
-        return originWidth <= imageResizeProperties.getWidth() && originHeight <= imageResizeProperties.getHeight();
-    }
-
-    private BufferedImage handleResizeImage(BufferedImage originalImage, int originWidth, int originHeight) throws IOException {
-        return Thumbnails.of(originalImage)
-                .size(imageResizeProperties.getWidth(), imageResizeProperties.getHeight())
-                .rendering(Rendering.QUALITY)
-                .antialiasing(Antialiasing.ON)
-                .outputQuality(0.9)
-                .asBufferedImage();
-    }
-
-    private File buildImageFile(BufferedImage resizedImage, File convertedImage) throws IOException {
-        File resizedFile = new File(System.getProperty("java.io.tmpdir") + "/resized_" + convertedImage.getName());
-
-        File parentDir = resizedFile.getParentFile();
-        if (parentDir != null && !parentDir.exists()) {
-            parentDir.mkdirs();
-        }
-
-        if (!imageUtility.validateFileExtension(resizedFile.getName())) {
-            log.error("[ImageProcessingFailed] 지원하지 않는 파일 형식입니다: {}", resizedFile.getName());
-            throw new IOException("[ImageProcessingFailed] 지원하지 않는 파일 형식입니다: " + resizedFile.getName());
-        }
-
-        String fileExtension = imageUtility.getFileExtension(resizedFile.getName());
-
-        ImageIO.write(resizedImage, fileExtension, resizedFile);
-
-        if (!resizedFile.exists()) {
-            log.error("[ImageProcessingFailed] 리사이즈된 파일 생성에 실패했습니다.");
-            throw new IOException("[ImageProcessingFailed] 리사이즈된 파일 생성에 실패했습니다.");
-        }
-
-        return resizedFile;
     }
 }

--- a/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
@@ -49,7 +49,7 @@ public class ResizeImageUseCase {
                     .size(imageResizeProperties.getWidth(), imageResizeProperties.getHeight())
                     .rendering(Rendering.QUALITY)
                     .antialiasing(Antialiasing.ON)
-                    .outputQuality(0.9)
+                    .outputQuality(0.85)
                     .toFile(resizedImage);
 
             return resizedImage;

--- a/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
+++ b/image/src/main/java/com/back/image/app/usecase/ResizeImageUseCase.java
@@ -7,6 +7,9 @@ import com.back.image.config.ImageResizeProperties;
 import com.back.image.utils.ImageUtility;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import net.coobird.thumbnailator.resizers.configurations.Antialiasing;
+import net.coobird.thumbnailator.resizers.configurations.Rendering;
 import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
@@ -69,26 +72,13 @@ public class ResizeImageUseCase {
         return originWidth <= imageResizeProperties.getWidth() && originHeight <= imageResizeProperties.getHeight();
     }
 
-    private BufferedImage handleResizeImage(BufferedImage originalImage, int originWidth, int originHeight) {
-        double widthScale = (double) imageResizeProperties.getWidth() / (double) originWidth;
-        double heightScale = (double) imageResizeProperties.getHeight() / (double) originHeight;
-        double scale = Math.min(widthScale, heightScale);
-
-        int resizedWidth = (int) Math.round(originWidth * scale);
-        int resizedHeight = (int) Math.round(originHeight * scale);
-
-        BufferedImage resizedImage = new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_RGB);
-        Graphics2D graphics2D = resizedImage.createGraphics();
-
-        // 품질과 속도의 균형을 위한 렌더링 힌트 설정
-        graphics2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        graphics2D.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-        graphics2D.drawImage(originalImage, 0, 0, resizedWidth, resizedHeight, null);
-        graphics2D.dispose();
-
-        return resizedImage;
+    private BufferedImage handleResizeImage(BufferedImage originalImage, int originWidth, int originHeight) throws IOException {
+        return Thumbnails.of(originalImage)
+                .size(imageResizeProperties.getWidth(), imageResizeProperties.getHeight())
+                .rendering(Rendering.QUALITY)
+                .antialiasing(Antialiasing.ON)
+                .outputQuality(0.9)
+                .asBufferedImage();
     }
 
     private File buildImageFile(BufferedImage resizedImage, File convertedImage) throws IOException {

--- a/image/src/test/java/com/back/app/usecase/ConvertImageUseCaseTest.java
+++ b/image/src/test/java/com/back/app/usecase/ConvertImageUseCaseTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.*;
 
 class ConvertImageUseCaseTest {
@@ -56,6 +57,8 @@ class ConvertImageUseCaseTest {
         List<MultipartFile> multipartFiles = List.of(multipartFile1, multipartFile2);
 
         when(imageUtility.validateFileExtension(anyString())).thenReturn(true);
+        when(imageUtility.getFileExtension(contains("test1.jpg"))).thenReturn("jpg");
+        when(imageUtility.getFileExtension(contains("test2.png"))).thenReturn("png");
 
         // When
         List<File> convertedFiles = convertImageUseCase.convertMultipleFile(multipartFiles);
@@ -63,8 +66,8 @@ class ConvertImageUseCaseTest {
         // Then
         assertNotNull(convertedFiles);
         assertEquals(2, convertedFiles.size());
-        assertTrue(convertedFiles.stream().anyMatch(f -> f.getName().equals(filename1)));
-        assertTrue(convertedFiles.stream().anyMatch(f -> f.getName().equals(filename2)));
+        assertTrue(convertedFiles.stream().anyMatch(f -> f.getName().endsWith(".jpg")));
+        assertTrue(convertedFiles.stream().anyMatch(f -> f.getName().endsWith(".png")));
         convertedFiles.forEach(file -> {
             assertTrue(file.exists());
             assertTrue(file.length() > 0);

--- a/image/src/test/java/com/back/app/usecase/ResizeImageUseCaseTest.java
+++ b/image/src/test/java/com/back/app/usecase/ResizeImageUseCaseTest.java
@@ -4,6 +4,7 @@ import com.back.common.exception.CustomException;
 import com.back.image.app.usecase.ResizeImageUseCase;
 import com.back.image.config.ImageResizeProperties;
 import com.back.image.utils.ImageUtility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -19,12 +19,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 class ResizeImageUseCaseTest {
 
@@ -38,13 +40,24 @@ class ResizeImageUseCaseTest {
     private ResizeImageUseCase resizeImageUseCase;
 
     @TempDir
-    Path tempDir; // JUnit 5 provides a temporary directory for tests
+    Path tempDir;
+
+    private List<File> filesToDelete = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         when(imageResizeProperties.getWidth()).thenReturn(500);
         when(imageResizeProperties.getHeight()).thenReturn(500);
+    }
+
+    @AfterEach
+    void tearDown() {
+        for (File file : filesToDelete) {
+            if (file != null && file.exists()) {
+                file.delete();
+            }
+        }
     }
 
     private File createDummyImageFile(String filename, int width, int height) throws IOException {
@@ -55,50 +68,45 @@ class ResizeImageUseCaseTest {
     }
 
     @Test
-    @DisplayName("이미지 크기가 maxWidth보다 작으면 원본 파일을 반환한다")
-    void resizeImage_widthLessThanMaxWidth_returnsOriginalFile() throws IOException {
+    @DisplayName("이미지 리사이징 시 항상 'resized_' 접두사가 붙은 새로운 파일을 생성한다")
+    void resizeImage_alwaysReturnsNewResizedFile() throws IOException {
         // Given
-        File originalFile = createDummyImageFile("small_image.jpg", 300, 200); // 300 < 500
-        when(imageUtility.validateFileExtension(anyString())).thenReturn(true);
-        when(imageUtility.getFileExtension(anyString())).thenReturn("jpg");
+        File originalFile = createDummyImageFile("test_image.jpg", 1000, 800);
 
         // When
         File resultFile = resizeImageUseCase.resizeImage(originalFile);
+        filesToDelete.add(resultFile);
 
         // Then
-        assertEquals(originalFile, resultFile); // Should return the original file
-        verify(imageUtility, never()).validateFileExtension(anyString()); // Validation should not be called
-        verify(imageUtility, never()).getFileExtension(anyString());
-        // Clean up
-        Files.deleteIfExists(originalFile.toPath());
+        assertNotEquals(originalFile.getAbsolutePath(), resultFile.getAbsolutePath());
+        assertTrue(resultFile.getName().startsWith("resized_"));
+        assertTrue(resultFile.exists());
+
+        BufferedImage resizedImage = ImageIO.read(resultFile);
+        // Thumbnails.size(500, 500)은 비율을 유지하면서 500x500 안에 들어가도록 조정함
+        assertEquals(500, resizedImage.getWidth());
+        assertEquals(400, resizedImage.getHeight()); // 1000:800 = 500:400
+        resizedImage.flush();
     }
 
     @Test
-    @DisplayName("이미지 크기가 maxWidth보다 크면 리사이즈된 파일을 반환한다")
-    void resizeImage_widthGreaterThanMaxWidth_returnsResizedFile() throws IOException {
+    @DisplayName("여러 이미지 파일 리사이즈를 성공적으로 수행한다")
+    void resizeMultipleImage_success() throws IOException {
         // Given
-        File originalFile = createDummyImageFile("large_image.jpg", 1000, 800); // 1000 > 500
-        when(imageUtility.validateFileExtension(anyString())).thenReturn(true);
-        when(imageUtility.getFileExtension(anyString())).thenReturn("jpg");
+        File file1 = createDummyImageFile("image1.jpg", 1000, 1000);
+        File file2 = createDummyImageFile("image2.jpg", 800, 600);
+        List<File> filesToResize = List.of(file1, file2);
 
         // When
-        File resultFile = resizeImageUseCase.resizeImage(originalFile);
+        List<File> results = resizeImageUseCase.resizeMultipleImage(filesToResize);
+        filesToDelete.addAll(results);
 
         // Then
-        assertNotEquals(originalFile, resultFile); // Should be a new resized file
-        assertTrue(resultFile.exists());
-        assertTrue(resultFile.getName().startsWith("resized_"));
-
-        BufferedImage resizedImage = ImageIO.read(resultFile);
-        assertEquals(500, resizedImage.getWidth());
-        assertEquals(400, resizedImage.getHeight()); // Original ratio 1000/800 = 1.25 -> 500/400 = 1.25
-
-        verify(imageUtility, times(1)).validateFileExtension(resultFile.getName());
-        verify(imageUtility, times(1)).getFileExtension(resultFile.getName());
-
-        // Clean up
-        Files.deleteIfExists(originalFile.toPath());
-        Files.deleteIfExists(resultFile.toPath());
+        assertEquals(2, results.size());
+        for (File result : results) {
+            assertTrue(result.getName().startsWith("resized_"));
+            assertTrue(result.exists());
+        }
     }
 
     @Test
@@ -106,7 +114,7 @@ class ResizeImageUseCaseTest {
     void resizeImage_nullOrNonExistentFile_throwsCustomException() {
         // Given
         File nullFile = null;
-        File nonExistentFile = tempDir.resolve("non_existent.jpg").toFile();
+        File nonExistentFile = new File(tempDir.toFile(), "non_existent.jpg");
 
         // When & Then
         assertThrows(CustomException.class, () -> resizeImageUseCase.resizeImage(nullFile));
@@ -114,77 +122,17 @@ class ResizeImageUseCaseTest {
     }
 
     @Test
-    @DisplayName("파일 확장자를 인식할 수 없을 경우 CustomException을 발생시킨다")
-    void resizeImage_unknownFileExtension_throwsCustomException() throws IOException {
+    @DisplayName("이미지 리사이징 중 IOException이 발생하면 CustomException으로 래핑하여 던진다")
+    void resizeImage_ioException_throwsCustomException() throws IOException {
         // Given
-        File originalFile = createDummyImageFile("image", 1000, 800); // No extension
-        when(imageUtility.validateFileExtension(anyString())).thenThrow(new IOException("파일 확장자를 확인할 수 없습니다."));
+        // 읽을 수 없는 파일을 생성하여 IOException 유도
+        File corruptedFile = tempDir.resolve("corrupted.jpg").toFile();
+        Files.write(corruptedFile.toPath(), new byte[]{0, 1, 2, 3}); 
+
         // When & Then
         CustomException thrown = assertThrows(CustomException.class, () ->
-                resizeImageUseCase.resizeMultipleImage(Collections.singletonList(originalFile))
+                resizeImageUseCase.resizeImage(corruptedFile)
         );
         assertEquals(com.back.common.code.FailureCode.IMAGE_PROCESSING_FAILED, thrown.getFailureCode());
-        // Clean up
-        Files.deleteIfExists(originalFile.toPath());
-    }
-
-    @Test
-    @DisplayName("리사이즈된 파일 생성에 실패하면 IOException을 발생시킨다")
-    void resizeImage_failedToCreateResizedFile_throwsIOException() throws IOException {
-        // Given
-        File originalFile = createDummyImageFile("image.jpg", 1000, 800);
-        // Simulate failure by making validateFileExtension throw an IOException
-        // or by making ImageIO.write fail (harder to mock for unit tests)
-        // For this test, we'll simulate the case where validateFileExtension throws IOException
-        // which will be caught and wrapped by resizeMultipleImage.
-        when(imageUtility.validateFileExtension(anyString())).thenThrow(new IOException("Simulated validation failure"));
-        
-        // When & Then
-        CustomException thrown = assertThrows(CustomException.class, () ->
-                resizeImageUseCase.resizeMultipleImage(Collections.singletonList(originalFile))
-        );
-        assertEquals(com.back.common.code.FailureCode.IMAGE_PROCESSING_FAILED, thrown.getFailureCode());
-        
-        // Clean up
-        Files.deleteIfExists(originalFile.toPath());
-    }
-
-    // Test for multiple files with mixed success/failure (though resizeMultipleImage wraps all IOExceptions)
-    @Test
-    @DisplayName("여러 이미지 파일 리사이즈 중 하나라도 실패하면 CustomException을 발생시킨다")
-    void resizeMultipleImage_partialFailure_throwsCustomException() throws IOException {
-        // Given
-        File file1 = createDummyImageFile("valid.jpg", 1000, 800);
-        File file2 = createDummyImageFile("invalid.png", 600, 600); // Changed dimensions
-        List<File> filesToResize = List.of(file1, file2);
-
-        when(imageUtility.validateFileExtension("valid.jpg")).thenReturn(true);
-        when(imageUtility.getFileExtension("valid.jpg")).thenReturn("jpg");
-        when(imageUtility.validateFileExtension("resized_valid.jpg")).thenReturn(true);
-        when(imageUtility.getFileExtension("resized_valid.jpg")).thenReturn("jpg");
-
-        // Mocks for file2 (invalid case)
-        // For "invalid.png", assume getFileExtension can still extract "png",
-        // but validateFileExtension should return FALSE for unsupported format.
-        // The file name generated in resizeImage for file2 will be "resized_invalid.png"
-        when(imageUtility.validateFileExtension(startsWith("resized_invalid.png"))).thenThrow(new IOException("Simulated unsupported format"));
-        when(imageUtility.getFileExtension(startsWith("resized_invalid.png"))).thenReturn("png"); // <--- MOCK THIS TO AVOID NULL for ImageIO.write
-        
-        // When & Then
-        CustomException thrown = assertThrows(CustomException.class, () ->
-                resizeImageUseCase.resizeMultipleImage(filesToResize)
-        );
-        assertEquals(com.back.common.code.FailureCode.IMAGE_PROCESSING_FAILED, thrown.getFailureCode());
-        verify(imageUtility, times(1)).validateFileExtension(startsWith("resized_invalid.png"));
-        
-        // Clean up all potential temporary files
-        Files.deleteIfExists(file1.toPath());
-        Files.deleteIfExists(file2.toPath());
-        Files.walk(tempDir)
-            .filter(Files::isRegularFile)
-            .filter(p -> p.getFileName().toString().startsWith("resized_"))
-            .forEach(p -> {
-                try { Files.delete(p); } catch (IOException e) { /* ignore */ }
-            });
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

* Resolved: #351

## 🔎 작업 내용


### 1. 이미지 처리 라이브러리 교체 및 고도화

* **Thumbnailator 도입**: 기존의 로우 레벨 `Graphics2D` 구현 방식을 `Thumbnailator` 라이브러리로 교체하여 코드 가독성과 유지보수성을 확보했습니다.
* **색상 왜곡 방지 (TwelveMonkeys 연동)**: 리사이징 과정에서 흔히 발생하는 ICC 프로파일 손실 및 색 바램 현상을 방지하기 위해 `TwelveMonkeys ImageIO` 플러그인을 적용, 원본에 가까운 색 재현력을 구현했습니다.

### 2. 메모리 최적화 (극한의 다이어트 전략)

* **File-to-File 스트림 처리**: 이미지를 `BufferedImage` 형태로 힙(Heap) 메모리에 전체 로드하지 않고, 파일 스트림을 통해 직접 처리하는 `toFile()` API를 적용했습니다.
* **메모리 절감 성과**: JFR(Java Flight Recorder) 분석 결과, **힙 메모리 점유율을 기존 대비 약 2배 절약(250MB → 110MB)** 했으며, 고용량 이미지 처리 시 발생하던 메모리 스파이크를 완벽히 억제했습니다.

### 3. 성능 및 품질 밸런싱

* **최적화 설정**: `outputQuality(0.85)`를 적용하여, 육안으로 식별하기 힘든 수준의 품질을 유지하면서 인코딩 속도와 최종 파일 용량을 최적화했습니다.

---

## 📌 참고 사항

### ⚠️ 주의해야 할 점 (Trade-off)

* **CPU 연산량**: 메모리 안정성을 위해 고정밀 알고리즘을 사용함에 따라 CPU 연산 시간이 기존 대비 약 1.6배 증가했습니다. 하지만 이는 OOM(OutOfMemoryError) 방지 및 시스템 안정성을 위한 의도된 선택입니다.

---

## 📷 테스트 결과

### JFR 메모리 프로파일링 비교

* **최적화 전**: 힙 메모리 Committed가 600MB 이상으로 치솟으며 불안정한 모습.
<img width="2439" height="473" alt="image" src="https://github.com/user-attachments/assets/acb77146-65ad-47fe-9631-de0dbf022ad3" />
<img width="2439" height="473" alt="image" src="https://github.com/user-attachments/assets/aa14435e-fc53-4f63-8d71-acefcbbb7850" />

* **최적화 후**: 힙 메모리 사용량이 **110MB**  대에서 일정하고 안정적으로 유지**됨을 확인.
<img width="2439" height="473" alt="image" src="https://github.com/user-attachments/assets/f6ef46ca-9849-4ca7-b9ab-3fa123323e6e" />
<img width="2439" height="473" alt="image" src="https://github.com/user-attachments/assets/7f595ad1-421d-4717-abca-3a05ac18fed9" />

---

## ✅ Check List

* [x] 라벨 지정
* [x] 리뷰어 지정
* [x] 담당자 지정
* [x] 테스트 완료
* [x] 이슈 제목 컨벤션 준수
* [x] PR 제목 및 설명 작성
* [x] 커밋 메시지 컨벤션 준수