### PR TITLE
[FEAT] Chat 서비스 커스텀 메트릭 추가 (#344)

### DIFF
--- a/chat/src/main/java/com/back/chat/adapter/out/metrics/ChatMetrics.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/metrics/ChatMetrics.java
@@ -13,7 +13,7 @@ public class ChatMetrics {
     private final MeterRegistry registry;
 
     // Gauge
-    private final AtomicInteger outboxPending = new AtomicInteger(0);
+    private final AtomicInteger outboxRetryBacklog = new AtomicInteger(0);
 
     // Fixed counters (no tags)
     private final Counter wsSendTotal;
@@ -26,8 +26,8 @@ public class ChatMetrics {
     public ChatMetrics(MeterRegistry registry) {
         this.registry = registry;
 
-        Gauge.builder("resello_chat_outbox_pending", outboxPending, AtomicInteger::get)
-                .description("Current pending outbox count")
+        Gauge.builder("resello_chat_outbox_retry_backlog", outboxRetryBacklog, AtomicInteger::get)
+                .description("Outbox FAILED records waiting for retry publish")
                 .register(registry);
 
         this.wsSendTotal = Counter.builder("resello_chat_ws_send_total")
@@ -88,8 +88,8 @@ public class ChatMetrics {
     }
 
     // ---------- Gauge setter ----------
-    public void setOutboxPending(int count) {
-        outboxPending.set(Math.max(count, 0));
+    public void setOutboxRetryBacklog(int failedCount) {
+        outboxRetryBacklog.set(Math.max(failedCount, 0));
     }
 
     private String safeTag(String v) {

--- a/chat/src/main/java/com/back/chat/adapter/out/metrics/ChatMetrics.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/metrics/ChatMetrics.java
@@ -1,0 +1,101 @@
+package com.back.chat.adapter.out.metrics;
+
+import io.micrometer.core.instrument.*;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class ChatMetrics {
+
+    private final MeterRegistry registry;
+
+    // Gauge
+    private final AtomicInteger outboxPending = new AtomicInteger(0);
+
+    // Fixed counters (no tags)
+    private final Counter wsSendTotal;
+    private final Counter blindTriggerTotal;
+
+    // Cache for tagged counters/timers
+    private final ConcurrentHashMap<String, Counter> counterCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Timer> timerCache = new ConcurrentHashMap<>();
+
+    public ChatMetrics(MeterRegistry registry) {
+        this.registry = registry;
+
+        Gauge.builder("resello_chat_outbox_pending", outboxPending, AtomicInteger::get)
+                .description("Current pending outbox count")
+                .register(registry);
+
+        this.wsSendTotal = Counter.builder("resello_chat_ws_send_total")
+                .description("Total WS send attempts")
+                .register(registry);
+
+        this.blindTriggerTotal = Counter.builder("resello_chat_blind_trigger_total")
+                .description("Total blind triggers (threshold reached)")
+                .register(registry);
+    }
+
+    // ---------- Timer ----------
+    public Timer timer(String name, Tags tags) {
+        // key는 name + tags 조합
+        String key = name + "|" + tags.toString();
+        return timerCache.computeIfAbsent(key, k ->
+                Timer.builder(name)
+                        .tags(tags)
+                        .publishPercentileHistogram()
+                        .register(registry)
+        );
+    }
+
+    public void recordRunnable(String name, Tags tags, Runnable task) {
+        timer(name, tags).record(task);
+    }
+
+    public <T> T recordCallable(String name, Tags tags, Callable<T> task) {
+        try {
+            return timer(name, tags).recordCallable(task);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ---------- Counters ----------
+    public void incWsSendTotal() {
+        wsSendTotal.increment();
+    }
+
+    public void incBlindTrigger() {
+        blindTriggerTotal.increment();
+    }
+
+    public void incOutboxPublishFail(String eventType, String cause) {
+        // 태그 값은 반드시 제한된 셋으로 (폭발 방지)
+        String safeEventType = safeTag(eventType);
+        String safeCause = safeTag(cause);
+
+        String key = "resello_chat_outbox_publish_fail_total|eventType=" + safeEventType + "|cause=" + safeCause;
+
+        Counter c = counterCache.computeIfAbsent(key, k ->
+                Counter.builder("resello_chat_outbox_publish_fail_total")
+                        .tags("eventType", safeEventType, "cause", safeCause)
+                        .register(registry)
+        );
+        c.increment();
+    }
+
+    // ---------- Gauge setter ----------
+    public void setOutboxPending(int count) {
+        outboxPending.set(Math.max(count, 0));
+    }
+
+    private String safeTag(String v) {
+        if (v == null || v.isBlank()) return "UNKNOWN";
+        // 너무 길면 시계열/카디널리티 위험 + Prometheus 라벨 가독성 저하
+        if (v.length() > 50) return v.substring(0, 50);
+        return v;
+    }
+}

--- a/chat/src/main/java/com/back/chat/adapter/out/metrics/ChatMetrics.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/metrics/ChatMetrics.java
@@ -98,4 +98,6 @@ public class ChatMetrics {
         if (v.length() > 50) return v.substring(0, 50);
         return v;
     }
+
+    public MeterRegistry getRegistry() { return registry; }
 }

--- a/chat/src/main/java/com/back/chat/adapter/out/outbox/ChatOutboxRepository.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/outbox/ChatOutboxRepository.java
@@ -114,4 +114,6 @@ RETURNING status
             @Param("retryBaseDelaySeconds") int retryBaseDelaySeconds,
             @Param("retryMaxDelaySeconds") int retryMaxDelaySeconds
     );
+
+    long countByStatus(OutboxStatus status);
 }

--- a/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxFailedPoller.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxFailedPoller.java
@@ -1,5 +1,6 @@
 package com.back.chat.adapter.out.outbox;
 
+import com.back.chat.adapter.out.metrics.ChatMetrics;
 import com.back.chat.domain.event.ChatEventType;
 import com.back.common.chat.ChatDeadLetterPayload;
 import com.back.common.chat.ChatMessageBlindedKafkaEvent;
@@ -13,6 +14,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.back.chat.adapter.out.outbox.OutboxUtil.safeMsg;
 
@@ -29,9 +31,16 @@ public class OutboxFailedPoller {
 
     private final JsonMapper jsonMapper;
 
+    private final ChatMetrics metrics;
+
+    private final AtomicLong lastBacklogUpdateEpochMs = new AtomicLong(0);
+
     @Scheduled(fixedDelay = OutboxPollingProperties.failedPollIntervalMs)
     public void tickFailedOnly() {
         LocalDateTime now = LocalDateTime.now();
+
+        // 30초에 한번 FAILED 상태의 대기 Outbox 개수 조회 및 게이지 갱신.
+        updateBacklogIfNeeded();
 
         // 1) FAILED 중 재시도 시간 도달한 것만 선점
         List<Long> claimedIds =
@@ -98,5 +107,15 @@ public class OutboxFailedPoller {
                         }
                     });
         }
+    }
+
+    private void updateBacklogIfNeeded() {
+        long nowMs = System.currentTimeMillis();
+        long prev = lastBacklogUpdateEpochMs.get();
+        if (nowMs - prev < 30_000) return;
+
+        if (!lastBacklogUpdateEpochMs.compareAndSet(prev, nowMs)) return;
+
+        metrics.setOutboxRetryBacklog(Math.toIntExact(outboxRepository.countByStatus(OutboxStatus.FAILED)));
     }
 }

--- a/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxPublisher.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxPublisher.java
@@ -54,7 +54,7 @@ public class OutboxPublisher {
         final String eventType = outbox.getEventType().name();
 
         final Timer timer = metrics.timer(
-                "resello_chat_outbox_publish_seconds",
+                "resello_chat_outbox_publish",
                 Tags.of("eventType", outbox.getEventType().name())
         );
         final Timer.Sample sample = Timer.start(metrics.getRegistry());

--- a/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxPublisher.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxPublisher.java
@@ -7,6 +7,8 @@ import com.back.common.chat.ChatMessageBlindedKafkaEvent;
 import com.back.common.code.FailureCode;
 import com.back.common.event.Envelope;
 import com.back.common.exception.BadRequestException;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import static com.back.chat.adapter.out.outbox.OutboxUtil.safeMsg;
 
@@ -46,24 +49,35 @@ public class OutboxPublisher {
 
         Envelope<ChatMessageBlindedKafkaEvent> envelope = Envelope.of(outbox.getEventId().toString(), ChatEventType.MESSAGE_BLINDED.toString(), payload);
 
+        final Long outboxId = outbox.getId();
+        final UUID eventId = outbox.getEventId();
+        final String eventType = outbox.getEventType().name();
+
+        final Timer timer = metrics.timer(
+                "resello_chat_outbox_publish_seconds",
+                Tags.of("eventType", outbox.getEventType().name())
+        );
+        final Timer.Sample sample = Timer.start(metrics.getRegistry());
+
         kafkaTemplate.send(OutboxPollingProperties.CHAT_BLIND_REQUESTED_TOPIC, envelope)
                 .whenComplete((res, ex) -> {
+                    sample.stop(timer);
+
                     LocalDateTime now2 = LocalDateTime.now();
 
                     if (ex == null) {
-                        statusUpdater.markSent(outbox.getId(), now2);
+                        statusUpdater.markSent(outboxId, now2);
                         return;
                     }
 
                     log.warn("[OUTBOX] publish failed outboxId={}, eventId={}, err={}",
-                            outbox.getId(), outbox.getEventId(), safeMsg(ex));
+                            outboxId, eventId, safeMsg(ex));
 
-                    metrics.incOutboxPublishFail(outbox.getEventType().name(), ex.getClass().getSimpleName());
+                    metrics.incOutboxPublishFail(eventType, ex.getClass().getSimpleName());
 
                     statusUpdater.markFailed(
-                            outbox.getId(),
+                            outboxId,
                             safeMsg(ex),
-                            now2,
                             OutboxPollingProperties.RETRY_BASE_DELAY_SECONDS
                     );
                 });

--- a/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxPublisher.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxPublisher.java
@@ -1,5 +1,6 @@
 package com.back.chat.adapter.out.outbox;
 
+import com.back.chat.adapter.out.metrics.ChatMetrics;
 import com.back.chat.domain.event.ChatEventType;
 import com.back.chat.domain.event.ChatOutboxSavedEvent;
 import com.back.common.chat.ChatMessageBlindedKafkaEvent;
@@ -30,6 +31,8 @@ public class OutboxPublisher {
 
     private final JsonMapper jsonMapper;
 
+    private final ChatMetrics metrics;
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void publish(ChatOutboxSavedEvent event){
         ChatOutbox outbox = outboxRepository.findById(event.outboxId()).orElseThrow(()->new BadRequestException(FailureCode.CHAT_OUTBOX_NOT_FOUND));
@@ -54,6 +57,8 @@ public class OutboxPublisher {
 
                     log.warn("[OUTBOX] publish failed outboxId={}, eventId={}, err={}",
                             outbox.getId(), outbox.getEventId(), safeMsg(ex));
+
+                    metrics.incOutboxPublishFail(outbox.getEventType().name(), ex.getClass().getSimpleName());
 
                     statusUpdater.markFailed(
                             outbox.getId(),

--- a/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxStatusUpdater.java
+++ b/chat/src/main/java/com/back/chat/adapter/out/outbox/OutboxStatusUpdater.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -18,8 +17,7 @@ public class OutboxStatusUpdater {
     }
 
     @Transactional
-    public void markFailed(Long outboxId, String error, LocalDateTime now,
-                           int retryBaseDelaySeconds) {
+    public void markFailed(Long outboxId, String error, int retryBaseDelaySeconds) {
         chatOutboxRepository.markInitialFailed(outboxId, error, retryBaseDelaySeconds);
     }
 

--- a/chat/src/main/java/com/back/chat/app/ChatFacade.java
+++ b/chat/src/main/java/com/back/chat/app/ChatFacade.java
@@ -1,12 +1,14 @@
 package com.back.chat.app;
 
 
+import com.back.chat.adapter.out.metrics.ChatMetrics;
 import com.back.chat.app.usecase.*;
 import com.back.chat.adapter.in.web.dto.request.ChatMessageReportRequestDto;
 import com.back.chat.adapter.in.web.dto.request.ChatMessageSendRequestDto;
 import com.back.chat.adapter.in.web.dto.response.ChatMessageHistoryResponseDto;
 import com.back.chat.adapter.in.web.dto.response.ChatMessageReportResponseDto;
 import com.back.chat.adapter.in.web.dto.response.ChatRoomEnterResponseDto;
+import io.micrometer.core.instrument.Tags;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,8 @@ public class ChatFacade {
     private final CreateChatRoomsUseCase createChatRoomsUseCase;
     private final DeleteChatRoomUseCase deleteChatRoomUseCase;
 
+    private final ChatMetrics metrics;
+
     @Transactional
     public ChatRoomEnterResponseDto enterChatRoom(Long brandId, Long userId){
         return chatEnterChatRoomUseCase.enterChatRoom(brandId, userId);
@@ -32,12 +36,22 @@ public class ChatFacade {
 
     @Transactional
     public void sendMessage(ChatMessageSendRequestDto requestDto, Long userId) {
-        chatSendMessageUseCase.sendMessage(requestDto, userId);
+        metrics.incWsSendTotal();
+
+        metrics.recordRunnable(
+                "resello_chat_ws_send_seconds",
+                Tags.of("result", "ok"),
+                () -> chatSendMessageUseCase.sendMessage(requestDto, userId)
+        );
     }
 
     @Transactional(readOnly = true)
     public ChatMessageHistoryResponseDto getHistory(Long roomId, Long cursorMessageId) {
-        return chatGetHistoryUseCase.getHistory(roomId, cursorMessageId);
+        return metrics.recordCallable(
+                "resello_chat_history_query_seconds",
+                Tags.of("result","ok"),
+                () -> chatGetHistoryUseCase.getHistory(roomId, cursorMessageId)
+        );
     }
 
     @Transactional

--- a/chat/src/main/java/com/back/chat/app/ChatFacade.java
+++ b/chat/src/main/java/com/back/chat/app/ChatFacade.java
@@ -56,7 +56,13 @@ public class ChatFacade {
 
     @Transactional
     public ChatMessageReportResponseDto reportMessage(Long reporterUserId, ChatMessageReportRequestDto requestDto) {
-        return chatReportMessageUseCase.reportMessage(reporterUserId, requestDto);
+        return metrics.recordCallable(
+                "resello_chat_report_seconds",
+                Tags.of("result","ok"),
+                () -> {
+                    return chatReportMessageUseCase.reportMessage(reporterUserId, requestDto);
+                }
+        );
     }
 
     @Transactional

--- a/chat/src/main/java/com/back/chat/app/ChatFacade.java
+++ b/chat/src/main/java/com/back/chat/app/ChatFacade.java
@@ -39,7 +39,7 @@ public class ChatFacade {
         metrics.incWsSendTotal();
 
         metrics.recordRunnable(
-                "resello_chat_ws_send_seconds",
+                "resello_chat_ws_send",
                 Tags.of("result", "ok"),
                 () -> chatSendMessageUseCase.sendMessage(requestDto, userId)
         );
@@ -48,7 +48,7 @@ public class ChatFacade {
     @Transactional(readOnly = true)
     public ChatMessageHistoryResponseDto getHistory(Long roomId, Long cursorMessageId) {
         return metrics.recordCallable(
-                "resello_chat_history_query_seconds",
+                "resello_chat_history_query",
                 Tags.of("result","ok"),
                 () -> chatGetHistoryUseCase.getHistory(roomId, cursorMessageId)
         );
@@ -57,7 +57,7 @@ public class ChatFacade {
     @Transactional
     public ChatMessageReportResponseDto reportMessage(Long reporterUserId, ChatMessageReportRequestDto requestDto) {
         return metrics.recordCallable(
-                "resello_chat_report_seconds",
+                "resello_chat_report",
                 Tags.of("result","ok"),
                 () -> {
                     return chatReportMessageUseCase.reportMessage(reporterUserId, requestDto);

--- a/chat/src/main/java/com/back/chat/app/usecase/ChatReportMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/usecase/ChatReportMessageUseCase.java
@@ -96,7 +96,7 @@ public class ChatReportMessageUseCase {
             }
 
             ChatOutbox outbox = metrics.recordCallable(
-                    "resello_chat_outbox_save_seconds",
+                    "resello_chat_outbox_save",
                     Tags.of("eventType", ChatEventType.MESSAGE_BLINDED.name()),
                     () -> chatOutboxRepository.save(
                             ChatOutbox.pending(

--- a/chat/src/main/java/com/back/chat/app/usecase/ChatReportMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/usecase/ChatReportMessageUseCase.java
@@ -1,5 +1,6 @@
 package com.back.chat.app.usecase;
 
+import com.back.chat.adapter.out.metrics.ChatMetrics;
 import com.back.chat.adapter.out.outbox.ChatOutbox;
 import com.back.chat.adapter.out.outbox.ChatOutboxRepository;
 import com.back.chat.app.ChatSupport;
@@ -34,6 +35,8 @@ public class ChatReportMessageUseCase {
     private final ChatOutboxRepository chatOutboxRepository;
     private final JsonMapper jsonMapper;
 
+    private final ChatMetrics metrics;
+
     public ChatMessageReportResponseDto reportMessage(Long reporterUserId, ChatMessageReportRequestDto requestDto) {
         Long messageId = requestDto.chatMessageId();
 
@@ -63,6 +66,8 @@ public class ChatReportMessageUseCase {
         boolean blindedNow = chatSupport.blindIfReached(messageId, ChatMessageBlindPolicy.MESSAGE_BLIND_THRESHOLD) == 1;
 
         if (blindedNow) {
+
+            metrics.incBlindTrigger();
 
             eventPublisher.publishEvent(
                     new ChatMessageBlindedEvent(

--- a/chat/src/main/java/com/back/chat/app/usecase/ChatReportMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/usecase/ChatReportMessageUseCase.java
@@ -17,6 +17,7 @@ import com.back.common.chat.ChatMessageBlindedKafkaEvent;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
 import com.back.common.exception.ConflictException;
+import io.micrometer.core.instrument.Tags;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -94,16 +95,21 @@ public class ChatReportMessageUseCase {
                 throw new IllegalStateException("Outbox payload 직렬화 실패", e);
             }
 
-            ChatOutbox outbox = chatOutboxRepository.save(
-                    ChatOutbox.pending(
-                            UUID.fromString(payload.eventId()),
-                            "CHAT_MESSAGE",
-                            message.getId(),
-                            ChatEventType.MESSAGE_BLINDED,
-                            payloadJson,
-                            now
+            ChatOutbox outbox = metrics.recordCallable(
+                    "resello_chat_outbox_save_seconds",
+                    Tags.of("eventType", ChatEventType.MESSAGE_BLINDED.name()),
+                    () -> chatOutboxRepository.save(
+                            ChatOutbox.pending(
+                                    UUID.fromString(payload.eventId()),
+                                    "CHAT_MESSAGE",
+                                    message.getId(),
+                                    ChatEventType.MESSAGE_BLINDED,
+                                    payloadJson,
+                                    now
+                            )
                     )
             );
+
             eventPublisher.publishEvent(new ChatOutboxSavedEvent(outbox.getId()));
         }
 

--- a/chat/src/main/java/com/back/chat/app/usecase/ChatSendMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/usecase/ChatSendMessageUseCase.java
@@ -1,5 +1,6 @@
 package com.back.chat.app.usecase;
 
+import com.back.chat.adapter.out.metrics.ChatMetrics;
 import com.back.chat.adapter.out.redis.RedisChatRestrictionReader;
 import com.back.chat.app.ChatSupport;
 import com.back.chat.domain.entity.ChatMessage;
@@ -9,6 +10,7 @@ import com.back.chat.domain.event.ChatMessageSavedEvent;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
 import com.back.common.exception.ForbiddenException;
+import io.micrometer.core.instrument.Tags;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,8 @@ public class ChatSendMessageUseCase {
     private final ApplicationEventPublisher eventPublisher;
     private final RedisChatRestrictionReader redisChatRestrictionReader;
 
+    private final ChatMetrics metrics;
+
     @Transactional
     public void sendMessage(ChatMessageSendRequestDto requestDto, Long userId) {
         LocalDateTime now = LocalDateTime.now();
@@ -38,8 +42,12 @@ public class ChatSendMessageUseCase {
             throw new ForbiddenException(FailureCode.CHAT_RESTRICTED);
         }
 
-        ChatMessage savedMessage = chatSupport.saveMessage(
-                ChatMessage.create(roomId,userId,requestDto.content())
+        ChatMessage savedMessage = metrics.recordCallable(
+                "resello_chat_message_save_seconds",
+                Tags.of("result", "ok"),
+                () -> chatSupport.saveMessage(
+                        ChatMessage.create(roomId, userId, requestDto.content())
+                )
         );
 
         ChatMessagePayload payload = new ChatMessagePayload(

--- a/chat/src/main/java/com/back/chat/app/usecase/ChatSendMessageUseCase.java
+++ b/chat/src/main/java/com/back/chat/app/usecase/ChatSendMessageUseCase.java
@@ -43,7 +43,7 @@ public class ChatSendMessageUseCase {
         }
 
         ChatMessage savedMessage = metrics.recordCallable(
-                "resello_chat_message_save_seconds",
+                "resello_chat_message_save",
                 Tags.of("result", "ok"),
                 () -> chatSupport.saveMessage(
                         ChatMessage.create(roomId, userId, requestDto.content())


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #344 

## 🔎 작업 내용

- Chat 서비스 커스텀 메트릭 추가

<br>

resello_chat_ws_send_seconds
resello_chat_history_query_seconds
resello_chat_report_seconds
resello_chat_outbox_save_seconds
resello_chat_outbox_publish_seconds
resello_chat_message_save_seconds
resello_chat_ws_send_total
resello_chat_blind_trigger_total
resello_chat_outbox_publish_fail_total
resello_chat_outbox_retry_backlog

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
