### PR TITLE
[FEAT] 회원 정보 수정 이벤트 발행 (#249)

### DIFF
--- a/user/src/main/java/com/back/user/adapter/out/UserUpdatedKafkaPublisher.java
+++ b/user/src/main/java/com/back/user/adapter/out/UserUpdatedKafkaPublisher.java
@@ -1,0 +1,41 @@
+package com.back.user.adapter.out;
+
+import com.back.common.event.Envelope;
+import com.back.common.event.KafkaEventPublisher;
+import com.back.user.app.event.UserUpdatedPayload;
+import com.back.user.domain.event.UserUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserUpdatedKafkaPublisher {
+
+    @Value("${custom.kafka.topic.user-account-updated}")
+    private String userUpdatedTopic;
+
+    private final KafkaEventPublisher kafkaEventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishUserUpdated(UserUpdatedEvent event) {
+        Envelope<UserUpdatedPayload> envelope = Envelope.of(userUpdatedTopic, UserUpdatedPayload.builder()
+                .id(event.id())
+                .address(event.address())
+                .name(event.name())
+                .phone(event.phone())
+                .email(event.email())
+                .nickname(event.nickname())
+                .build());
+
+        kafkaEventPublisher.publish(userUpdatedTopic, envelope);
+
+        log.info("[ACCOUNT_UPDATED_KAFKA_PUBLISH] 회원 정보 수정 이벤트 발행 eventId={}, occurredAt={}, topic={}, userId={}",
+                envelope.header().eventId(), envelope.header().occurrenceAt(), userUpdatedTopic, event.id());
+    }
+
+}

--- a/user/src/main/java/com/back/user/adapter/out/UserUpdatedKafkaPublisher.java
+++ b/user/src/main/java/com/back/user/adapter/out/UserUpdatedKafkaPublisher.java
@@ -33,9 +33,6 @@ public class UserUpdatedKafkaPublisher {
                 .build());
 
         kafkaEventPublisher.publish(userUpdatedTopic, envelope);
-
-        log.info("[ACCOUNT_UPDATED_KAFKA_PUBLISH] 회원 정보 수정 이벤트 발행 eventId={}, occurredAt={}, topic={}, userId={}",
-                envelope.header().eventId(), envelope.header().occurrenceAt(), userUpdatedTopic, event.id());
     }
 
 }

--- a/user/src/main/java/com/back/user/app/UserUpdateUseCase.java
+++ b/user/src/main/java/com/back/user/app/UserUpdateUseCase.java
@@ -2,16 +2,21 @@ package com.back.user.app;
 
 import com.back.user.domain.User;
 import com.back.user.domain.UserSetting;
+import com.back.user.domain.event.UserUpdatedEvent;
 import com.back.user.dto.request.UpdateFcmTokenRequest;
 import com.back.user.dto.request.UpdateNotificationSettingsRequest;
 import com.back.user.dto.request.UpdateUserProfileRequestDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserUpdateUseCase {
     private final UserSupport userSupport;
+    private final ApplicationEventPublisher eventPublisher;
 
     public void updateFcmToken(User user, UpdateFcmTokenRequest request) {
         user.updateFcmToken(request.fcmToken());
@@ -36,5 +41,13 @@ public class UserUpdateUseCase {
     public void updateUserProfile(User user, UpdateUserProfileRequestDto request) {
         userSupport.validateNicknameAvailable(request.nickname(), user.getNickname());
         user.updateProfile(request);
+        eventPublisher.publishEvent(UserUpdatedEvent.builder()
+                .id(user.getId())
+                .nickname(request.nickname())
+                .address(user.getAddress())
+                .email(user.getEmail())
+                .name(user.getName())
+                .phone(user.getPhone())
+                .build());
     }
 }

--- a/user/src/main/java/com/back/user/app/event/UserUpdatedPayload.java
+++ b/user/src/main/java/com/back/user/app/event/UserUpdatedPayload.java
@@ -1,0 +1,15 @@
+package com.back.user.app.event;
+
+import com.back.common.event.KafkaPayload;
+import lombok.Builder;
+
+@Builder
+public record UserUpdatedPayload(
+        Long id,
+        String nickname,
+        String name,
+        String email,
+        String address,
+        String phone
+) implements KafkaPayload
+{}

--- a/user/src/main/java/com/back/user/domain/event/UserUpdatedEvent.java
+++ b/user/src/main/java/com/back/user/domain/event/UserUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.back.user.domain.event;
+
+import com.back.common.event.EventName;
+import lombok.Builder;
+
+@Builder
+public record UserUpdatedEvent(
+        Long id,
+        String nickname,
+        String name,
+        String email,
+        String address,
+        String phone
+) implements EventName {
+}

--- a/user/src/test/java/com/back/user/adapter/out/UserUpdatedKafkaPublisherTest.java
+++ b/user/src/test/java/com/back/user/adapter/out/UserUpdatedKafkaPublisherTest.java
@@ -1,0 +1,52 @@
+package com.back.user.adapter.out;
+
+import com.back.common.event.Envelope;
+import com.back.common.event.KafkaEventPublisher;
+import com.back.user.domain.event.UserUpdatedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserUpdatedKafkaPublisherTest {
+
+    @Mock
+    private KafkaEventPublisher kafkaEventPublisher;
+
+    @InjectMocks
+    private UserUpdatedKafkaPublisher userUpdatedKafkaPublisher;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(userUpdatedKafkaPublisher, "userUpdatedTopic", "user.account.updated");
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 이벤트 수신 시 올바른 토픽으로 Envelope를 발행한다")
+    void publishUserUpdated_success_publishesToCorrectTopic() {
+        // given
+        UserUpdatedEvent event = UserUpdatedEvent.builder()
+                .id(1L)
+                .nickname("newNick")
+                .name("김철수")
+                .email("kim@example.com")
+                .address("서울시 서초구")
+                .phone("01098765432")
+                .build();
+
+        // when
+        userUpdatedKafkaPublisher.publishUserUpdated(event);
+
+        // then
+        verify(kafkaEventPublisher).publish(eq("user.account.updated"), any(Envelope.class));
+    }
+}

--- a/user/src/test/java/com/back/user/app/UserUpdateUseCaseTest.java
+++ b/user/src/test/java/com/back/user/app/UserUpdateUseCaseTest.java
@@ -1,0 +1,133 @@
+package com.back.user.app;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.user.domain.User;
+import com.back.user.domain.enums.Provider;
+import com.back.user.domain.enums.Role;
+import com.back.user.domain.event.UserUpdatedEvent;
+import com.back.user.dto.request.UpdateUserProfileRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserUpdateUseCaseTest {
+
+    @InjectMocks
+    private UserUpdateUseCase userUpdateUseCase;
+
+    @Mock
+    private UserSupport userSupport;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Test
+    @DisplayName("프로필 수정 성공 시 UserUpdatedEvent가 변경된 값으로 발행된다")
+    void updateUserProfile_success_publishesEvent() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .nickname("oldNick")
+                .name("홍길동")
+                .email("hong@example.com")
+                .address("서울시 강남구")
+                .phone("01012345678")
+                .provider(Provider.KAKAO)
+                .providerId("kakao-123")
+                .role(Role.USER)
+                .build();
+
+        UpdateUserProfileRequestDto request = new UpdateUserProfileRequestDto(
+                "newNick", "김철수", "01098765432", "서울시 서초구"
+        );
+
+        // when
+        userUpdateUseCase.updateUserProfile(user, request);
+
+        // then
+        ArgumentCaptor<UserUpdatedEvent> captor = ArgumentCaptor.forClass(UserUpdatedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        UserUpdatedEvent event = captor.getValue();
+        assertThat(event.id()).isEqualTo(1L);
+        assertThat(event.nickname()).isEqualTo("newNick");
+        assertThat(event.name()).isEqualTo("김철수");
+        assertThat(event.email()).isEqualTo("hong@example.com");
+        assertThat(event.address()).isEqualTo("서울시 서초구");
+        assertThat(event.phone()).isEqualTo("01098765432");
+    }
+
+    @Test
+    @DisplayName("nickname이 null이면 나머지 필드만 수정되고 이벤트가 발행된다")
+    void updateUserProfile_withNullNickname_updatesOtherFieldsAndPublishesEvent() {
+        // given
+        User user = User.builder()
+                .id(2L)
+                .nickname("unchanged")
+                .name("홍길동")
+                .email("hong@example.com")
+                .address("서울시 강남구")
+                .phone("01012345678")
+                .provider(Provider.KAKAO)
+                .providerId("kakao-456")
+                .role(Role.USER)
+                .build();
+
+        UpdateUserProfileRequestDto request = new UpdateUserProfileRequestDto(
+                null, null, null, "경기도 성남시"
+        );
+
+        // when
+        userUpdateUseCase.updateUserProfile(user, request);
+
+        // then
+        ArgumentCaptor<UserUpdatedEvent> captor = ArgumentCaptor.forClass(UserUpdatedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        UserUpdatedEvent event = captor.getValue();
+        assertThat(event.nickname()).isNull();
+        assertThat(event.address()).isEqualTo("경기도 성남시");
+        assertThat(event.email()).isEqualTo("hong@example.com");
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 시 예외가 발생하고 이벤트는 발행되지 않는다")
+    void updateUserProfile_duplicateNickname_throwsAndNoEvent() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .nickname("oldNick")
+                .name("홍길동")
+                .email("hong@example.com")
+                .address("서울시 강남구")
+                .phone("01012345678")
+                .provider(Provider.KAKAO)
+                .providerId("kakao-123")
+                .role(Role.USER)
+                .build();
+
+        UpdateUserProfileRequestDto request = new UpdateUserProfileRequestDto(
+                "duplicateNick", null, null, null
+        );
+
+        doThrow(new CustomException(FailureCode.NICKNAME_ALREADY_EXISTS))
+                .when(userSupport).validateNicknameAvailable("duplicateNick", "oldNick");
+
+        // when & then
+        assertThatThrownBy(() -> userUpdateUseCase.updateUserProfile(user, request))
+                .isInstanceOf(CustomException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #249 

## 🔎 작업 내용

- 회원 정보가 수정되면 이벤트를 발행합니다. 

<br>

## 📷 테스트 결과

<img width="456" height="148" alt="image" src="https://github.com/user-attachments/assets/87ee6dfc-3175-4f0f-80b2-4b3a3bf1202c" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
