### PR TITLE
[REFACTOR] 정산 배치 리팩토링 및 배치 성능 개선 (#335)

### DIFF
--- a/settlement/src/main/java/com/back/settlement/adapter/out/SettlementCustomRepository.java
+++ b/settlement/src/main/java/com/back/settlement/adapter/out/SettlementCustomRepository.java
@@ -30,5 +30,5 @@ public interface SettlementCustomRepository {
 
     List<Long> findDistinctUnsettledSellerIds(LocalDateTime startAt, LocalDateTime endAt, Long systemPayeeId);
 
-    List<SettlementItem> findUnsettledItemsByPayeeId(Long payeeId, LocalDateTime startAt, LocalDateTime endAt);
+    List<SettlementItem> findUnsettledItemsByPayeeIds(List<Long> payeeIds, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/settlement/src/main/java/com/back/settlement/adapter/out/SettlementCustomRepositoryImpl.java
+++ b/settlement/src/main/java/com/back/settlement/adapter/out/SettlementCustomRepositoryImpl.java
@@ -110,11 +110,11 @@ public class SettlementCustomRepositoryImpl implements SettlementCustomRepositor
                 .fetch();
     }
 
-    public List<SettlementItem> findUnsettledItemsByPayeeId(Long payeeId, LocalDateTime startAt, LocalDateTime endAt) {
+    public List<SettlementItem> findUnsettledItemsByPayeeIds(List<Long> payeeIds, LocalDateTime startAt, LocalDateTime endAt) {
         return queryFactory
                 .selectFrom(settlementItem)
                 .where(
-                        settlementItem.payeeId.eq(payeeId),
+                        settlementItem.payeeId.in(payeeIds),
                         settlementItem.status.eq(SettlementItemStatus.COLLECTED),
                         settlementItem.confirmedAt.goe(startAt),
                         settlementItem.confirmedAt.loe(endAt)

--- a/settlement/src/main/java/com/back/settlement/app/support/SettlementSupport.java
+++ b/settlement/src/main/java/com/back/settlement/app/support/SettlementSupport.java
@@ -45,8 +45,8 @@ public class SettlementSupport {
         return settlementCustomRepository.findDistinctUnsettledSellerIds(startAt, endAt, systemPayeeId);
     }
 
-    public List<SettlementItem> findUnsettledItems(Long payeeId, LocalDateTime startAt, LocalDateTime endAt) {
-        return settlementCustomRepository.findUnsettledItemsByPayeeId(payeeId, startAt, endAt);
+    public List<SettlementItem> findUnsettledItemsByPayeeIds(List<Long> payeeIds, LocalDateTime startAt, LocalDateTime endAt) {
+        return settlementCustomRepository.findUnsettledItemsByPayeeIds(payeeIds, startAt, endAt);
     }
 
     public Settlement findById(Long settlementId) {

--- a/settlement/src/main/java/com/back/settlement/app/usecase/SettlementCreateUseCase.java
+++ b/settlement/src/main/java/com/back/settlement/app/usecase/SettlementCreateUseCase.java
@@ -10,6 +10,8 @@ import com.back.settlement.domain.SettlementItem;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,16 +26,23 @@ public class SettlementCreateUseCase {
     private final SettlementItemRepository settlementItemRepository;
     private final SettlementSupport settlementSupport;
 
-    public SettlementWithItems createSettlement(Long payeeId, YearMonth targetMonth) {
+    public List<SettlementWithItems> createSettlements(List<Long> payeeIds, YearMonth targetMonth) {
         LocalDateTime startAt = LocalDateUtils.startOfMonth(targetMonth);
         LocalDateTime endAt = LocalDateUtils.endOfMonth(targetMonth);
 
-        List<SettlementItem> items = settlementSupport.findUnsettledItems(payeeId, startAt, endAt);
+        List<SettlementItem> allItems = settlementSupport.findUnsettledItemsByPayeeIds(payeeIds, startAt, endAt);
 
-        Settlement settlement = Settlement.create(payeeId, items, startAt, endAt);
-        log.info("정산 생성 완료. payeeId={}, itemCount={}, netAmount={}", payeeId, items.size(), settlement.getTotalNetAmount());
+        Map<Long, List<SettlementItem>> itemsByPayee = allItems.stream()
+                .collect(Collectors.groupingBy(SettlementItem::getPayeeId));
 
-        return new SettlementWithItems(settlement, items);
+        return payeeIds.stream()
+                .map(payeeId -> itemsByPayee.getOrDefault(payeeId, List.of()))
+                .filter(items -> !items.isEmpty())
+                .map(items -> {
+                    Settlement settlement = Settlement.create(items.get(0).getPayeeId(), items, startAt, endAt);
+                    return new SettlementWithItems(settlement, items);
+                })
+                .toList();
     }
 
     @Transactional
@@ -44,8 +53,8 @@ public class SettlementCreateUseCase {
             item.included();
         });
         settlementItemRepository.saveAll(items);
-        saved.complete(); // PENDING -> COMPLETED
-        settlementRepository.save(saved);
+        saved.complete(); // PENDING -> COMPLETED, 도메인 이벤트 등록
+        settlementRepository.save(saved); // AbstractAggregateRoot의 도메인 이벤트 발행을 위해 save() 필수 (dirty checking만으로는 이벤트 미발행)
         log.info("정산 생성 및 확정 완료. settlementId={}", saved.getId());
     }
 }

--- a/settlement/src/main/java/com/back/settlement/batch/PayeeSettlementWriteItem.java
+++ b/settlement/src/main/java/com/back/settlement/batch/PayeeSettlementWriteItem.java
@@ -1,0 +1,33 @@
+package com.back.settlement.batch;
+
+import com.back.settlement.domain.Settlement;
+import com.back.settlement.domain.SettlementItem;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PayeeSettlementWriteItem {
+    private final Long payeeId;
+    private Settlement settlement;
+    private List<SettlementItem> items;
+
+    private PayeeSettlementWriteItem(Long payeeId) {
+        this.payeeId = payeeId;
+    }
+
+    public static PayeeSettlementWriteItem create(Long payeeId) {
+        return new PayeeSettlementWriteItem(payeeId);
+    }
+
+    public void enrich(Settlement settlement, List<SettlementItem> items) {
+        this.settlement = settlement;
+        this.items = items;
+    }
+
+    public boolean isEnriched() {
+        return settlement != null;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/batch/SettlementDailyStepConfig.java
+++ b/settlement/src/main/java/com/back/settlement/batch/SettlementDailyStepConfig.java
@@ -3,96 +3,26 @@ package com.back.settlement.batch;
 import static com.back.settlement.domain.SettlementPolicy.CHUNK_SIZE;
 
 import com.back.common.dto.settlement.SettlementTargetOrder;
-import com.back.settlement.adapter.out.feign.market.OrderClient;
-import com.back.settlement.app.support.LocalDateUtils;
-import com.back.settlement.app.usecase.SettlementItemAddUseCase;
-import java.time.LocalDate;
-import java.util.Iterator;
-import java.util.List;
+import com.back.settlement.batch.reader.OrderPagingItemReader;
+import com.back.settlement.batch.writer.OrderItemWriter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.infrastructure.item.ItemProcessor;
-import org.springframework.batch.infrastructure.item.ItemReader;
-import org.springframework.batch.infrastructure.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
-@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class SettlementDailyStepConfig {
-    private final OrderClient orderClient;
-    private final SettlementItemAddUseCase settlementItemAddUseCase;
 
     @Bean
-    public Step collectOrdersStep(
-            JobRepository jobRepository,
-            PlatformTransactionManager transactionManager,
-            ItemReader<SettlementTargetOrder> orderReader,
-            ItemProcessor<SettlementTargetOrder, SettlementTargetOrder> orderProcessor,
-            ItemWriter<SettlementTargetOrder> orderWriter
-    ) {
+    public Step collectOrdersStep(JobRepository jobRepository, PlatformTransactionManager transactionManager, OrderPagingItemReader reader, OrderItemWriter writer) {
         return new StepBuilder("collectOrdersStep", jobRepository)
                 .<SettlementTargetOrder, SettlementTargetOrder>chunk(CHUNK_SIZE, transactionManager)
-                .reader(orderReader)
-                .processor(orderProcessor)
-                .writer(orderWriter)
+                .reader(reader)
+                .writer(writer)
                 .build();
-    }
-
-    @Bean
-    @StepScope
-    public ItemReader<SettlementTargetOrder> orderReader(@Value("#{jobParameters['targetDate']}") String targetDateStr) {
-        return new ItemReader<>() {
-            private int page = 0;
-            private Iterator<SettlementTargetOrder> iterator;
-            private boolean exhausted = false;
-
-            @Override
-            public SettlementTargetOrder read() {
-                if (exhausted) {
-                    return null;
-                }
-                if (iterator != null && iterator.hasNext()) {
-                    return iterator.next();
-                }
-
-                LocalDate targetDate = LocalDateUtils.parseOrDefault(targetDateStr);
-                List<SettlementTargetOrder> pageData = orderClient.findSettlementTargetOrders(targetDate, page++, CHUNK_SIZE);
-
-                if (pageData.isEmpty()) {
-                    exhausted = true;
-                    log.info("주문 수집 완료. 총 페이지: {}", page - 1);
-                    return null;
-                }
-                log.info("주문 조회. page={}, size={}", page - 1, pageData.size());
-                iterator = pageData.iterator();
-                return iterator.next();
-            }
-        };
-    }
-
-    @Bean
-    public ItemProcessor<SettlementTargetOrder, SettlementTargetOrder> orderProcessor() {
-        return order -> {
-            log.debug("주문 처리. orderId={}", order.orderId());
-            return order;
-        };
-    }
-
-    @Bean
-    public ItemWriter<SettlementTargetOrder> orderWriter() {
-        return chunk -> {
-            for (SettlementTargetOrder order : chunk) {
-                settlementItemAddUseCase.add(order);
-            }
-            log.info("정산 항목 생성 완료. 건수={}", chunk.size());
-        };
     }
 }

--- a/settlement/src/main/java/com/back/settlement/batch/SettlementJobLauncher.java
+++ b/settlement/src/main/java/com/back/settlement/batch/SettlementJobLauncher.java
@@ -4,6 +4,7 @@ import static com.back.common.code.FailureCode.BATCH_EXECUTION_FAILED;
 import static com.back.common.code.FailureCode.SETTLEMENT_ALREADY_PROCESSED_DAILY;
 import static com.back.common.code.FailureCode.SETTLEMENT_ALREADY_PROCESSED_MONTHLY;
 
+import com.back.common.code.FailureCode;
 import com.back.common.exception.ConflictException;
 import com.back.common.exception.CustomException;
 import com.back.settlement.app.dto.response.BatchExecutionResponse;
@@ -28,41 +29,31 @@ public class SettlementJobLauncher {
     private final Job monthlySettlementJob;
 
     public BatchExecutionResponse runDaily(LocalDate targetDate) {
-        try {
-            JobParameters jobParameters = new JobParametersBuilder()
-                    .addString("targetDate", targetDate.toString())
-                    .toJobParameters();
-            log.info("일간 정산 배치 Job 시작. targetDate={}", targetDate);
-
-            JobExecution execution = jobLauncher.run(dailySettlementJob, jobParameters);
-            log.info("일간 정산 배치 Job 완료. targetDate={}, status={}", targetDate, execution.getStatus());
-
-            return BatchExecutionResponse.from(execution, targetDate.toString());
-        } catch (JobInstanceAlreadyCompleteException e) {
-            log.warn("일간 정산 배치 이미 완료됨. targetDate={}", targetDate);
-            throw new ConflictException(SETTLEMENT_ALREADY_PROCESSED_DAILY);
-        } catch (Exception e) {
-            log.error("일간 정산 배치 Job 실행 실패. targetDate={}", targetDate, e);
-            throw new CustomException(e.getMessage(), BATCH_EXECUTION_FAILED);
-        }
+        JobParameters params = new JobParametersBuilder()
+                .addString("targetDate", targetDate.toString())
+                .toJobParameters();
+        return executeJob(dailySettlementJob, params, targetDate.toString(), SETTLEMENT_ALREADY_PROCESSED_DAILY);
     }
 
     public BatchExecutionResponse runMonthly(YearMonth targetMonth) {
+        JobParameters params = new JobParametersBuilder()
+                .addString("targetMonth", targetMonth.toString())
+                .toJobParameters();
+        return executeJob(monthlySettlementJob, params, targetMonth.toString(), SETTLEMENT_ALREADY_PROCESSED_MONTHLY);
+    }
+
+    private BatchExecutionResponse executeJob(
+            Job job, JobParameters params, String target, FailureCode alreadyCompleteCode) {
         try {
-            JobParameters jobParameters = new JobParametersBuilder()
-                    .addString("targetMonth", targetMonth.toString())
-                    .toJobParameters();
-            log.info("월간 정산 배치 Job 시작. targetMonth={}", targetMonth);
-
-            JobExecution execution = jobLauncher.run(monthlySettlementJob, jobParameters);
-            log.info("월간 정산 배치 Job 완료. targetMonth={}, status={}", targetMonth, execution.getStatus());
-
-            return BatchExecutionResponse.from(execution, targetMonth.toString());
+            log.info("정산 배치 Job 시작. job={}, target={}", job.getName(), target);
+            JobExecution execution = jobLauncher.run(job, params);
+            log.info("정산 배치 Job 완료. job={}, target={}, status={}", job.getName(), target, execution.getStatus());
+            return BatchExecutionResponse.from(execution, target);
         } catch (JobInstanceAlreadyCompleteException e) {
-            log.warn("월간 정산 배치 이미 완료됨. targetMonth={}", targetMonth);
-            throw new ConflictException(SETTLEMENT_ALREADY_PROCESSED_MONTHLY);
+            log.warn("정산 배치 이미 완료됨. job={}, target={}", job.getName(), target);
+            throw new ConflictException(alreadyCompleteCode);
         } catch (Exception e) {
-            log.error("월간 정산 배치 Job 실행 실패. targetMonth={}", targetMonth, e);
+            log.error("정산 배치 Job 실행 실패. job={}, target={}", job.getName(), target, e);
             throw new CustomException(e.getMessage(), BATCH_EXECUTION_FAILED);
         }
     }

--- a/settlement/src/main/java/com/back/settlement/batch/SettlementMonthlyStepConfig.java
+++ b/settlement/src/main/java/com/back/settlement/batch/SettlementMonthlyStepConfig.java
@@ -2,6 +2,7 @@ package com.back.settlement.batch;
 
 import static com.back.settlement.domain.SettlementPolicy.CHUNK_SIZE;
 
+import com.back.settlement.batch.listener.SettlementEnrichListener;
 import com.back.settlement.batch.reader.PayeeIdItemReader;
 import com.back.settlement.batch.writer.SettlementChunkWriter;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +18,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class SettlementMonthlyStepConfig {
 
     @Bean
-    public Step createSettlementsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager, PayeeIdItemReader reader, SettlementChunkWriter writer) {
+    public Step createSettlementsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager, PayeeIdItemReader reader, SettlementChunkWriter writer, SettlementEnrichListener enrichListener) {
         return new StepBuilder("createSettlementsStep", jobRepository)
-                .<Long, Long>chunk(CHUNK_SIZE, transactionManager)
+                .<PayeeSettlementWriteItem, PayeeSettlementWriteItem>chunk(CHUNK_SIZE, transactionManager)
                 .reader(reader)
                 .writer(writer)
+                .listener(enrichListener)
                 .build();
     }
 }

--- a/settlement/src/main/java/com/back/settlement/batch/SettlementMonthlyStepConfig.java
+++ b/settlement/src/main/java/com/back/settlement/batch/SettlementMonthlyStepConfig.java
@@ -2,94 +2,26 @@ package com.back.settlement.batch;
 
 import static com.back.settlement.domain.SettlementPolicy.CHUNK_SIZE;
 
-import com.back.settlement.app.support.LocalDateUtils;
-import com.back.settlement.app.support.SettlementSupport;
-import com.back.settlement.app.usecase.SettlementCreateUseCase;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import com.back.settlement.batch.reader.PayeeIdItemReader;
+import com.back.settlement.batch.writer.SettlementChunkWriter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.infrastructure.item.ItemProcessor;
-import org.springframework.batch.infrastructure.item.ItemReader;
-import org.springframework.batch.infrastructure.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
-@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class SettlementMonthlyStepConfig {
-    private final SettlementSupport settlementSupport;
-    private final SettlementCreateUseCase settlementCreateUseCase;
-
-    @Value("${settlement.system-payee-id}")
-    private Long systemPayeeId;
 
     @Bean
-    public Step createSettlementsStep(
-            JobRepository jobRepository,
-            PlatformTransactionManager transactionManager,
-            ItemReader<Long> payeeIdReader,
-            ItemProcessor<Long, SettlementWithItems> createSettlementProcessor,
-            ItemWriter<SettlementWithItems> saveSettlementWriter
-    ) {
+    public Step createSettlementsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager, PayeeIdItemReader reader, SettlementChunkWriter writer) {
         return new StepBuilder("createSettlementsStep", jobRepository)
-                .<Long, SettlementWithItems>chunk(CHUNK_SIZE, transactionManager)
-                .reader(payeeIdReader)
-                .processor(createSettlementProcessor)
-                .writer(saveSettlementWriter)
+                .<Long, Long>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .writer(writer)
                 .build();
-    }
-
-    @Bean
-    @StepScope
-    public ItemReader<Long> payeeIdReader(@Value("#{jobParameters['targetMonth']}") String targetMonthStr) {
-        return new ItemReader<>() {
-            private Iterator<Long> iterator;
-            private boolean initialized = false;
-
-            @Override
-            public Long read() {
-                if (!initialized) {
-                    YearMonth targetMonth = LocalDateUtils.parseYearMonthOrDefault(targetMonthStr);
-                    LocalDateTime startAt = LocalDateUtils.startOfMonth(targetMonth);
-                    LocalDateTime endAt = LocalDateUtils.endOfMonth(targetMonth);
-
-                    List<Long> sellerIds = settlementSupport.findUnsettledSellerIds(startAt, endAt, systemPayeeId);
-                    List<Long> payeeIds = new ArrayList<>(sellerIds);
-                    payeeIds.add(systemPayeeId);
-
-                    iterator = payeeIds.iterator();
-                    initialized = true;
-                    log.info("정산 대상: 판매자 {}명 + 시스템계좌, targetMonth={}", sellerIds.size(), targetMonth);
-                }
-                return iterator != null && iterator.hasNext() ? iterator.next() : null;
-            }
-        };
-    }
-
-    @Bean
-    @StepScope
-    public ItemProcessor<Long, SettlementWithItems> createSettlementProcessor(@Value("#{jobParameters['targetMonth']}") String targetMonthStr) {
-        return payeeId -> settlementCreateUseCase.createSettlement(payeeId, LocalDateUtils.parseYearMonthOrDefault(targetMonthStr));
-    }
-
-    @Bean
-    public ItemWriter<SettlementWithItems> saveSettlementWriter() {
-        return chunk -> {
-            for (SettlementWithItems item : chunk) {
-                settlementCreateUseCase.saveSettlement(item.settlement(), item.items());
-            }
-            log.info("정산 완료. 건수={}", chunk.size());
-        };
     }
 }

--- a/settlement/src/main/java/com/back/settlement/batch/listener/SettlementEnrichListener.java
+++ b/settlement/src/main/java/com/back/settlement/batch/listener/SettlementEnrichListener.java
@@ -1,0 +1,55 @@
+package com.back.settlement.batch.listener;
+
+import com.back.settlement.app.support.LocalDateUtils;
+import com.back.settlement.app.usecase.SettlementCreateUseCase;
+import com.back.settlement.batch.PayeeSettlementWriteItem;
+import com.back.settlement.batch.SettlementWithItems;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.listener.ItemWriteListener;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@StepScope
+@Component
+public class SettlementEnrichListener implements ItemWriteListener<PayeeSettlementWriteItem> {
+    private final SettlementCreateUseCase settlementCreateUseCase;
+
+    @Value("#{jobParameters['targetMonth']}")
+    private String targetMonthStr;
+
+    public SettlementEnrichListener(SettlementCreateUseCase settlementCreateUseCase) {
+        this.settlementCreateUseCase = settlementCreateUseCase;
+    }
+
+    @Override
+    public void beforeWrite(Chunk<? extends PayeeSettlementWriteItem> items) {
+        List<Long> payeeIds = items.getItems().stream()
+                .map(PayeeSettlementWriteItem::getPayeeId)
+                .toList();
+
+        YearMonth targetMonth = LocalDateUtils.parseYearMonthOrDefault(targetMonthStr);
+        List<SettlementWithItems> settlements = settlementCreateUseCase.createSettlements(payeeIds, targetMonth);
+
+        Map<Long, SettlementWithItems> byPayee = settlements.stream()
+                .collect(Collectors.toMap(
+                        swi -> swi.items().get(0).getPayeeId(),
+                        swi -> swi
+                ));
+
+        items.getItems().forEach(writeItem -> {
+            SettlementWithItems swi = byPayee.get(writeItem.getPayeeId());
+            if (swi != null) {
+                writeItem.enrich(swi.settlement(), swi.items());
+            }
+        });
+
+        log.info("정산 데이터 보강 완료. payeeIds={}, enriched={}", payeeIds.size(), byPayee.size());
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/batch/reader/OrderPagingItemReader.java
+++ b/settlement/src/main/java/com/back/settlement/batch/reader/OrderPagingItemReader.java
@@ -1,0 +1,52 @@
+package com.back.settlement.batch.reader;
+
+import static com.back.settlement.domain.SettlementPolicy.CHUNK_SIZE;
+
+import com.back.common.dto.settlement.SettlementTargetOrder;
+import com.back.settlement.adapter.out.feign.market.OrderClient;
+import com.back.settlement.app.support.LocalDateUtils;
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@StepScope
+@Component
+public class OrderPagingItemReader implements ItemReader<SettlementTargetOrder> {
+    private int page = 0;
+    private Iterator<SettlementTargetOrder> iterator;
+    private boolean exhausted = false;
+    private final OrderClient orderClient;
+    private final LocalDate targetDate;
+
+    public OrderPagingItemReader(OrderClient orderClient, @Value("#{jobParameters['targetDate']}") String targetDateStr) {
+        this.orderClient = orderClient;
+        this.targetDate = LocalDateUtils.parseOrDefault(targetDateStr);
+    }
+
+    @Override
+    public SettlementTargetOrder read() {
+        if (exhausted) {
+            return null;
+        }
+        if (iterator != null && iterator.hasNext()) {
+            return iterator.next();
+        }
+
+        List<SettlementTargetOrder> pageData = orderClient.findSettlementTargetOrders(targetDate, page++, CHUNK_SIZE);
+
+        if (pageData.isEmpty()) {
+            exhausted = true;
+            log.info("주문 수집 완료. 총 페이지: {}", page - 1);
+            return null;
+        }
+        log.info("주문 조회. page={}, size={}", page - 1, pageData.size());
+        iterator = pageData.iterator();
+        return iterator.next();
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/batch/reader/PayeeIdItemReader.java
+++ b/settlement/src/main/java/com/back/settlement/batch/reader/PayeeIdItemReader.java
@@ -2,6 +2,7 @@ package com.back.settlement.batch.reader;
 
 import com.back.settlement.app.support.LocalDateUtils;
 import com.back.settlement.app.support.SettlementSupport;
+import com.back.settlement.batch.PayeeSettlementWriteItem;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @StepScope
 @Component
-public class PayeeIdItemReader implements ItemReader<Long> {
+public class PayeeIdItemReader implements ItemReader<PayeeSettlementWriteItem> {
     private final SettlementSupport settlementSupport;
     private final Long systemPayeeId;
     private final YearMonth targetMonth;
@@ -30,7 +31,7 @@ public class PayeeIdItemReader implements ItemReader<Long> {
     }
 
     @Override
-    public Long read() {
+    public PayeeSettlementWriteItem read() {
         if (!initialized) {
             LocalDateTime startAt = LocalDateUtils.startOfMonth(targetMonth);
             LocalDateTime endAt = LocalDateUtils.endOfMonth(targetMonth);
@@ -43,6 +44,6 @@ public class PayeeIdItemReader implements ItemReader<Long> {
             initialized = true;
             log.info("정산 대상: 판매자 {}명 + 시스템계좌, targetMonth={}", sellerIds.size(), targetMonth);
         }
-        return iterator != null && iterator.hasNext() ? iterator.next() : null;
+        return iterator != null && iterator.hasNext() ? PayeeSettlementWriteItem.create(iterator.next()) : null;
     }
 }

--- a/settlement/src/main/java/com/back/settlement/batch/reader/PayeeIdItemReader.java
+++ b/settlement/src/main/java/com/back/settlement/batch/reader/PayeeIdItemReader.java
@@ -1,0 +1,48 @@
+package com.back.settlement.batch.reader;
+
+import com.back.settlement.app.support.LocalDateUtils;
+import com.back.settlement.app.support.SettlementSupport;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@StepScope
+@Component
+public class PayeeIdItemReader implements ItemReader<Long> {
+    private final SettlementSupport settlementSupport;
+    private final Long systemPayeeId;
+    private final YearMonth targetMonth;
+    private Iterator<Long> iterator;
+    private boolean initialized = false;
+
+    public PayeeIdItemReader(SettlementSupport settlementSupport, @Value("${settlement.system-payee-id}") Long systemPayeeId, @Value("#{jobParameters['targetMonth']}") String targetMonthStr) {
+        this.settlementSupport = settlementSupport;
+        this.systemPayeeId = systemPayeeId;
+        this.targetMonth = LocalDateUtils.parseYearMonthOrDefault(targetMonthStr);
+    }
+
+    @Override
+    public Long read() {
+        if (!initialized) {
+            LocalDateTime startAt = LocalDateUtils.startOfMonth(targetMonth);
+            LocalDateTime endAt = LocalDateUtils.endOfMonth(targetMonth);
+
+            List<Long> sellerIds = settlementSupport.findUnsettledSellerIds(startAt, endAt, systemPayeeId);
+            List<Long> payeeIds = new ArrayList<>(sellerIds);
+            payeeIds.add(systemPayeeId);
+
+            iterator = payeeIds.iterator();
+            initialized = true;
+            log.info("정산 대상: 판매자 {}명 + 시스템계좌, targetMonth={}", sellerIds.size(), targetMonth);
+        }
+        return iterator != null && iterator.hasNext() ? iterator.next() : null;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/batch/writer/OrderItemWriter.java
+++ b/settlement/src/main/java/com/back/settlement/batch/writer/OrderItemWriter.java
@@ -1,0 +1,24 @@
+package com.back.settlement.batch.writer;
+
+import com.back.common.dto.settlement.SettlementTargetOrder;
+import com.back.settlement.app.usecase.SettlementItemAddUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderItemWriter implements ItemWriter<SettlementTargetOrder> {
+    private final SettlementItemAddUseCase settlementItemAddUseCase;
+
+    @Override
+    public void write(Chunk<? extends SettlementTargetOrder> chunk) {
+        for (SettlementTargetOrder order : chunk) {
+            settlementItemAddUseCase.add(order);
+        }
+        log.info("정산 항목 생성 완료. 건수={}", chunk.size());
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/batch/writer/SettlementChunkWriter.java
+++ b/settlement/src/main/java/com/back/settlement/batch/writer/SettlementChunkWriter.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class SettlementChunkWriter implements ItemWriter<Long> {
     private final SettlementCreateUseCase settlementCreateUseCase;
 
+    // Spring Data JPA의 Repository는 clear()를 제공하지 않으므로 EntityManager를 직접 사용한다.
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -35,16 +36,12 @@ public class SettlementChunkWriter implements ItemWriter<Long> {
     public void write(Chunk<? extends Long> chunk) {
         YearMonth targetMonth = LocalDateUtils.parseYearMonthOrDefault(targetMonthStr);
         List<Long> payeeIds = new ArrayList<>(chunk.getItems());
-
-        // 1) IN절 배치 조회: 청크 내 모든 payeeId의 미정산 항목을 1회 SELECT
         List<SettlementWithItems> settlements = settlementCreateUseCase.createSettlements(payeeIds, targetMonth);
 
-        // 2) 정산별 저장: 도메인 이벤트(SettlementLog, Outbox) 정상 발행
         for (SettlementWithItems swi : settlements) {
             settlementCreateUseCase.saveSettlement(swi.settlement(), swi.items());
         }
 
-        // 3) 변경사항 DB 반영 후 1차 캐시 정리 (flush 없이 clear하면 dirty 변경 소실)
         entityManager.flush();
         entityManager.clear();
 

--- a/settlement/src/main/java/com/back/settlement/batch/writer/SettlementChunkWriter.java
+++ b/settlement/src/main/java/com/back/settlement/batch/writer/SettlementChunkWriter.java
@@ -1,50 +1,41 @@
 package com.back.settlement.batch.writer;
 
-import com.back.settlement.app.support.LocalDateUtils;
 import com.back.settlement.app.usecase.SettlementCreateUseCase;
-import com.back.settlement.batch.SettlementWithItems;
+import com.back.settlement.batch.PayeeSettlementWriteItem;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.time.YearMonth;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.batch.infrastructure.item.Chunk;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @StepScope
 @Component
-public class SettlementChunkWriter implements ItemWriter<Long> {
+public class SettlementChunkWriter implements ItemWriter<PayeeSettlementWriteItem> {
     private final SettlementCreateUseCase settlementCreateUseCase;
 
-    // Spring Data JPA의 Repository는 clear()를 제공하지 않으므로 EntityManager를 직접 사용한다.
     @PersistenceContext
     private EntityManager entityManager;
-
-    @Value("#{jobParameters['targetMonth']}")
-    private String targetMonthStr;
 
     public SettlementChunkWriter(SettlementCreateUseCase settlementCreateUseCase) {
         this.settlementCreateUseCase = settlementCreateUseCase;
     }
 
     @Override
-    public void write(Chunk<? extends Long> chunk) {
-        YearMonth targetMonth = LocalDateUtils.parseYearMonthOrDefault(targetMonthStr);
-        List<Long> payeeIds = new ArrayList<>(chunk.getItems());
-        List<SettlementWithItems> settlements = settlementCreateUseCase.createSettlements(payeeIds, targetMonth);
-
-        for (SettlementWithItems swi : settlements) {
-            settlementCreateUseCase.saveSettlement(swi.settlement(), swi.items());
+    public void write(Chunk<? extends PayeeSettlementWriteItem> chunk) {
+        int count = 0;
+        for (PayeeSettlementWriteItem writeItem : chunk.getItems()) {
+            if (writeItem.isEnriched()) {
+                settlementCreateUseCase.saveSettlement(writeItem.getSettlement(), writeItem.getItems());
+                count++;
+            }
         }
 
         entityManager.flush();
         entityManager.clear();
 
-        log.info("정산 청크 완료. payeeIds={}, settlements={}", payeeIds.size(), settlements.size());
+        log.info("정산 청크 저장 완료. settlements={}", count);
     }
 }

--- a/settlement/src/main/java/com/back/settlement/batch/writer/SettlementChunkWriter.java
+++ b/settlement/src/main/java/com/back/settlement/batch/writer/SettlementChunkWriter.java
@@ -1,0 +1,53 @@
+package com.back.settlement.batch.writer;
+
+import com.back.settlement.app.support.LocalDateUtils;
+import com.back.settlement.app.usecase.SettlementCreateUseCase;
+import com.back.settlement.batch.SettlementWithItems;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@StepScope
+@Component
+public class SettlementChunkWriter implements ItemWriter<Long> {
+    private final SettlementCreateUseCase settlementCreateUseCase;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Value("#{jobParameters['targetMonth']}")
+    private String targetMonthStr;
+
+    public SettlementChunkWriter(SettlementCreateUseCase settlementCreateUseCase) {
+        this.settlementCreateUseCase = settlementCreateUseCase;
+    }
+
+    @Override
+    public void write(Chunk<? extends Long> chunk) {
+        YearMonth targetMonth = LocalDateUtils.parseYearMonthOrDefault(targetMonthStr);
+        List<Long> payeeIds = new ArrayList<>(chunk.getItems());
+
+        // 1) IN절 배치 조회: 청크 내 모든 payeeId의 미정산 항목을 1회 SELECT
+        List<SettlementWithItems> settlements = settlementCreateUseCase.createSettlements(payeeIds, targetMonth);
+
+        // 2) 정산별 저장: 도메인 이벤트(SettlementLog, Outbox) 정상 발행
+        for (SettlementWithItems swi : settlements) {
+            settlementCreateUseCase.saveSettlement(swi.settlement(), swi.items());
+        }
+
+        // 3) 변경사항 DB 반영 후 1차 캐시 정리 (flush 없이 clear하면 dirty 변경 소실)
+        entityManager.flush();
+        entityManager.clear();
+
+        log.info("정산 청크 완료. payeeIds={}, settlements={}", payeeIds.size(), settlements.size());
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/config/OutboxKafkaConfig.java
+++ b/settlement/src/main/java/com/back/settlement/config/OutboxKafkaConfig.java
@@ -1,6 +1,5 @@
 package com.back.settlement.config;
 
-import com.back.common.event.EventName;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -18,13 +17,13 @@ import org.springframework.kafka.support.serializer.JacksonJsonSerializer;
 public class OutboxKafkaConfig {
 
     @Bean(name = "kafkaTemplate")
-    public KafkaTemplate<String, EventName> kafkaTemplate(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+    public KafkaTemplate<String, Object> kafkaTemplate(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JacksonJsonSerializer.class);
 
-        ProducerFactory<String, EventName> factory = new DefaultKafkaProducerFactory<>(props);
+        ProducerFactory<String, Object> factory = new DefaultKafkaProducerFactory<>(props);
         return new KafkaTemplate<>(factory);
     }
 

--- a/settlement/src/main/java/com/back/settlement/config/OutboxKafkaConfig.java
+++ b/settlement/src/main/java/com/back/settlement/config/OutboxKafkaConfig.java
@@ -1,5 +1,6 @@
 package com.back.settlement.config;
 
+import com.back.common.event.EventName;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -17,13 +18,13 @@ import org.springframework.kafka.support.serializer.JacksonJsonSerializer;
 public class OutboxKafkaConfig {
 
     @Bean(name = "kafkaTemplate")
-    public KafkaTemplate<String, Object> kafkaTemplate(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+    public KafkaTemplate<String, EventName> kafkaTemplate(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JacksonJsonSerializer.class);
 
-        ProducerFactory<String, Object> factory = new DefaultKafkaProducerFactory<>(props);
+        ProducerFactory<String, EventName> factory = new DefaultKafkaProducerFactory<>(props);
         return new KafkaTemplate<>(factory);
     }
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #335 

## 🔎 작업 내용
### 구조 개선
- StepConfig에서 Reader/Writer 별도 클래스 추출 (`PayeeIdItemReader`,`SettlementChunkWriter`)
- Processor 제거 및 SRP를 지키기 위해 beforeWrite 사용
  - 기존 Processor는 판매자별 개별 조회(1건씩)를 수행했음
  - Processor는 건별 처리 구조라 chunk 단위 IN절 배치 조회에 적합하지 않고 별도 가공 로직도 없으므로 제거
- beforeWrite에서 chunk 전체 payeeId로 배치 조회 후 아이템을 보강(enrich)하도록 변경.
    - Writer는 이제 저장만 전담(조회/보강 책임 제거)
- chunk 아이템을 PayeeSettlementWriteItem()로 감싸서 사용 ( writer에 chunk 아이템 조회도 할 경우 SRP 위반 )
    - beforeWrite에서 바로 enrich 후 같은 객체를 Writer에 전달
    - 별도 공유 상태/캐시 없이 Listener-Writer 간 데이터 전달을 처리
- JobLauncher의 중복 로직은 executeJob으로 추출

### 1차 성능 최적화
- 판매자별 순차 SELECT → **IN절 배치 조회** 전환 (2,000회 → 20회)
- chunk 단위 **EntityManager.flush()/clear()** 로 영속성 컨텍스트에 데이터가 쌓이는 것을 방지
- `hibernate.jdbc.batch_size: 100`, `order_updates: true` 적용

## 📷 테스트 결과
### Intellij Profile Before vs After (판매자 2,000명, settlement_item 200,000건)

| 항목 | Before (02-22) | After (02-24) | 개선율 |
|------|----------------|---------------|--------|
| **배치 실행 시간** | ~162초 | **~46초** | **-72%** |
| CPU 샘플 (배치 스레드) | 4,786 | 1,974 | -59% |
| SELECT 라운드트립 | 920 샘플 | 289 샘플 | -69% |
| Flush CPU 비용 | 3,297 샘플 | 1,324 샘플 | -60% |
| Object Allocation | 15,023 | 8,799 | -41% |
| 메모리 committed (배치 완료 후) | 560 MB (유지) | 434 MB (축소) | -23% |
---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
