### PR TITLE
[FEAT] 사이즈별 즉시구매가, 판매가 조회 api 구현(#254)

### DIFF
--- a/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1Market.java
@@ -16,6 +16,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Market API", description = "상품 구매 및 주문 관련 API")
 @RequestMapping("/api/v1/market")
 public interface ApiV1Market {
@@ -33,11 +35,15 @@ public interface ApiV1Market {
             @RequestBody @Valid BiddingRequestDto requestDto,
             HttpServletRequest request);
 
-    @Operation(summary = "즉시 구매가 조회", description = "특정 상품에 대해 즉시 구매 가능한(판매 입찰 중 가장 낮은) 가격을 조회한다.")
+    @Operation(summary = "전체 사이즈별 즉시구매, 판매가 조회", description = "특정 상품에 대해 사이즈별로 즉시 구매 가능한 가격과 즉시 판매 가능한 가격을 조회한다.")
+    @GetMapping("/products/{productInfoId}/size-prices")
+    CommonResponse<List<ProductSizePriceResponseDto>> getAllSizePrices(@PathVariable Long productInfoId);
+
+    @Operation(summary = "즉시 구매가 조회(단건)", description = "특정 상품에 대해 즉시 구매 가능한(판매 입찰 중 가장 낮은) 가격을 조회한다.")
     @GetMapping("/products/{productId}/buy-now-price")
     CommonResponse<InstantBuyPriceResponseDto> getBuyNowPrice(@PathVariable Long productId);
 
-    @Operation(summary = "즉시 판매가 조회", description = "특정 상품에 대해 즉시 판매 가능한(구매 입찰 중 가장 높은) 가격을 조회한다.")
+    @Operation(summary = "즉시 판매가 조회(단건)", description = "특정 상품에 대해 즉시 판매 가능한(구매 입찰 중 가장 높은) 가격을 조회한다.")
     @GetMapping("/products/{productId}/sell-now-price")
     CommonResponse<InstantSellPriceResponseDto> getSellNowPrice(@PathVariable Long productId);
 

--- a/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
+++ b/market/src/main/java/com/back/market/adapter/in/ApiV1MarketController.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class ApiV1MarketController implements ApiV1Market{
@@ -45,6 +47,12 @@ public class ApiV1MarketController implements ApiV1Market{
         String ip = IpAddressExtractor.extractClientIp(request);
         MarketPaymentResponseDto response = marketFacade.registerSellBid(userId, ip, requestDto);
         return CommonResponse.successWithData(HttpStatus.CREATED, response);
+    }
+
+    @Override
+    public CommonResponse<List<ProductSizePriceResponseDto>> getAllSizePrices(Long productInfoId) {
+        List<ProductSizePriceResponseDto> response = marketFacade.getAllSizePrices(productInfoId);
+        return CommonResponse.successWithData(HttpStatus.OK, response);
     }
 
     @Override

--- a/market/src/main/java/com/back/market/adapter/out/MarketProductRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/MarketProductRepository.java
@@ -3,8 +3,12 @@ package com.back.market.adapter.out;
 import com.back.market.domain.MarketProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MarketProductRepository  extends JpaRepository<MarketProduct, Long> {
     boolean existsById(Long productOptionId);
 
     void deleteByProductInfoId(Long productInfoId);
+
+    List<MarketProduct> findAllByProductInfoId(Long productInfoId);
 }

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +57,16 @@ public class MarketFacade {
         marketDetectorAdapter.detectBidSpam(userId);
         marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
         return registerBidUseCase.registerSellBid(userId, requestDto);
+    }
+
+    /**
+     * 사이즈별 즉시 구매가/판매가 조회
+     * @param productInfoId 상품 정보 ID
+     * @return List<ProductSizePriceResponseDto>
+     */
+    @Transactional(readOnly = true)
+    public List<ProductSizePriceResponseDto> getAllSizePrices(Long productInfoId) {
+        return getInstantPriceUseCase.getAllSizePrices(productInfoId);
     }
 
     /**

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -110,7 +110,7 @@ public class MarketSupport {
     }
 
     /**
-     * 즉시 구매가 조회(최저가 판매 입찰 조회)
+     * 즉시 구매가 조회(최저가 판매 입찰 조회) (단건 조회)
      * @param productId 상품 PK
      * @param position 구매/판매
      * @param status 구매 상태
@@ -121,7 +121,7 @@ public class MarketSupport {
     }
 
     /**
-     * 즉시 판매가 조회(최고가 구매 입찰 조회)
+     * 즉시 판매가 조회(최고가 구매 입찰 조회) (단건 조회)
      * @param productId 상품 PK
      * @param position 구매/판매
      * @param status 구매 상태
@@ -165,6 +165,19 @@ public class MarketSupport {
      */
     public Order findOrderWithDetails(Long userId, Long orderId) {
         return orderRepository.findOrderWithDetails(userId, orderId).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+    }
+
+    /**
+     * 특정 상품에 대한 즉시구매/판매가 일괄 조회
+     * @param productInfoId 상품 정보 ID
+     * @return List<MarketProduct>
+     */
+    public List<MarketProduct> findAllByProductInfoId(Long productInfoId) {
+        List<MarketProduct> products = marketProductRepository.findAllByProductInfoId(productInfoId);
+        if(products.isEmpty()) {
+            throw new BadRequestException(FailureCode.PRODUCT_NOT_FOUND);
+        }
+        return products;
     }
 
 }

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -82,10 +82,10 @@ public class MarketSupport {
     /**
      * MarketProduct 존재 여부 확인
      * @param productId PK
-     * @return boolean
+     * @return boolean 상품이 없는 경우 true 반환
      */
-    public boolean existsByMarketProduct(Long productId) {
-        return marketProductRepository.existsById(productId);
+    public boolean isMarketProductMissing(Long productId) {
+        return !marketProductRepository.existsById(productId);
     }
 
     /**

--- a/market/src/main/java/com/back/market/app/usecase/CreateProductUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/CreateProductUseCase.java
@@ -22,7 +22,7 @@ public class CreateProductUseCase {
     public int createMarketProduct(List<ProductCreatedResultPayload> payloads) {
         int savedCount = 0;
         for(ProductCreatedResultPayload payload: payloads) {
-            if(!marketSupport.existsByMarketProduct(payload.productOptionId())) {
+            if(marketSupport.isMarketProductMissing(payload.productOptionId())) {
                 MarketProduct product = marketProductMapper.toEntity(payload);
                 marketProductRepository.save(product);
                 savedCount++;

--- a/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
@@ -78,7 +78,7 @@ public class GetInstantPriceUseCase {
     }
 
     private void verifyProductExists(Long productId) {
-        if (!marketSupport.existsByMarketProduct(productId)) {
+        if (marketSupport.isMarketProductMissing(productId)) {
             throw new BadRequestException(FailureCode.PRODUCT_NOT_FOUND);
         }
     }

--- a/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/GetInstantPriceUseCase.java
@@ -4,15 +4,19 @@ import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
 import com.back.market.app.MarketSupport;
 import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
 import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
 import com.back.market.dto.response.InstantBuyPriceResponseDto;
 import com.back.market.dto.response.InstantSellPriceResponseDto;
+import com.back.market.dto.response.ProductSizePriceResponseDto;
+import com.back.market.mapper.MarketProductMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * 즉시구매가, 즉시판매가 조회
@@ -22,9 +26,22 @@ import java.math.BigDecimal;
 public class GetInstantPriceUseCase {
 
     private final MarketSupport marketSupport;
+    private final MarketProductMapper marketProductMapper;
+
+    @Transactional(readOnly = true)
+    public List<ProductSizePriceResponseDto> getAllSizePrices(Long productInfoId) {
+        List<MarketProduct> productList = marketSupport.findAllByProductInfoId(productInfoId);
+        return productList.stream()
+                .map(product -> {
+                    BigDecimal buyPrice = marketSupport.findInstantBuyPrice(product.getId(), BiddingPosition.SELL, BiddingStatus.PROCESS).map(Bidding::getPrice).orElse(null);
+
+                    BigDecimal sellPrice = marketSupport.findInstantSellPrice(product.getId(), BiddingPosition.BUY, BiddingStatus.PROCESS).map(Bidding::getPrice).orElse(null);
+                    return marketProductMapper.toSizePriceDto(product, buyPrice, sellPrice);
+                }).toList();
+    }
 
     /**
-     * 즉시 구매가 조회
+     * 즉시 구매가 조회(단건 조회)
      * @param productId 조회할 상품 ID
      * @return InstantBuyPriceResponseDto
      */
@@ -43,7 +60,7 @@ public class GetInstantPriceUseCase {
     }
 
     /**
-     * 즉시 판매가 조회
+     * 즉시 판매가 조회(단건 조회)
      * @param productId 조회할 상품 ID
      * @return InstantSellPriceResponseDto
      */

--- a/market/src/main/java/com/back/market/dto/response/ProductSizePriceResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/ProductSizePriceResponseDto.java
@@ -1,0 +1,11 @@
+package com.back.market.dto.response;
+
+import java.math.BigDecimal;
+
+public record ProductSizePriceResponseDto(
+        Long productId,
+        String productOption,
+        BigDecimal instantBuyPrice,
+        BigDecimal instantSellPrice
+) {
+}

--- a/market/src/main/java/com/back/market/dto/response/TotalSizePriceResponseDto.java
+++ b/market/src/main/java/com/back/market/dto/response/TotalSizePriceResponseDto.java
@@ -1,0 +1,9 @@
+package com.back.market.dto.response;
+
+import java.util.List;
+
+public record TotalSizePriceResponseDto(
+        Long productInfoId,
+        List<ProductSizePriceResponseDto> sizePriceList
+) {
+}

--- a/market/src/main/java/com/back/market/mapper/MarketProductMapper.java
+++ b/market/src/main/java/com/back/market/mapper/MarketProductMapper.java
@@ -1,6 +1,7 @@
 package com.back.market.mapper;
 
 import com.back.market.domain.MarketProduct;
+import com.back.market.dto.response.ProductSizePriceResponseDto;
 import com.back.market.event.payload.OptionPayload;
 import com.back.market.event.payload.ProductCreatedPayload;
 import com.back.market.event.payload.ProductUpdatedPayload;
@@ -12,6 +13,15 @@ import java.math.BigDecimal;
 
 @Component
 public class MarketProductMapper {
+
+    public ProductSizePriceResponseDto toSizePriceDto(MarketProduct product, BigDecimal buyPrice, BigDecimal sellPrice) {
+        return new ProductSizePriceResponseDto(
+                product.getId(),
+                product.getProductOption(),
+                buyPrice,
+                sellPrice
+        );
+    }
 
     // 1단계: 원본(Payload)을 중간재(ResultPayload)로 변환
     public ProductCreatedResultPayload toResultPayload(ProductCreatedPayload payload, OptionPayload.ValuePayload optionValue) {
@@ -78,7 +88,7 @@ public class MarketProductMapper {
             String name,
             String productNumber,
             String productOption,
-            Long price,
+            BigDecimal price,
             String categoryName,
             String thumbnailImage
     ) {
@@ -89,7 +99,7 @@ public class MarketProductMapper {
                 .name(name)
                 .productNumber(productNumber)
                 .productOption(productOption) // 사이즈 등 옵션
-                .releasePrice(BigDecimal.valueOf(price)) // 편의상 long으로 받아 여기에서 BigDecimal 변환
+                .releasePrice(price) // 편의상 long으로 받아 여기에서 BigDecimal 변환
                 .categoryName(categoryName)
                 .thumbnailImage(thumbnailImage)
                 .build();

--- a/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeRollbackTests.java
@@ -83,7 +83,7 @@ public class MatchInstantTradeRollbackTests {
                     "신발",        // name
                     "N1",         // productNumber
                     "270",        // productOption (사이즈)
-                    100000L,      // price
+                    BigDecimal.valueOf(100000L),      // price
                     "스니커즈",     // categoryName
                     "img"
             ));

--- a/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeUseCaseV2Tests.java
@@ -251,7 +251,7 @@ public class MatchInstantTradeUseCaseV2Tests {
                     "신발",        // name
                     "N1",         // productNumber
                     "270",        // productOption (사이즈)
-                    100000L,      // price
+                    BigDecimal.valueOf(100000L),      // price
                     "스니커즈",     // categoryName
                     "img"
             ));

--- a/market/src/test/java/com/back/market/event/PaymentResultEventTests.java
+++ b/market/src/test/java/com/back/market/event/PaymentResultEventTests.java
@@ -73,7 +73,7 @@ public class PaymentResultEventTests {
 
         // 결제 실패는 금액 정보 없이 RelType과 ID만 전송
         PaymentFailedPayload payload = new PaymentFailedPayload(
-                RelType.ORDER, testOrderId
+                RelType.ORDER, testOrderId, "실패이유"
         );
         Envelope<PaymentFailedPayload> envelope = Envelope.of("PaymentFailedEvent", payload);
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #254

## 🔎 작업 내용

- 사이즈별 즉시구매/판매가 조회 api 구현

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- 사이즈별 조회 api swagger 호출 결과
  <img width="1425" height="785" alt="image" src="https://github.com/user-attachments/assets/68032071-0f02-481d-9626-aade974db838" />

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
