### PR TITLE
[FIX] FeignClient 요청 시 403 forbidden 뜨는 문제 해결(#363)

### DIFF
--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -40,8 +40,8 @@ public class MarketFacade {
     @Transactional
     public MarketPaymentResponseDto registerBuyBid(Long userId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(userId);
-        marketDetectorAdapter.detectBidSpam(userId);
-        marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
+//        marketDetectorAdapter.detectBidSpam(userId);
+//        marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
         return registerBidUseCase.registerBuyBid(userId, requestDto);
     }
 
@@ -54,8 +54,8 @@ public class MarketFacade {
     @Transactional
     public MarketPaymentResponseDto registerSellBid(Long userId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(userId);
-        marketDetectorAdapter.detectBidSpam(userId);
-        marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
+//        marketDetectorAdapter.detectBidSpam(userId);
+//        marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
         return registerBidUseCase.registerSellBid(userId, requestDto);
     }
 
@@ -97,8 +97,8 @@ public class MarketFacade {
      */
     public MarketPaymentResponseDto purchaseNow(Long buyerId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(buyerId);
-        marketDetectorAdapter.detectBidSpam(buyerId);
-        marketDetectorAdapter.detectHijack(buyerId, user.getEmail(), ip, requestDto.price());
+//        marketDetectorAdapter.detectBidSpam(buyerId);
+//        marketDetectorAdapter.detectHijack(buyerId, user.getEmail(), ip, requestDto.price());
         return matchInstantTradeUseCase.buyNow(buyerId, requestDto);
     }
 
@@ -110,8 +110,8 @@ public class MarketFacade {
      */
     public MarketPaymentResponseDto sellNow(Long sellerId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(sellerId);
-        marketDetectorAdapter.detectBidSpam(sellerId);
-        marketDetectorAdapter.detectHijack(sellerId, user.getEmail(), ip, requestDto.price());
+//        marketDetectorAdapter.detectBidSpam(sellerId);
+//        marketDetectorAdapter.detectHijack(sellerId, user.getEmail(), ip, requestDto.price());
         return matchInstantTradeUseCase.sellNow(sellerId, requestDto);
     }
 

--- a/security/src/main/java/com/back/security/config/BaseSecurityConfig.java
+++ b/security/src/main/java/com/back/security/config/BaseSecurityConfig.java
@@ -38,7 +38,8 @@ public class BaseSecurityConfig {
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                         "/actuator/**",
-                        "/ws/**"
+                        "/ws/**",
+                        "/api/v1/internal/**"
                 ).permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/products/**", "/api/v1/market/products/**").permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #363

## 🔎 작업 내용

- detector 모듈이 죽어있을 경우 timeout 설정이 없어서 마켓 모듈의 api가 실행되지 않는 문제, 마켓 api 테스트를 위해 주석 처리
- internal api를 securityconfig 화이트리스트에 추가

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
