### PR TITLE
[PERF] PriceDropped 알림 성능 개선 (Bulk Update) (#365)

### DIFF
--- a/notification/src/main/java/com/back/notification/adapter/out/PriceAlertRepository.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/PriceAlertRepository.java
@@ -2,6 +2,7 @@ package com.back.notification.adapter.out;
 
 import com.back.notification.domain.PriceAlert;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,4 +29,8 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
     );
 
     List<PriceAlert> findByUserIdOrderByIdDesc(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PriceAlert pa SET pa.triggeredAt = :now WHERE pa.id IN :ids")
+    void bulkTrigger(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertSupport.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertSupport.java
@@ -25,7 +25,12 @@ public class PriceAlertSupport {
         List<PriceAlert> priceAlerts = priceAlertRepository.findEligibleAlerts(payload.productId(),
                 payload.currentPrice(), now.minusDays(1));
 
-        priceAlerts.forEach(alert -> alert.trigger(now));
+        List<Long> ids = priceAlerts.stream().map(PriceAlert::getId).toList();
+        int chunkSize = 1000;
+        for (int i = 0; i < ids.size(); i += chunkSize) {
+            List<Long> chunk = ids.subList(i, Math.min(i + chunkSize, ids.size()));
+            priceAlertRepository.bulkTrigger(chunk, now);
+        }
 
         return priceAlerts.stream()
                 .map(PriceAlert::getUser)

--- a/notification/src/main/java/com/back/notification/domain/PriceAlert.java
+++ b/notification/src/main/java/com/back/notification/domain/PriceAlert.java
@@ -34,7 +34,4 @@ public class PriceAlert extends BaseTimeEntity {
 
     private LocalDateTime triggeredAt;
 
-    public void trigger(LocalDateTime now) {
-        this.triggeredAt = now;
-    }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #365 

## 🔎 작업 내용

- 가격 알림 트리거 방식을 Dirty Checking 기반 N번 UPDATE에서 `@Modifying` + JPQL 벌크 UPDATE로 전환
  - 기존: `forEach`로 각 엔티티의 `trigger()` 호출 → 트랜잭션 종료 시점에 UPDATE 쿼리 N번 발생
  - 변경: `bulkTrigger()` 메서드로 대상 id 목록을 한 번에 UPDATE 처리
  - `clearAutomatically = true` 설정으로 벌크 UPDATE 이후 1차 캐시를 초기화하여 stale 데이터 반환 방지
- PostgreSQL PreparedStatement 파라미터 한계(65,535개) 대응을 위해 id 목록을 1,000개 단위 청크로 분할하여 실행


<br>


## 📌 참고 사항

- 10만 건 알림 발송 기준 `findTarget()` 성능: **4,900ms → 830ms (약 1/5 수준 감소)**
  | 단계 | Before | After |
  |---|---|---|
  | trigger() / bulkTrigger() | ~4,900ms | 820ms + 10ms (id 추출) |
  | **전체 findTarget()** | **5,777ms** | **1,620ms** |

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- bulk update로 triggeredAt이 업데이트됨
<img width="1291" height="495" alt="image" src="https://github.com/user-attachments/assets/04529c0e-7d97-4fa7-9c0f-e52ef241f0d7" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
