### PR TITLE
[FIX] 구매입찰 등록 및 주문 관련 오류들 수정(#366)

### DIFF
--- a/common/src/main/java/com/back/common/code/FailureCode.java
+++ b/common/src/main/java/com/back/common/code/FailureCode.java
@@ -37,6 +37,7 @@ public enum FailureCode {
     CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "CONSTRAINT_VIOLATION", "제약 조건 위반으로 작업을 수행할 수 없습니다."),
     ORDER_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "ORDER_ACCESS_DENIED", "해당 주문에 대한 접근 권한이 없습니다."),
     ORDER_NOT_DELIVERED(HttpStatus.BAD_REQUEST, "ORDER_NOT_DELIVERED", "배송 완료된 주문만 구매 확정할 수 있습니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "INVALID_ORDER_STATUS", "유효하지 않은 주문 상태입니다."),
 
     /**
      * 401 Unauthorized

--- a/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
+++ b/market/src/main/java/com/back/market/adapter/out/OrderRepository.java
@@ -27,4 +27,6 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
 
     @Query("SELECT o from Order o JOIN FETCH o.buyBidding bb JOIN FETCH o.sellBidding sb JOIN FETCH bb.marketProduct WHERE o.id = :orderId")
     Optional<Order> findOrderWithDetails(@Param("orderId") Long orderId);
+
+    Optional<Order> findBySellBiddingId(Long sellBiddingId);
 }

--- a/market/src/main/java/com/back/market/adapter/out/cash/MarketCashAdapter.java
+++ b/market/src/main/java/com/back/market/adapter/out/cash/MarketCashAdapter.java
@@ -38,6 +38,12 @@ public class MarketCashAdapter {
             // 공통 에러 던지기
             throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
         }
+
+        if (response.getData() == null) {
+            log.error("[MarketCashAdapter] 결제 응답 성공(OK)이나 데이터가 null입니다. (RelId: {})", paymentReq.relId());
+            // 데이터가 없으면 비즈니스 로직을 진행할 수 없으므로 예외 발생
+            throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+        }
         return response.getData();
     }
 

--- a/market/src/main/java/com/back/market/app/MarketFacade.java
+++ b/market/src/main/java/com/back/market/app/MarketFacade.java
@@ -9,15 +9,18 @@ import com.back.market.dto.request.BiddingRequestDto;
 import com.back.market.dto.response.*;
 import com.back.market.event.OrderCompletedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MarketFacade {
@@ -40,8 +43,7 @@ public class MarketFacade {
     @Transactional
     public MarketPaymentResponseDto registerBuyBid(Long userId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(userId);
-//        marketDetectorAdapter.detectBidSpam(userId);
-//        marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
+        callDetector(userId, user.getEmail(), ip, requestDto.price());
         return registerBidUseCase.registerBuyBid(userId, requestDto);
     }
 
@@ -54,8 +56,7 @@ public class MarketFacade {
     @Transactional
     public MarketPaymentResponseDto registerSellBid(Long userId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(userId);
-//        marketDetectorAdapter.detectBidSpam(userId);
-//        marketDetectorAdapter.detectHijack(userId, user.getEmail(), ip, requestDto.price());
+        callDetector(userId, user.getEmail(), ip, requestDto.price());
         return registerBidUseCase.registerSellBid(userId, requestDto);
     }
 
@@ -97,8 +98,7 @@ public class MarketFacade {
      */
     public MarketPaymentResponseDto purchaseNow(Long buyerId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(buyerId);
-//        marketDetectorAdapter.detectBidSpam(buyerId);
-//        marketDetectorAdapter.detectHijack(buyerId, user.getEmail(), ip, requestDto.price());
+        callDetector(buyerId, user.getEmail(), ip, requestDto.price());
         return matchInstantTradeUseCase.buyNow(buyerId, requestDto);
     }
 
@@ -110,8 +110,7 @@ public class MarketFacade {
      */
     public MarketPaymentResponseDto sellNow(Long sellerId, String ip, BiddingRequestDto requestDto) {
         MarketUser user = marketSupport.findMarketUserById(sellerId);
-//        marketDetectorAdapter.detectBidSpam(sellerId);
-//        marketDetectorAdapter.detectHijack(sellerId, user.getEmail(), ip, requestDto.price());
+        callDetector(sellerId, user.getEmail(), ip, requestDto.price());
         return matchInstantTradeUseCase.sellNow(sellerId, requestDto);
     }
 
@@ -178,5 +177,14 @@ public class MarketFacade {
     @Transactional(readOnly = true)
     public OrderDetailResponseDto getOrderDetail(Long userId, Long orderId) {
         return getOrdersUseCase.getOrderDetail(userId, orderId);
+    }
+
+    private void callDetector(Long sellerId, String email, String ip, BigDecimal price) {
+        try {
+            marketDetectorAdapter.detectBidSpam(sellerId);
+            marketDetectorAdapter.detectHijack(sellerId, email, ip, price);
+        } catch (Exception e) {
+            log.warn("[MarketFacade] Detector API 호출 실패. userId: {}, email: {}, ip: {}, price: {}, error: {}", sellerId, email, ip, price, e.getMessage(), e);
+        }
     }
 }

--- a/market/src/main/java/com/back/market/app/MarketSupport.java
+++ b/market/src/main/java/com/back/market/app/MarketSupport.java
@@ -180,4 +180,7 @@ public class MarketSupport {
         return products;
     }
 
+    public Order findOrderBySellBiddingId(Long sellBiddingId) {
+        return orderRepository.findBySellBiddingId(sellBiddingId).orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+    }
 }

--- a/market/src/main/java/com/back/market/app/usecase/BiddingStatusService.java
+++ b/market/src/main/java/com/back/market/app/usecase/BiddingStatusService.java
@@ -1,0 +1,32 @@
+package com.back.market.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.enums.BiddingStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BiddingStatusService {
+    private final BiddingRepository biddingRepository;
+
+    /**
+     * 새로운 트랜잭션에서 bidding 상태를 변경하는 메서드
+     * @param biddingId 변경할 bidding의 ID
+     * @param status 변경할 상태
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markStatusInNewTx(Long biddingId, BiddingStatus status) {
+        Bidding bidding = biddingRepository.findById(biddingId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+
+        bidding.changeStatus(status);
+        biddingRepository.save(bidding);
+    }
+}
+

--- a/market/src/main/java/com/back/market/app/usecase/BiddingStatusService.java
+++ b/market/src/main/java/com/back/market/app/usecase/BiddingStatusService.java
@@ -6,12 +6,14 @@ import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.domain.Bidding;
 import com.back.market.domain.enums.BiddingStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BiddingStatusService {
     private final BiddingRepository biddingRepository;
 
@@ -22,11 +24,17 @@ public class BiddingStatusService {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markStatusInNewTx(Long biddingId, BiddingStatus status) {
-        Bidding bidding = biddingRepository.findById(biddingId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
+        log.info("[BiddingStatusService] markStatusInNewTx 시작 - biddingId={}, newStatus={}", biddingId, status);
+        try {
+            Bidding bidding = biddingRepository.findById(biddingId)
+                    .orElseThrow(() -> new BadRequestException(FailureCode.BIDDING_NOT_FOUND));
 
-        bidding.changeStatus(status);
-        biddingRepository.save(bidding);
+            bidding.changeStatus(status);
+            biddingRepository.save(bidding);
+            log.info("[BiddingStatusService] markStatusInNewTx 커밋됨 - biddingId={}, newStatus={}", biddingId, status);
+        } catch (Exception e) {
+            log.error("[BiddingStatusService] markStatusInNewTx 실패 - biddingId={}, newStatus={}, error={}", biddingId, status, e.getMessage(), e);
+            throw e;
+        }
     }
 }
-

--- a/market/src/main/java/com/back/market/app/usecase/ConfirmPaymentUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/ConfirmPaymentUseCase.java
@@ -57,7 +57,7 @@ public class ConfirmPaymentUseCase {
             Order order = marketSupport.findOrderById(payload.relId());
             if (order.getOrderStatus() == OrderStatus.HOLD) {
                 // 1. 주문 취소
-                order.changeStatus(OrderStatus.CANCELLED);
+                order.changeStatus(OrderStatus.CANCELLED_PAYMENT_FAILED);
                 log.info("[Market] 결제 실패로 인한 주문 취소 완료 - OrderId: {}, status: {}", order.getId(), order.getOrderStatus());
 
                 // 2. 구매자의 입찰 취소(결제 실패 책임)

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -191,7 +191,7 @@ public class MatchInstantTradeUseCase {
         }
         log.info("[MatchInstantTrade] executeTrade 완료 - orderId={}, resultStatus={}", savedOrder.getId(), resultData.status());
          return MarketPaymentResponseDto.from(resultData, targetBid.getMarketProduct().getName(), me.getName(), me.getEmail());
-     }
+    }
 
     private void handleCompensation(Bidding targetBid, Bidding myBid, Order savedOrder, boolean isOrderNew, boolean isMyBidNew) {
         // 판매 입찰 원상복구(process로)

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -42,6 +43,8 @@ public class MatchInstantTradeUseCase {
     private final MarketCashAdapter marketCashAdapter;
     private final ApplicationEventPublisher eventPublisher;
     private final MarketSupport marketSupport;
+    private final BiddingStatusService biddingStatusService;
+    private final OrderStatusService orderStatusService;
 
     /**
      * MARKET-009 즉시 구매 실행
@@ -100,30 +103,44 @@ public class MatchInstantTradeUseCase {
      */
     private MarketPaymentResponseDto executeTrade(Long userId, BiddingRequestDto requestDto, Bidding targetBid, BiddingPosition myPosition) {
         // 1. 자전거래 검증
-        if(targetBid.getMarketUser().getId().equals(userId)){
+        if(Objects.equals(targetBid.getMarketUser().getId(), userId)){
             throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
         }
 
-        // 2. 입찰 생성 및 상태 변경
-        // 사용자 조회
         MarketUser me = marketSupport.findMarketUserById(userId);
+        Order savedOrder;
+        Bidding myBid;
 
-        Bidding myBid = biddingMapper.toEntity(requestDto, me, targetBid.getMarketProduct(), myPosition);
-        myBid.changeStatus(BiddingStatus.MATCHED);
-        biddingRepository.save(myBid);
+        if (myPosition == BiddingPosition.BUY) {
+            try {
+                savedOrder = marketSupport.findOrderBySellBiddingId(targetBid.getId());
 
-        // 3. 상대방 입찰 상태 변경
-        targetBid.changeStatus(BiddingStatus.MATCHED);
-
-        // 4. 주문 생성
-        Order order;
-
-        if(myPosition == BiddingPosition.BUY) {
-            order = orderMapper.toEntity(myBid, targetBid, me.getAddress());
+                if (savedOrder.getOrderStatus() == OrderStatus.CANCELLED_PAYMENT_FAILED) {
+                    log.info("[MatchInstantTradeUseCase] 기존 실패 주문 재사용 - OrderId: {}, SellBiddingId: {}", savedOrder.getId(), targetBid.getId());
+                    myBid = savedOrder.getBuyBidding();
+                    myBid.changeStatus(BiddingStatus.MATCHED);
+                    targetBid.changeStatus(BiddingStatus.MATCHED);
+                    savedOrder.changeStatus(OrderStatus.HOLD);
+                } else {
+                    // 이미 진행 중(HOLD/PAID)인 경우 중복 처리 방지
+                    throw new BadRequestException(FailureCode.INVALID_ORDER_STATUS);
+                }
+            } catch (BadRequestException e) {
+                if (e.getFailureCode() == FailureCode.ORDER_NOT_FOUND) {
+                    log.info("[MatchTrade] 신규 주문 생성 - SellBiddingId: {}", targetBid.getId());
+                    myBid = createAndSaveNewBidding(requestDto, me, targetBid, myPosition);
+                    targetBid.changeStatus(BiddingStatus.MATCHED);
+                    savedOrder = orderRepository.save(orderMapper.toEntity(myBid, targetBid, me.getAddress()));
+                } else {
+                    throw e;
+                }
+            }
         } else {
-            order = orderMapper.toEntity(targetBid, myBid, targetBid.getMarketUser().getAddress());
+            //즉시 판매 로직
+            myBid = createAndSaveNewBidding(requestDto, me, targetBid, myPosition);
+            targetBid.changeStatus(BiddingStatus.MATCHED);
+            savedOrder = orderRepository.save(orderMapper.toEntity(targetBid, myBid, targetBid.getMarketUser().getAddress()));
         }
-        Order savedOrder = orderRepository.save(order);
 
         // 5. 실제 결제 요청(FeignClient 사용)
         if(myPosition == BiddingPosition.BUY) {
@@ -132,6 +149,22 @@ public class MatchInstantTradeUseCase {
             PayAndHoldResponseDto resultData = marketCashAdapter.getPayAndHoldResult(paymentReq);
 
             // 6. 결과 상태에 따른 주문 상태 업데이트
+            if (resultData == null) {
+                log.error("[MatchInstantTrade] Cash 모듈이 null을 반환했습니다. 주문 취소 처리합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
+                // 보상: 주문/입찰 상태를 REQUIRES_NEW로 저장
+                orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
+                biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                // 판매자의 매물은 다시 판매중(PROCESS)으로 복원해야 함
+                biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
+
+                // 메인 트랜잭션의 영속성 컨텍스트와 DB 상태 동기화
+                savedOrder.changeStatus(OrderStatus.CANCELLED_PAYMENT_FAILED);
+                myBid.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                targetBid.changeStatus(BiddingStatus.PROCESS);
+
+                throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+            }
+
             if (resultData.status() == PayAndHoldStatus.PAID) {
                 // 결제 완료 -> 주문 상태 변경
                 log.info("[MatchInstantTrade] 결제 완료 (PAID) - OrderId: {}", savedOrder.getId());
@@ -142,7 +175,23 @@ public class MatchInstantTradeUseCase {
                 // PG 결제 필요 -> 주문은 대기 상태 유지 (HOLD)
                 // (Order 생성 시 기본값이 HOLD이므로 별도 상태 변경 불필요)
                 log.info("[MatchInstantTrade] PG 결제 필요 (REQUIRES_PG) - OrderId: {}, TossId: {}", savedOrder.getId(), resultData.tossOrderId());
+            } else {
+                // 기타 상태(실패 등) -> 주문/입찰 취소 및 보상 처리
+                log.warn("[MatchInstantTrade] 결제 실패 상태 감지 ({}). 주문/입찰을 취소합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", resultData.status(), savedOrder.getId(), myBid.getId(), targetBid.getId());
+                // 주문 및 구매자 입찰만 실패로 기록; 판매자의 매물은 다시 판매중으로 복원
+                orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
+                biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
+
+                // 메인 트랜잭션의 영속성 컨텍스트와 DB 상태 동기화
+                savedOrder.changeStatus(OrderStatus.CANCELLED_PAYMENT_FAILED);
+                myBid.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                targetBid.changeStatus(BiddingStatus.PROCESS);
+
+                // 메인 트랜잭션을 롤백시켜 영속성 컨텍스트가 DB에 오래된 상태를 덮어쓰는 것을 방지
+                throw new BadRequestException(FailureCode.PAYMENT_CONFIRM_FAILED);
             }
+
             return MarketPaymentResponseDto.from(
                     resultData,
                     targetBid.getMarketProduct().getName(), // 상품명
@@ -174,6 +223,12 @@ public class MatchInstantTradeUseCase {
         }
     }
 
+    // 반복되는 입찰 생성 로직을 메서드로 분리
+    private Bidding createAndSaveNewBidding(BiddingRequestDto dto, MarketUser user, Bidding target, BiddingPosition pos) {
+        Bidding bidding = biddingMapper.toEntity(dto, user, target.getMarketProduct(), pos);
+        bidding.changeStatus(BiddingStatus.MATCHED);
+        return biddingRepository.save(bidding);
+    }
     /**
      * 주문 생성 이벤트 발행
      * @param order 주문

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -2,7 +2,6 @@ package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
-import com.back.common.exception.CustomException;
 import com.back.market.event.OrderCreatedEvent;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.OrderRepository;
@@ -15,7 +14,6 @@ import com.back.market.domain.enums.BiddingPosition;
 import com.back.market.domain.enums.BiddingStatus;
 import com.back.market.domain.enums.OrderStatus;
 import com.back.common.dto.cash.enums.PayAndHoldStatus;
-import com.back.common.dto.cash.enums.RelType;
 import com.back.market.dto.request.BiddingRequestDto;
 import com.back.common.dto.cash.request.PayAndHoldRequestDto;
 import com.back.common.dto.cash.response.PayAndHoldResponseDto;

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -2,6 +2,7 @@ package com.back.market.app.usecase;
 
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
+import com.back.common.exception.CustomException;
 import com.back.market.event.OrderCreatedEvent;
 import com.back.market.adapter.out.BiddingRepository;
 import com.back.market.adapter.out.OrderRepository;
@@ -103,7 +104,7 @@ public class MatchInstantTradeUseCase {
      */
     private MarketPaymentResponseDto executeTrade(Long userId, BiddingRequestDto requestDto, Bidding targetBid, BiddingPosition myPosition) {
         // 1. 자전거래 검증
-        if(Objects.equals(targetBid.getMarketUser().getId(), userId)){
+        if (Objects.equals(targetBid.getMarketUser().getId(), userId)) {
             throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
         }
 
@@ -149,104 +150,61 @@ public class MatchInstantTradeUseCase {
         }
 
         // 5. 실제 결제 요청(FeignClient 사용)
-        if(myPosition == BiddingPosition.BUY) {
+        PayAndHoldRequestDto paymentReq;
+        if (myPosition == BiddingPosition.BUY) {
             // Cash 호출
-            PayAndHoldRequestDto paymentReq = cashRequestMapper.toPayAndHoldRequestForOrder(savedOrder);
-            PayAndHoldResponseDto resultData = marketCashAdapter.getPayAndHoldResult(paymentReq);
+            paymentReq = cashRequestMapper.toPayAndHoldRequestForOrder(savedOrder);
+        } else {
+            paymentReq = cashRequestMapper.toPayAndHoldRequestForBidding(userId, requestDto.price(), myBid.getId());
+        }
+
+        // cash 모듈 호출부분 예외 처리
+        PayAndHoldResponseDto resultData;
+        try {
+            resultData = marketCashAdapter.getPayAndHoldResult(paymentReq);
 
             // 6. 결과 상태에 따른 주문 상태 업데이트
             if (resultData == null) {
                 log.error("[MatchInstantTrade] Cash 모듈이 null을 반환했습니다. 주문 취소 처리합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
-                // 보상: 주문/입찰 상태를 REQUIRES_NEW로 저장
-                if (!isOrderNew) {
-                    orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
-                } else {
-                    log.info("[MatchInstantTrade] 신규 주문이므로 REQUIRES_NEW로 주문 상태를 기록하지 않습니다. orderId={}", savedOrder.getId());
-                }
-
-                if (!isMyBidNew) {
-                    biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
-                } else {
-                    log.info("[MatchInstantTrade] 신규 구매 입찰이므로 REQUIRES_NEW로 구매자 입찰 상태를 기록하지 않습니다. buyBiddingId={}", myBid.getId());
-                }
-
-                // 판매자의 매물은 다시 판매중(PROCESS)으로 복원해야 함 (대상 입찰은 기존 엔티티임)
-                biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
-
-                // 메인 트랜잭션의 영속성 컨텍스트와 DB 상태 동기화
-                savedOrder.changeStatus(OrderStatus.CANCELLED_PAYMENT_FAILED);
-                myBid.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
-                targetBid.changeStatus(BiddingStatus.PROCESS);
-
                 throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
             }
+        } catch (Exception e) {
+            log.error("[MatchTrade] cash모듈 통신 중 에러 발생. 보상 로직 실행 - OrderId:{}, error: {}", savedOrder.getId(), e.getMessage(), e);
 
-            if (resultData.status() == PayAndHoldStatus.PAID) {
-                // 결제 완료 -> 주문 상태 변경
-                log.info("[MatchInstantTrade] 결제 완료 (PAID) - OrderId: {}", savedOrder.getId());
-                savedOrder.changeStatus(OrderStatus.PAID);
-
-                publishOrderCreatedEvent(savedOrder, BiddingPosition.BUY);
-            } else if (resultData.status() == PayAndHoldStatus.REQUIRES_PG) {
-                // PG 결제 필요 -> 주문은 대기 상태 유지 (HOLD)
-                // (Order 생성 시 기본값이 HOLD이므로 별도 상태 변경 불필요)
-                log.info("[MatchInstantTrade] PG 결제 필요 (REQUIRES_PG) - OrderId: {}, TossId: {}", savedOrder.getId(), resultData.tossOrderId());
-            } else {
-                // 기타 상태(실패 등) -> 주문/입찰 취소 및 보상 처리
-                log.warn("[MatchInstantTrade] 결제 실패 상태 감지 ({}). 주문/입찰을 취소합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", resultData.status(), savedOrder.getId(), myBid.getId(), targetBid.getId());
-                if (!isOrderNew) {
-                    orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
-                } else {
-                    log.info("[MatchInstantTrade] 신규 주문이므로 REQUIRES_NEW로 주문 상태를 기록하지 않습니다. orderId={}", savedOrder.getId());
-                }
-
-                if (!isMyBidNew) {
-                    biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
-                } else {
-                    log.info("[MatchInstantTrade] 신규 구매 입찰이므로 REQUIRES_NEW로 구매자 입찰 상태를 기록하지 않습니다. buyBiddingId={}", myBid.getId());
-                }
-
-                // 판매자의 매물은 기존 엔티티이므로 반드시 복원
-                biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
-
-                // 메인 트랜잭션의 영속성 컨텍스트와 DB 상태 동기화
-                savedOrder.changeStatus(OrderStatus.CANCELLED_PAYMENT_FAILED);
-                myBid.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
-                targetBid.changeStatus(BiddingStatus.PROCESS);
-
-                // 메인 트랜잭션을 롤백시켜 영속성 컨텍스트가 DB에 오래된 상태를 덮어쓰는 것을 방지
-                throw new BadRequestException(FailureCode.PAYMENT_CONFIRM_FAILED);
-            }
-
-            return MarketPaymentResponseDto.from(
-                    resultData,
-                    targetBid.getMarketProduct().getName(), // 상품명
-                    me.getName(),                       // 구매자 이름
-                    me.getEmail()                           // 구매자 이메일
-            );
-        } else {
-            // 내가 판매자라면 홀딩할 필요가 없음(이미 구매자가 홀딩한 금액 존재)
-            log.info("[MatchTrade] 즉시 판매 체결 (결제 불필요) - OrderId: {}", savedOrder.getId());
-            savedOrder.changeStatus(OrderStatus.PAID);
-
-            publishOrderCreatedEvent(savedOrder, BiddingPosition.SELL);
-
-            PayAndHoldResponseDto cashResponse = PayAndHoldResponseDto.of(
-                    PayAndHoldStatus.PAID,
-                    RelType.ORDER,
-                    savedOrder.getId(),
-                    BigDecimal.ZERO,
-                    BigDecimal.ZERO,
-                    null
-            );
-
-            return MarketPaymentResponseDto.from(
-                    cashResponse,
-                    targetBid.getMarketProduct().getName(),
-                    me.getName(),
-                    me.getEmail()
-            );
+            //공통 보상 로직 실행
+            handleCompensation(targetBid, myBid, savedOrder, isOrderNew, isMyBidNew);
+            throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
         }
+
+        if (resultData.status() == PayAndHoldStatus.PAID) {
+            savedOrder.changeStatus(OrderStatus.PAID);
+            publishOrderCreatedEvent(savedOrder, myPosition);
+        } else if (resultData.status() == PayAndHoldStatus.REQUIRES_PG) {
+            log.info("[MatchInstantTrade] Cash 모듈이 결제 대기 상태(REQUIRES_PG)를 반환했습니다. 주문 상태를 PAID로 변경하지 않습니다. orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
+        } else {
+            log.warn("[MatchTrade] 결제 거절됨 ({}). 보상 로직 실행", resultData.status());
+            handleCompensation(targetBid, myBid, savedOrder, isOrderNew, isMyBidNew);
+            throw new BadRequestException(FailureCode.PAYMENT_CONFIRM_FAILED);
+        }
+        return MarketPaymentResponseDto.from(resultData, targetBid.getMarketProduct().getName(), me.getName(), me.getEmail());
+    }
+
+    private void handleCompensation(Bidding targetBid, Bidding myBid, Order savedOrder, boolean isOrderNew, boolean isMyBidNew) {
+        // 판매 입찰 원상복구(process로)
+        biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
+        targetBid.changeStatus(BiddingStatus.PROCESS);
+
+        // 구매 입찰(mybid) 원상복구
+        if(!isMyBidNew) {
+            biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+        }
+        myBid.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+
+        // 주문 원상복구
+        if(!isOrderNew) {
+            orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
+        }
+        savedOrder.changeStatus(OrderStatus.CANCELLED_PAYMENT_FAILED);
     }
 
     // 반복되는 입찰 생성 로직을 메서드로 분리

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -110,6 +110,8 @@ public class MatchInstantTradeUseCase {
         MarketUser me = marketSupport.findMarketUserById(userId);
         Order savedOrder;
         Bidding myBid;
+        boolean isOrderNew = false;
+        boolean isMyBidNew = false;
 
         if (myPosition == BiddingPosition.BUY) {
             try {
@@ -129,8 +131,10 @@ public class MatchInstantTradeUseCase {
                 if (e.getFailureCode() == FailureCode.ORDER_NOT_FOUND) {
                     log.info("[MatchTrade] 신규 주문 생성 - SellBiddingId: {}", targetBid.getId());
                     myBid = createAndSaveNewBidding(requestDto, me, targetBid, myPosition);
+                    isMyBidNew = true;
                     targetBid.changeStatus(BiddingStatus.MATCHED);
                     savedOrder = orderRepository.save(orderMapper.toEntity(myBid, targetBid, me.getAddress()));
+                    isOrderNew = true;
                 } else {
                     throw e;
                 }
@@ -138,8 +142,10 @@ public class MatchInstantTradeUseCase {
         } else {
             //즉시 판매 로직
             myBid = createAndSaveNewBidding(requestDto, me, targetBid, myPosition);
+            isMyBidNew = true;
             targetBid.changeStatus(BiddingStatus.MATCHED);
             savedOrder = orderRepository.save(orderMapper.toEntity(targetBid, myBid, targetBid.getMarketUser().getAddress()));
+            isOrderNew = true;
         }
 
         // 5. 실제 결제 요청(FeignClient 사용)
@@ -152,9 +158,19 @@ public class MatchInstantTradeUseCase {
             if (resultData == null) {
                 log.error("[MatchInstantTrade] Cash 모듈이 null을 반환했습니다. 주문 취소 처리합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
                 // 보상: 주문/입찰 상태를 REQUIRES_NEW로 저장
-                orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
-                biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
-                // 판매자의 매물은 다시 판매중(PROCESS)으로 복원해야 함
+                if (!isOrderNew) {
+                    orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
+                } else {
+                    log.info("[MatchInstantTrade] 신규 주문이므로 REQUIRES_NEW로 주문 상태를 기록하지 않습니다. orderId={}", savedOrder.getId());
+                }
+
+                if (!isMyBidNew) {
+                    biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                } else {
+                    log.info("[MatchInstantTrade] 신규 구매 입찰이므로 REQUIRES_NEW로 구매자 입찰 상태를 기록하지 않습니다. buyBiddingId={}", myBid.getId());
+                }
+
+                // 판매자의 매물은 다시 판매중(PROCESS)으로 복원해야 함 (대상 입찰은 기존 엔티티임)
                 biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
 
                 // 메인 트랜잭션의 영속성 컨텍스트와 DB 상태 동기화
@@ -178,9 +194,19 @@ public class MatchInstantTradeUseCase {
             } else {
                 // 기타 상태(실패 등) -> 주문/입찰 취소 및 보상 처리
                 log.warn("[MatchInstantTrade] 결제 실패 상태 감지 ({}). 주문/입찰을 취소합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", resultData.status(), savedOrder.getId(), myBid.getId(), targetBid.getId());
-                // 주문 및 구매자 입찰만 실패로 기록; 판매자의 매물은 다시 판매중으로 복원
-                orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
-                biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                if (!isOrderNew) {
+                    orderStatusService.markStatusInNewTx(savedOrder.getId(), OrderStatus.CANCELLED_PAYMENT_FAILED);
+                } else {
+                    log.info("[MatchInstantTrade] 신규 주문이므로 REQUIRES_NEW로 주문 상태를 기록하지 않습니다. orderId={}", savedOrder.getId());
+                }
+
+                if (!isMyBidNew) {
+                    biddingStatusService.markStatusInNewTx(myBid.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                } else {
+                    log.info("[MatchInstantTrade] 신규 구매 입찰이므로 REQUIRES_NEW로 구매자 입찰 상태를 기록하지 않습니다. buyBiddingId={}", myBid.getId());
+                }
+
+                // 판매자의 매물은 기존 엔티티이므로 반드시 복원
                 biddingStatusService.markStatusInNewTx(targetBid.getId(), BiddingStatus.PROCESS);
 
                 // 메인 트랜잭션의 영속성 컨텍스트와 DB 상태 동기화

--- a/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/MatchInstantTradeUseCase.java
@@ -101,10 +101,11 @@ public class MatchInstantTradeUseCase {
      * </p>
      */
     private MarketPaymentResponseDto executeTrade(Long userId, BiddingRequestDto requestDto, Bidding targetBid, BiddingPosition myPosition) {
-        // 1. 자전거래 검증
-        if (Objects.equals(targetBid.getMarketUser().getId(), userId)) {
-            throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
-        }
+        log.info("[MatchInstantTrade] executeTrade 시작 - userId={}, productId={}, targetBidId={}, myPosition={}", userId, requestDto.productId(), targetBid.getId(), myPosition);
+         // 1. 자전거래 검증
+         if (Objects.equals(targetBid.getMarketUser().getId(), userId)) {
+             throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
+         }
 
         MarketUser me = marketSupport.findMarketUserById(userId);
         Order savedOrder;
@@ -159,20 +160,24 @@ public class MatchInstantTradeUseCase {
         // cash 모듈 호출부분 예외 처리
         PayAndHoldResponseDto resultData;
         try {
+            log.info("[MatchInstantTrade] calling cash module - orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
             resultData = marketCashAdapter.getPayAndHoldResult(paymentReq);
 
-            // 6. 결과 상태에 따른 주문 상태 업데이트
-            if (resultData == null) {
-                log.error("[MatchInstantTrade] Cash 모듈이 null을 반환했습니다. 주문 취소 처리합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
-                throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
-            }
-        } catch (Exception e) {
+            log.info("[MatchInstantTrade] cash module returned - orderId={}, status={}, relId={}", savedOrder.getId(), resultData == null ? null : resultData.status(), resultData == null ? null : resultData.relId());
+             // 6. 결과 상태에 따른 주문 상태 업데이트
+             if (resultData == null) {
+                 log.error("[MatchInstantTrade] Cash 모듈이 null을 반환했습니다. 주문 취소 처리합니다. orderId={}, buyBiddingId={}, sellBiddingId={}", savedOrder.getId(), myBid.getId(), targetBid.getId());
+                 throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+             }
+         } catch (Exception e) {
             log.error("[MatchTrade] cash모듈 통신 중 에러 발생. 보상 로직 실행 - OrderId:{}, error: {}", savedOrder.getId(), e.getMessage(), e);
 
-            //공통 보상 로직 실행
-            handleCompensation(targetBid, myBid, savedOrder, isOrderNew, isMyBidNew);
-            throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
-        }
+             //공통 보상 로직 실행
+            log.info("[MatchInstantTrade] 보상 로직 시작 - orderId={}, sellBiddingId={}, buyBiddingId={}, isOrderNew={}, isMyBidNew={}", savedOrder.getId(), targetBid.getId(), myBid.getId(), isOrderNew, isMyBidNew);
+             handleCompensation(targetBid, myBid, savedOrder, isOrderNew, isMyBidNew);
+            log.info("[MatchInstantTrade] 보상 로직 완료 - orderId={}, sellBiddingId={}, buyBiddingId={}", savedOrder.getId(), targetBid.getId(), myBid.getId());
+             throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+         }
 
         if (resultData.status() == PayAndHoldStatus.PAID) {
             savedOrder.changeStatus(OrderStatus.PAID);
@@ -184,8 +189,9 @@ public class MatchInstantTradeUseCase {
             handleCompensation(targetBid, myBid, savedOrder, isOrderNew, isMyBidNew);
             throw new BadRequestException(FailureCode.PAYMENT_CONFIRM_FAILED);
         }
-        return MarketPaymentResponseDto.from(resultData, targetBid.getMarketProduct().getName(), me.getName(), me.getEmail());
-    }
+        log.info("[MatchInstantTrade] executeTrade 완료 - orderId={}, resultStatus={}", savedOrder.getId(), resultData.status());
+         return MarketPaymentResponseDto.from(resultData, targetBid.getMarketProduct().getName(), me.getName(), me.getEmail());
+     }
 
     private void handleCompensation(Bidding targetBid, Bidding myBid, Order savedOrder, boolean isOrderNew, boolean isMyBidNew) {
         // 판매 입찰 원상복구(process로)

--- a/market/src/main/java/com/back/market/app/usecase/OrderStatusService.java
+++ b/market/src/main/java/com/back/market/app/usecase/OrderStatusService.java
@@ -1,0 +1,27 @@
+package com.back.market.app.usecase;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.BadRequestException;
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.domain.Order;
+import com.back.market.domain.enums.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderStatusService {
+    private final OrderRepository orderRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markStatusInNewTx(Long orderId, OrderStatus status) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+
+        order.changeStatus(status);
+        orderRepository.save(order);
+    }
+}
+

--- a/market/src/main/java/com/back/market/app/usecase/OrderStatusService.java
+++ b/market/src/main/java/com/back/market/app/usecase/OrderStatusService.java
@@ -6,22 +6,30 @@ import com.back.market.adapter.out.OrderRepository;
 import com.back.market.domain.Order;
 import com.back.market.domain.enums.OrderStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OrderStatusService {
     private final OrderRepository orderRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markStatusInNewTx(Long orderId, OrderStatus status) {
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
+        log.info("[OrderStatusService] markStatusInNewTx 시작 - orderId={}, newStatus={}", orderId, status);
+        try {
+            Order order = orderRepository.findById(orderId)
+                    .orElseThrow(() -> new BadRequestException(FailureCode.ORDER_NOT_FOUND));
 
-        order.changeStatus(status);
-        orderRepository.save(order);
+            order.changeStatus(status);
+            orderRepository.save(order);
+            log.info("[OrderStatusService] markStatusInNewTx 커밋됨 - orderId={}, newStatus={}", orderId, status);
+        } catch (Exception e) {
+            log.error("[OrderStatusService] markStatusInNewTx 실패 - orderId={}, newStatus={}, error={}", orderId, status, e.getMessage(), e);
+            throw e;
+        }
     }
 }
-

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * 구매/판매입찰 등록 비즈니스 로직
@@ -40,6 +41,7 @@ public class RegisterBidUseCase {
     private final MarketCashAdapter marketCashAdapter;
     private final MarketSupport marketSupport;
     private final ApplicationEventPublisher eventPublisher;
+    private final BiddingStatusService biddingStatusService;
 
     /**
      * MARKET-010: 구매 입찰 등록
@@ -76,17 +78,32 @@ public class RegisterBidUseCase {
         try {
             responseData = marketCashAdapter.getPayAndHoldResult(cashRequest);
 
+            // null 체크 추가: cash 어댑터가 null을 반환할 수 있으므로 방어적으로 처리
+            if (responseData == null) {
+                // 상태 변경을 새로운 트랜잭션에서 확실히 저장
+                biddingStatusService.markStatusInNewTx(savedBidding.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                log.error("[RegisterBuyBid] Cash 모듈이 null 응답을 반환했습니다. biddingId={}, productId={}, userId={}, price={}",
+                        savedBidding.getId(), product.getId(), userId, requestDto.price());
+                throw new BadRequestException(FailureCode.CASH_MODULE_ERROR);
+            }
+
             if (responseData.status() == PayAndHoldStatus.PAID) {
                 savedBidding.changeStatus(BiddingStatus.PROCESS);
-                log.info("[RegisterBuyBid] 예치금 홀딩 & 입찰 등록 완료 (HOLD->PROCESS) - BiddingId: {}", savedBidding.getId());
+                log.info("[RegisterBuyBid] 예치금 홀딩 & 입찰 등록 완료 (HOLD->PROCESS) - biddingId={}, productId={}, userId={}, price={}, relId={}",
+                        savedBidding.getId(), product.getId(), userId, requestDto.price(), responseData.relId());
             } else if (responseData.status() == PayAndHoldStatus.REQUIRES_PG) {
-                log.info("[RegisterBuyBid] PG 결제 필요, HOLD 상태 유지- relId: {}", responseData.relId());
+                log.info("[RegisterBuyBid] PG 결제 필요, HOLD 상태 유지 - biddingId={}, productId={}, userId={}, price={}, relId={}",
+                        savedBidding.getId(), product.getId(), userId, requestDto.price(), responseData.relId());
             } else {
-                savedBidding.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                // 결제 실패 상태를 별도 트랜잭션으로 확실히 저장
+                biddingStatusService.markStatusInNewTx(savedBidding.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
+                log.warn("[RegisterBuyBid] 결제 상태가 실패로 확인되어 입찰을 취소합니다. biddingId={}, productId={}, userId={}, price={}, payStatus={}",
+                        savedBidding.getId(), product.getId(), userId, requestDto.price(), responseData.status());
             }
         } catch (Exception e) {
-            log.error("[RegisterBuyBid] Cash 모듈 호출 중 에러 발생. 입찰을 FAIL 처리합니다. BiddingId: {}, Error: {}", savedBidding.getId(), e.getMessage(), e);
-            savedBidding.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+            log.error("[RegisterBuyBid] Cash 모듈 호출 중 에러 발생. 입찰을 FAIL 처리합니다. biddingId={}, productId={}, userId={}, price={}, error={}",
+                    savedBidding.getId(), product.getId(), userId, requestDto.price(), e.getMessage(), e);
+            biddingStatusService.markStatusInNewTx(savedBidding.getId(), BiddingStatus.CANCELLED_PAYMENT_FAILED);
             throw e;
         }
 
@@ -167,10 +184,14 @@ public class RegisterBidUseCase {
         ).ifPresent(minSellingBid -> {
             if(requestDto.price().compareTo(minSellingBid.getPrice()) >= 0) {
                 // 본인이 올린 상품의 거래를 막음
-                if (minSellingBid.getMarketUser().getId().equals(userId)) {
+                if (Objects.equals(minSellingBid.getMarketUser().getId(), userId)) {
+                    log.warn("[checkBuyPricePolicy] self trading detected. productId={}, userId={}, minSellingBidId={}, price={}, minPrice={}",
+                            requestDto.productId(), userId, minSellingBid.getId(), requestDto.price(), minSellingBid.getPrice());
                     throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
                 }
 
+                log.warn("[checkBuyPricePolicy] invalid buy price. productId={}, userId={}, price={}, minSellingPrice={}",
+                        requestDto.productId(), userId, requestDto.price(), minSellingBid.getPrice());
                 throw new BadRequestException(FailureCode.INVALID_BID_PRICE_BUY);
             }
         });
@@ -189,10 +210,14 @@ public class RegisterBidUseCase {
         ).ifPresent(maxBuyingBid -> {
             if(requestDto.price().compareTo(maxBuyingBid.getPrice()) <= 0) {
                 // 본인이 올린 상품의 거래를 막음
-                if (maxBuyingBid.getMarketUser().getId().equals(userId)) {
+                if (Objects.equals(maxBuyingBid.getMarketUser().getId(), userId)) {
+                    log.warn("[checkSellPricePolicy] self trading detected. productId={}, userId={}, maxBuyingBidId={}, price={}, maxPrice={}",
+                            requestDto.productId(), userId, maxBuyingBid.getId(), requestDto.price(), maxBuyingBid.getPrice());
                     throw new BadRequestException(FailureCode.SELF_TRADING_NOT_ALLOWED);
                 }
 
+                log.warn("[checkSellPricePolicy] invalid sell price. productId={}, userId={}, price={}, maxBuyingPrice={}",
+                        requestDto.productId(), userId, requestDto.price(), maxBuyingBid.getPrice());
                 throw new BadRequestException(FailureCode.INVALID_BID_PRICE_SELL);
             }
         });
@@ -217,3 +242,4 @@ public class RegisterBidUseCase {
      */
     private record UserProduct(MarketUser user, MarketProduct product) {}
 }
+

--- a/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
+++ b/market/src/main/java/com/back/market/app/usecase/RegisterBidUseCase.java
@@ -72,13 +72,22 @@ public class RegisterBidUseCase {
         );
 
         //요청에 따른 결과 수신
-        PayAndHoldResponseDto responseData = marketCashAdapter.getPayAndHoldResult(cashRequest);
+        PayAndHoldResponseDto responseData;
+        try {
+            responseData = marketCashAdapter.getPayAndHoldResult(cashRequest);
 
-        if (responseData.status() == PayAndHoldStatus.PAID) {
-            savedBidding.changeStatus(BiddingStatus.PROCESS);
-            log.info("[RegisterBid] 예치금 홀딩 & 입찰 등록 완료 (HOLD->PROCESS) - BiddingId: {}", savedBidding.getId());
-        } else if (responseData.status() == PayAndHoldStatus.REQUIRES_PG) {
-            log.info("[RegisterBid] PG 결제 필요, HOLD 상태 유지- relId: {}", responseData.relId());
+            if (responseData.status() == PayAndHoldStatus.PAID) {
+                savedBidding.changeStatus(BiddingStatus.PROCESS);
+                log.info("[RegisterBuyBid] 예치금 홀딩 & 입찰 등록 완료 (HOLD->PROCESS) - BiddingId: {}", savedBidding.getId());
+            } else if (responseData.status() == PayAndHoldStatus.REQUIRES_PG) {
+                log.info("[RegisterBuyBid] PG 결제 필요, HOLD 상태 유지- relId: {}", responseData.relId());
+            } else {
+                savedBidding.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+            }
+        } catch (Exception e) {
+            log.error("[RegisterBuyBid] Cash 모듈 호출 중 에러 발생. 입찰을 FAIL 처리합니다. BiddingId: {}, Error: {}", savedBidding.getId(), e.getMessage(), e);
+            savedBidding.changeStatus(BiddingStatus.CANCELLED_PAYMENT_FAILED);
+            throw e;
         }
 
         return MarketPaymentResponseDto.from(

--- a/market/src/main/java/com/back/market/domain/enums/OrderStatus.java
+++ b/market/src/main/java/com/back/market/domain/enums/OrderStatus.java
@@ -5,6 +5,7 @@ public enum OrderStatus {
     HOLD,        // 결제 대기 (낙찰 직후)
     PAID,        // 결제 완료 (거래 성사)
     CANCELLED,   // 주문 취소(결제 후, 배송 전까지만 가능)
+    CANCELLED_PAYMENT_FAILED,
     DELIVERY_PROCESSING,    // 배송중
     DELIVERY_COMPLETED, // 배송 완료(환불 요청은 배송 완료일로부터 일주일까지 가능)
     REFUNDED, // 주문 환불(배송중~배송완료 후 1주까지는 환불가능)

--- a/market/src/test/java/com/back/market/MarketDetectorAdapterServerErrorIgnoredTests.java
+++ b/market/src/test/java/com/back/market/MarketDetectorAdapterServerErrorIgnoredTests.java
@@ -1,0 +1,64 @@
+package com.back.market;
+
+import com.back.market.adapter.out.detector.DetectorClient;
+import com.back.market.adapter.out.detector.MarketDetectorAdapter;
+import feign.FeignException;
+import feign.Request;
+import feign.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class MarketDetectorAdapterServerErrorIgnoredTests {
+
+    private static final Logger log = LoggerFactory.getLogger(MarketDetectorAdapterServerErrorIgnoredTests.class);
+
+    @Autowired
+    private MarketDetectorAdapter marketDetectorAdapter;
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        @Primary
+        public DetectorClient detectorClient() {
+            return new DetectorClient() {
+                @Override
+                public void detectBidSpam(Long userId) {
+                    Response response = Response.builder()
+                            .status(500)
+                            .reason("Internal Server Error")
+                            .request(Request.create(Request.HttpMethod.POST, "/api/v1/internal/detects/bid-spam/" + userId, Collections.emptyMap(), null, Charset.defaultCharset(), null))
+                            .build();
+                    throw FeignException.errorStatus("detectBidSpam", response);
+                }
+
+                @Override
+                public void detectHijack(com.back.market.adapter.out.detector.dto.request.DetectHijackRequestDto requestDto) {
+                    // no-op
+                }
+            };
+        }
+    }
+
+    @Test
+    @DisplayName("Detector 서비스에서 500 에러가 발생하면 MarketDetectorAdapter는 예외를 흡수하고 정상 리턴한다 (서비스 장애 허용)")
+    void detectBidSpam_500_isIgnored() {
+        // 호출 시 예외를 흡수하고 종료되어야 함 (탐지 장애 시 입찰 허용)
+        Assertions.assertDoesNotThrow(() -> marketDetectorAdapter.detectBidSpam(456L));
+        log.info("Test: Detector 500 error ignored as expected for userId={}", 456L);
+        assertThat(true).isTrue();
+    }
+}

--- a/market/src/test/java/com/back/market/MarketDetectorAdapterTooManyRequestsTests.java
+++ b/market/src/test/java/com/back/market/MarketDetectorAdapterTooManyRequestsTests.java
@@ -1,0 +1,67 @@
+package com.back.market;
+
+import com.back.common.code.FailureCode;
+import com.back.common.exception.CustomException;
+import com.back.market.adapter.out.detector.DetectorClient;
+import com.back.market.adapter.out.detector.MarketDetectorAdapter;
+import feign.FeignException;
+import feign.Request;
+import feign.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class MarketDetectorAdapterTooManyRequestsTests {
+
+    private static final Logger log = LoggerFactory.getLogger(MarketDetectorAdapterTooManyRequestsTests.class);
+
+    @Autowired
+    private MarketDetectorAdapter marketDetectorAdapter;
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        @Primary
+        public DetectorClient detectorClient() {
+            return new DetectorClient() {
+                @Override
+                public void detectBidSpam(Long userId) {
+                    // 만들어낼 FeignException(429)
+                    Response response = Response.builder()
+                            .status(429)
+                            .reason("Too Many Requests")
+                            .request(Request.create(Request.HttpMethod.POST, "/api/v1/internal/detects/bid-spam/" + userId, Collections.emptyMap(), null, Charset.defaultCharset(), null))
+                            .build();
+                    throw FeignException.errorStatus("detectBidSpam", response);
+                }
+
+                @Override
+                public void detectHijack(com.back.market.adapter.out.detector.dto.request.DetectHijackRequestDto requestDto) {
+                    // no-op
+                }
+            };
+        }
+    }
+
+    @Test
+    @DisplayName("Detector(입찰탐지)가 429(Too Many Requests)를 반환하면 입찰 차단 예외(BID_SPAM_DETECTED)를 던진다")
+    void detectBidSpam_429_throwsCustomException() {
+        CustomException ex = assertThrows(CustomException.class, () -> marketDetectorAdapter.detectBidSpam(123L));
+        // 로그로 예외 상태 출력
+        log.info("Test caught CustomException - failureCode={}, message={}", ex.getFailureCode(), ex.getMessage(), ex);
+        // 내부 FailureCode 검증
+        assert ex.getFailureCode() == FailureCode.BID_SPAM_DETECTED;
+    }
+}

--- a/market/src/test/java/com/back/market/MatchInstantTradeCashTimeoutAndNullResponseTests.java
+++ b/market/src/test/java/com/back/market/MatchInstantTradeCashTimeoutAndNullResponseTests.java
@@ -1,0 +1,132 @@
+package com.back.market;
+
+import com.back.common.response.CommonResponse;
+import com.back.common.dto.cash.request.PayAndHoldRequestDto;
+import com.back.common.dto.cash.response.PayAndHoldResponseDto;
+import com.back.market.adapter.out.BiddingRepository;
+import com.back.market.adapter.out.MarketProductRepository;
+import com.back.market.adapter.out.MarketUserRepository;
+import com.back.market.adapter.out.OrderRepository;
+import com.back.market.adapter.out.cash.CashClient;
+import com.back.market.app.usecase.MatchInstantTradeUseCase;
+import com.back.market.domain.Bidding;
+import com.back.market.domain.MarketProduct;
+import com.back.market.domain.MarketUser;
+import com.back.market.mapper.BiddingMapper;
+import com.back.market.mapper.MarketProductMapper;
+import com.back.market.mapper.MarketUserMapper;
+import com.back.market.dto.request.BiddingRequestDto;
+import com.back.market.domain.enums.BiddingPosition;
+import com.back.market.domain.enums.BiddingStatus;
+import com.back.common.code.SuccessCode;
+import com.back.common.dto.cash.response.PaymentCancelResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class MatchInstantTradeCashTimeoutAndNullResponseTests {
+
+    private static final Logger log = LoggerFactory.getLogger(MatchInstantTradeCashTimeoutAndNullResponseTests.class);
+
+    @Autowired
+    private MatchInstantTradeUseCase matchInstantTradeUseCase;
+    @Autowired private BiddingRepository biddingRepository;
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private BiddingMapper biddingMapper;
+    @Autowired private MarketProductMapper marketProductMapper;
+    @Autowired private MarketUserMapper marketUserMapper;
+    @Autowired private MarketUserRepository marketUserRepository;
+    @Autowired private MarketProductRepository marketProductRepository;
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        @Primary
+        public CashClient cashClient() {
+            return new CashClient() {
+                @Override
+                public CommonResponse<PayAndHoldResponseDto> requestBidHold(PayAndHoldRequestDto requestDto) {
+                    // 시뮬레이션: null 응답 처리 테스트
+                    return null;
+                }
+
+                @Override
+                public CommonResponse<PaymentCancelResponseDto> refundBidHold(com.back.common.dto.cash.request.PaymentCancelRequestDto requestDto) {
+                    // 보상에서 호출될 수 있으므로 정상 응답을 반환
+                    return CommonResponse.success(SuccessCode.OK, new PaymentCancelResponseDto(requestDto.userId(), java.math.BigDecimal.ZERO));
+                }
+            };
+        }
+    }
+
+    @Test
+    @DisplayName("Cash 모듈이 null 응답을 반환하면 예외가 발생하고 REQUIRES_NEW 보상으로 판매 입찰이 PROCESS로 복구되어야 한다")
+    void cash_null_response_triggers_compensation() {
+        // Given
+        Long productId = 888L;
+        Long sellerId = 77L;
+        Long buyerId = 78L;
+        setupBaseData(productId, sellerId, buyerId, "서울");
+        Bidding sellBid = createBidding(productId, sellerId, 7000, BiddingPosition.SELL);
+
+        BiddingRequestDto request = new BiddingRequestDto(productId, BigDecimal.valueOf(7000), "270");
+
+        // When
+        Exception ex = assertThrows(Exception.class, () -> {
+            matchInstantTradeUseCase.buyNow(buyerId, request);
+        });
+
+        // 로그 출력: 예외 및 인자
+        log.error("Test: caught exception during buyNow: {}", ex.toString(), ex);
+
+        // Then: 입찰 상태가 PROCESS로 복구되어야 함
+        Bidding found = biddingRepository.findById(sellBid.getId()).orElseThrow();
+        log.info("Test: sellBid id={}, status after compensation={}", sellBid.getId(), found.getStatus());
+        assertThat(found.getStatus()).isEqualTo(BiddingStatus.PROCESS);
+    }
+
+    // Helper methods
+    private void setupBaseData(Long productId, Long sellerId, Long buyerId, String buyerAddress) {
+        MarketUser seller = marketUserMapper.toEntity(sellerId,"seller", "s@t.com", "판매자주소", "010-1234-5678");
+        marketUserRepository.save(seller);
+
+        MarketUser buyer = marketUserMapper.toEntity(buyerId,"buyer", "b@t.com", buyerAddress, "010-1234-5678");
+        marketUserRepository.save(buyer);
+
+        if (!marketProductRepository.existsById(productId)) {
+            marketProductRepository.save(marketProductMapper.toEntity(
+                    productId,
+                    1L,           // productInfoId (원본 정보 ID - 테스트용 임의 값)
+                    "Nike",       // brandName
+                    "신발",        // name
+                    "N1",         // productNumber
+                    "270",        // productOption (사이즈)
+                    BigDecimal.valueOf(100000L),      // price
+                    "카테고리",     // categoryName
+                    "img"
+            ));
+        }
+    }
+
+    private Bidding createBidding(Long productId, Long userId, long price, BiddingPosition position) {
+        MarketProduct product = marketProductRepository.findById(productId).orElseThrow();
+        MarketUser user = marketUserRepository.findById(userId).orElseThrow();
+        BiddingRequestDto requestDto = BiddingRequestDto.of(productId, BigDecimal.valueOf(price), "270");
+        Bidding bidding = biddingMapper.toEntity(requestDto, user, product, position);
+        bidding.changeStatus(BiddingStatus.PROCESS);
+        return biddingRepository.save(bidding);
+    }
+}
+

--- a/market/src/test/java/com/back/market/event/PaymentResultEventTests.java
+++ b/market/src/test/java/com/back/market/event/PaymentResultEventTests.java
@@ -90,9 +90,9 @@ public class PaymentResultEventTests {
         Thread.sleep(3000);
 
         // 3. Then (검증)
-        // 주문 상태 검증 - 상태가 HOLD -> CANCELLED(취소)로 잘 바뀌었는지 확인
+        // 주문 상태 검증 - 상태가 HOLD -> CANCELLED_PAYMENT_FAILED(취소)로 잘 바뀌었는지 확인
         Order updatedOrder = marketSupport.findOrderById(testOrderId);
-        assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.CANCELLED_PAYMENT_FAILED);
 
         // 구매 입찰 상태 검증 (CANCELLED_PAYMENT_FAILED)
         Bidding buyBid = marketSupport.findBiddingById(updatedOrder.getBuyBidding().getId());


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #366 

## 🔎 작업 내용

- 구매입찰 등록 중 결제 실패시 bidding 상태가 hold로 처리되는 로직 수정
- cash 모듈 응답 실패로 주문에 실패하는 경우 해당 주문을 재사용 가능하게끔 추가
- detector 모듈 응답 지연에 대한 타임아웃 적용(detector 호출을 건너뜀)
- cash 모듈 응답 지연에 대한 타임아웃 적용(에러 처리, 입찰or구매가 진행되면 안됨)
- yml에 타임아웃 관련 설정을 추가
```yml
feign:
  client:
    config:
      default: # 모든 feignclient 기본값
        connectTimeout: 2000
        readTimeout: 3000
      cash-client: # cash feignclient 별도 설정
        connectTimeout: 2000
        readTimeout: 5000
      detector-client: # detector feignclient 별도 설정
        connectTimeout: 1000
        readTimeout: 1500
  cash:
    url: http://localhost:8081
  detector:
    url: http://localhost:8088
```

## 테스트 결과

- 동기 통신에서의 보상 트랜잭션(saga 패턴) 테스트
  <img width="1455" height="497" alt="image" src="https://github.com/user-attachments/assets/3153450d-2700-48a7-8584-73fe7ad0e24d" />
- 입찰 스팸이 감지된 경우 입찰 제한 에러가 잘 발생하는지 테스트
  <img width="1457" height="276" alt="image" src="https://github.com/user-attachments/assets/9d25112a-821e-427c-b76e-6c017afdab44" />
- detector 모듈에서 500 에러 반환하는경우 ignore하는지 테스트
  <img width="1457" height="404" alt="image" src="https://github.com/user-attachments/assets/fb231e2e-a45d-4959-a644-b1bcdb4276c0" />




---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
