### PR TITLE
[FIX] 정산 지급 Kafka 메시지 필드명 불일치 수정 (#375)

### DIFF
--- a/settlement/src/main/java/com/back/settlement/app/event/payload/PayoutRequestPayload.java
+++ b/settlement/src/main/java/com/back/settlement/app/event/payload/PayoutRequestPayload.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public record PayoutRequestPayload(
         Long settlementId,
         Long payeeId,
-        BigDecimal totalSalesAmount,
+        BigDecimal totalGrossAmount,
         BigDecimal totalFeeAmount,
         BigDecimal totalNetAmount,
         LocalDateTime occurredAt


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #375 

## 🔎 작업 내용

- `PayoutRequestPayload.totalSalesAmount` → `totalGrossAmount`로 변경하여 Cash 모듈의 `CashPayoutRequestedPayload`와 필드명 일치

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
