### PR TITLE
[FIX] Feign 응답 역직렬화 실패로 인한 productDetail null 문제 로그 추가 (#377)

### DIFF
--- a/common/src/main/java/com/back/common/event/FeignResponse.java
+++ b/common/src/main/java/com/back/common/event/FeignResponse.java
@@ -1,0 +1,13 @@
+package com.back.common.event;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeignResponse<T> {
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+}

--- a/notification/src/main/java/com/back/notification/adapter/out/feign/product/ProductFeignClient.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/feign/product/ProductFeignClient.java
@@ -1,6 +1,6 @@
 package com.back.notification.adapter.out.feign.product;
 
-import com.back.common.event.FeignResponse;
+import com.back.common.response.CommonResponse;
 import com.back.notification.adapter.out.feign.product.dto.ProductDetailListResponse;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ProductFeignClient {
 
     @GetExchange("/api/v1/products/variants")
-    FeignResponse<ProductDetailListResponse> getProducts(@RequestParam("productIds") List<Long> productIds);
+    CommonResponse<ProductDetailListResponse> getProducts(@RequestParam("productIds") List<Long> productIds);
 }

--- a/notification/src/main/java/com/back/notification/adapter/out/feign/product/ProductFeignClient.java
+++ b/notification/src/main/java/com/back/notification/adapter/out/feign/product/ProductFeignClient.java
@@ -1,6 +1,6 @@
 package com.back.notification.adapter.out.feign.product;
 
-import com.back.common.response.CommonResponse;
+import com.back.common.event.FeignResponse;
 import com.back.notification.adapter.out.feign.product.dto.ProductDetailListResponse;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ProductFeignClient {
 
     @GetExchange("/api/v1/products/variants")
-    CommonResponse<ProductDetailListResponse> getProducts(@RequestParam("productIds") List<Long> productIds);
+    FeignResponse<ProductDetailListResponse> getProducts(@RequestParam("productIds") List<Long> productIds);
 }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
@@ -9,6 +9,7 @@ import com.back.notification.dto.response.PriceAlertIdDto;
 import com.back.notification.dto.response.PriceAlertResponseDto;
 import com.back.notification.mapper.PriceAlertMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PriceAlertFacade {
@@ -70,6 +72,7 @@ public class PriceAlertFacade {
                             (existing, replacement) -> existing
                     ));
         } catch (Exception e) {
+            log.error("[PriceAlert] product-service Feign 호출 실패: {}", e.getMessage(), e);
             return Collections.emptyMap();
         }
     }

--- a/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
+++ b/notification/src/main/java/com/back/notification/app/pricealert/PriceAlertFacade.java
@@ -56,10 +56,15 @@ public class PriceAlertFacade {
 
     private Map<Long, ProductDetailDto> fetchProductDetailMap(List<Long> productIds) {
         try {
-            ProductDetailListResponse response = productFeignClient.getProducts(productIds).getData();
+            log.info("[PriceAlert] Feign 호출 시작 - productIds: {}", productIds);
+            var feignResponse = productFeignClient.getProducts(productIds);
+            log.info("[PriceAlert] Feign 응답 - feignResponse: {}, data: {}", feignResponse, feignResponse != null ? feignResponse.getData() : null);
+            ProductDetailListResponse response = feignResponse.getData();
             if (response == null || response.getProducts() == null) {
+                log.warn("[PriceAlert] response 또는 products가 null - response: {}", response);
                 return Collections.emptyMap();
             }
+            log.info("[PriceAlert] products 개수: {}", response.getProducts().size());
             // ProductDetailDto 하나에 여러 variant(ProductDto)가 묶여 있으므로
             // 각 variant의 productId를 key로 해당 ProductDetailDto를 매핑
             return response.getProducts().stream()

--- a/notification/src/main/java/com/back/notification/config/HttpClientConfig.java
+++ b/notification/src/main/java/com/back/notification/config/HttpClientConfig.java
@@ -1,6 +1,9 @@
 package com.back.notification.config;
 
 import com.back.notification.adapter.out.feign.product.ProductFeignClient;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +12,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
+@Slf4j
 @Configuration
 public class HttpClientConfig {
 
@@ -23,6 +27,9 @@ public class HttpClientConfig {
 
     @Bean
     public ProductFeignClient productFeignClient() {
+        log.info("[HttpClientConfig] CAN_OVERRIDE_ACCESS_MODIFIERS: {}",
+                new ObjectMapper().getDeserializationConfig().isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS));
+
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(connectTimeout);
         factory.setReadTimeout(readTimeout);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #377 

## 🔎 작업 내용

- FeignResponse<T> 래퍼 클래스 추가
- ProductFeignClient 반환 타입 CommonResponse → FeignResponse로 교체 예정
  - 역직렬화 문제로 예상되어 로그 추적 후 수정 예정
- PriceAlertFacade Feign 호출 단계별 로그 추가

<br>


## 📌 참고 사항

- 기타 안내 사항 <!--(선택 사항)-->
    - 다른 서비스는 @FeignClient(Spring Cloud OpenFeign)를 사용해 해당 문제가 없었으나 notification은 @HttpExchange 방식을 사용하고 있어 별도 래퍼 클래스로 해결 예정

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 테스트 결과
- x

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
