### PR TITLE
[FEAT] 정산 실패 이벤트 발행 (#382)

### DIFF
--- a/cash/src/main/java/com/back/cash/adapter/in/listener/PayoutFailedOutboxListener.java
+++ b/cash/src/main/java/com/back/cash/adapter/in/listener/PayoutFailedOutboxListener.java
@@ -1,0 +1,43 @@
+package com.back.cash.adapter.in.listener;
+
+import com.back.cash.adapter.out.outbox.PayoutOutboxRepository;
+import com.back.cash.app.event.PayoutFailedPayload;
+import com.back.cash.domain.event.PayoutFailedEvent;
+import com.back.cash.domain.outbox.PayoutOutbox;
+import com.back.common.event.Envelope;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.json.JsonMapper;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PayoutFailedOutboxListener {
+
+    private final PayoutOutboxRepository outboxRepository;
+    private final JsonMapper jsonMapper;
+
+    @Value("${custom.kafka.topic.cash-payout-failed}")
+    private String cashPayoutFailedTopic;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void record(PayoutFailedEvent event) {
+        PayoutFailedPayload payload = new PayoutFailedPayload(event.settlementId(), event.reason());
+
+        Envelope<PayoutFailedPayload> envelope = Envelope.of(cashPayoutFailedTopic, payload);
+        String json = jsonMapper.writeValueAsString(envelope);
+
+        PayoutOutbox outbox = PayoutOutbox.createPending(envelope.header().eventId(), cashPayoutFailedTopic, json);
+        outboxRepository.save(outbox);
+
+        log.info("[PAYOUT_FAILED_OUTBOX_SAVED] 정산 실패 아웃박스 저장 eventId={}, settlementId={}",
+                envelope.header().eventId(), event.settlementId());
+    }
+}

--- a/cash/src/main/java/com/back/cash/adapter/out/outbox/PayoutOutboxPoller.java
+++ b/cash/src/main/java/com/back/cash/adapter/out/outbox/PayoutOutboxPoller.java
@@ -1,0 +1,70 @@
+package com.back.cash.adapter.out.outbox;
+
+import com.back.cash.domain.outbox.PayoutOutbox;
+import com.back.cash.domain.outbox.enums.OutboxStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Limit;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@Slf4j
+public class PayoutOutboxPoller {
+
+    private final PayoutOutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> outboxKafkaTemplate;
+
+    @Value("${custom.outbox.poll-size:100}")
+    private int pollSize;
+
+    @Value("${custom.outbox.max-retry:10}")
+    private int maxRetry;
+
+    @Value("${custom.outbox.retry-base-delay-seconds:10}")
+    private int retryBaseDelaySeconds;
+
+    @Value("${custom.outbox.retry-max-delay-seconds:300}")
+    private int retryMaxDelaySeconds;
+
+    public PayoutOutboxPoller(
+            PayoutOutboxRepository outboxRepository,
+            @Qualifier("outboxKafkaTemplate") KafkaTemplate<String, String> outboxKafkaTemplate
+    ) {
+        this.outboxRepository = outboxRepository;
+        this.outboxKafkaTemplate = outboxKafkaTemplate;
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void poll() {
+        List<PayoutOutbox> pending =
+                outboxRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING, Limit.of(pollSize));
+
+        List<PayoutOutbox> retryable =
+                outboxRepository.findRetryable(maxRetry, LocalDateTime.now(), Limit.of(pollSize));
+
+        process(pending);
+        process(retryable);
+    }
+
+    private void process(List<PayoutOutbox> list) {
+        for (PayoutOutbox outbox : list) {
+            try {
+                outboxKafkaTemplate.send(outbox.getTopic(), outbox.getPayload()).get();
+                outbox.markAsSent();
+                log.info("[PAYOUT_OUTBOX_SENT] 정산 실패 이벤트 발행 eventId={}, topic={}", outbox.getEventId(), outbox.getTopic());
+            } catch (Exception e) {
+                outbox.markAsFailed(retryBaseDelaySeconds, retryMaxDelaySeconds);
+                log.error("[PAYOUT_OUTBOX_SEND_FAILED] 정산 실패 이벤트 발행 실패 eventId={}, retryCount={}, nextRetryAt={}",
+                        outbox.getEventId(), outbox.getRetryCount(), outbox.getNextRetryAt(), e);
+            }
+        }
+    }
+}

--- a/cash/src/main/java/com/back/cash/adapter/out/outbox/PayoutOutboxRepository.java
+++ b/cash/src/main/java/com/back/cash/adapter/out/outbox/PayoutOutboxRepository.java
@@ -1,0 +1,23 @@
+package com.back.cash.adapter.out.outbox;
+
+import com.back.cash.domain.outbox.PayoutOutbox;
+import com.back.cash.domain.outbox.enums.OutboxStatus;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PayoutOutboxRepository extends JpaRepository<PayoutOutbox, Long> {
+
+    List<PayoutOutbox> findByStatusOrderByCreatedAtAsc(OutboxStatus status, Limit limit);
+
+    @Query("SELECT o FROM PayoutOutbox o " +
+            "WHERE o.status = 'FAILED' AND o.retryCount < :maxRetry AND o.nextRetryAt <= :now " +
+            "ORDER BY o.createdAt ASC")
+    List<PayoutOutbox> findRetryable(@Param("maxRetry") int maxRetry,
+                                     @Param("now") LocalDateTime now,
+                                     Limit limit);
+}

--- a/cash/src/main/java/com/back/cash/app/CashPayoutFacade.java
+++ b/cash/src/main/java/com/back/cash/app/CashPayoutFacade.java
@@ -4,6 +4,7 @@ import com.back.cash.adapter.out.PayoutRepository;
 import com.back.cash.app.usecase.CashPayoutUseCase;
 import com.back.cash.domain.event.CashPayoutRequestedCommand;
 import com.back.common.exception.BadRequestException;
+import com.back.common.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -25,8 +26,8 @@ public class CashPayoutFacade {
                 return;
             }
             throw e; // 중복 아닌 db에러 -> 예외 던짐
-        } catch (BadRequestException e) {
-            log.error("검증 실패. settlementId={}", command.settlementId(), e);
+        } catch (BadRequestException | EntityNotFoundException e) {
+            log.error("정산 지급 실패. settlementId={}", command.settlementId(), e);
             cashPayoutUseCase.saveFailedPayout(command, e.getMessage());
         }
         // 나머지 Exception은 catch 하지 않고 예외 던짐

--- a/cash/src/main/java/com/back/cash/app/event/PayoutFailedPayload.java
+++ b/cash/src/main/java/com/back/cash/app/event/PayoutFailedPayload.java
@@ -1,0 +1,8 @@
+package com.back.cash.app.event;
+
+import com.back.common.event.KafkaPayload;
+
+public record PayoutFailedPayload (
+        Long settlementId,
+        String reason
+) implements KafkaPayload {}

--- a/cash/src/main/java/com/back/cash/app/usecase/CashPayoutUseCase.java
+++ b/cash/src/main/java/com/back/cash/app/usecase/CashPayoutUseCase.java
@@ -7,11 +7,13 @@ import com.back.cash.domain.Payout;
 import com.back.cash.domain.Wallet;
 import com.back.cash.domain.enums.PayoutStatus;
 import com.back.cash.domain.event.CashPayoutRequestedCommand;
+import com.back.cash.domain.event.PayoutFailedEvent;
 import com.back.cash.mapper.PayoutMapper;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -26,6 +28,7 @@ public class CashPayoutUseCase {
     private final PayoutRepository payoutRepository;
     private final WalletSupport walletSupport;
     private final CashLogSupport cashLogSupport;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void execute(CashPayoutRequestedCommand command) {
@@ -89,12 +92,14 @@ public class CashPayoutUseCase {
             }
 
             payout.markFailed(reason);
+            eventPublisher.publishEvent(new PayoutFailedEvent(event.settlementId(), reason));
         } catch (DataIntegrityViolationException e) {
             // 동시성으로 insert한 경우 재조회 후 상태 판단
             payoutRepository.findBySettlementId(event.settlementId())
                     .ifPresent(existing -> {
                         if (existing.getStatus() != PayoutStatus.DONE) {
                             existing.markFailed(reason);
+                            eventPublisher.publishEvent(new PayoutFailedEvent(event.settlementId(), reason));
                         }
                     });
         }

--- a/cash/src/main/java/com/back/cash/domain/event/PayoutFailedEvent.java
+++ b/cash/src/main/java/com/back/cash/domain/event/PayoutFailedEvent.java
@@ -1,0 +1,7 @@
+package com.back.cash.domain.event;
+
+public record PayoutFailedEvent (
+        Long settlementId,
+        String reason
+) {
+}

--- a/cash/src/main/java/com/back/cash/domain/outbox/PayoutOutbox.java
+++ b/cash/src/main/java/com/back/cash/domain/outbox/PayoutOutbox.java
@@ -1,0 +1,69 @@
+package com.back.cash.domain.outbox;
+
+import com.back.cash.domain.outbox.enums.OutboxStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_payout_outbox_event_id",
+                columnNames = "eventId"
+        )
+)
+public class PayoutOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String eventId;
+
+    private String topic;
+
+    @Column(columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+
+    private int retryCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime processedAt;
+
+    private LocalDateTime nextRetryAt;
+
+    public static PayoutOutbox createPending(String eventId, String topic, String payload) {
+        PayoutOutbox outbox = new PayoutOutbox();
+        outbox.eventId = eventId;
+        outbox.topic = topic;
+        outbox.payload = payload;
+        outbox.status = OutboxStatus.PENDING;
+        outbox.retryCount = 0;
+        outbox.createdAt = LocalDateTime.now();
+        return outbox;
+    }
+
+    public void markAsSent() {
+        this.status = OutboxStatus.SENT;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed(int baseDelaySeconds, int maxDelaySeconds) {
+        this.retryCount++;
+        this.status = OutboxStatus.FAILED;
+        long delaySeconds = Math.min(
+                (long) Math.pow(2, retryCount - 1) * baseDelaySeconds,
+                maxDelaySeconds
+        );
+        this.nextRetryAt = LocalDateTime.now().plusSeconds(delaySeconds);
+    }
+}

--- a/cash/src/test/java/com/back/cash/adapter/in/listener/PayoutFailedOutboxListenerTest.java
+++ b/cash/src/test/java/com/back/cash/adapter/in/listener/PayoutFailedOutboxListenerTest.java
@@ -1,0 +1,88 @@
+package com.back.cash.adapter.in.listener;
+
+import com.back.cash.adapter.out.outbox.PayoutOutboxRepository;
+import com.back.cash.domain.event.PayoutFailedEvent;
+import com.back.cash.domain.outbox.PayoutOutbox;
+import com.back.cash.domain.outbox.enums.OutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PayoutFailedOutboxListenerTest {
+
+    private PayoutFailedOutboxListener listener;
+
+    @Mock
+    private PayoutOutboxRepository outboxRepository;
+
+    @Mock
+    private JsonMapper jsonMapper;
+
+    @Captor
+    private ArgumentCaptor<PayoutOutbox> outboxCaptor;
+
+    private static final String TOPIC = "cash.payout.failed";
+    private static final String MOCKED_JSON = "{\"header\":{\"eventId\":\"uuid\"},\"payload\":{}}";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        listener = new PayoutFailedOutboxListener(outboxRepository, jsonMapper);
+        setField(listener, "cashPayoutFailedTopic", TOPIC);
+    }
+
+    @Test
+    @DisplayName("record - PayoutFailedEvent → PENDING 상태로 outbox 저장")
+    void record_savesOutboxAsPending() {
+        // given
+        PayoutFailedEvent event = new PayoutFailedEvent(123L, "금액 검증 실패");
+        given(jsonMapper.writeValueAsString(any())).willReturn(MOCKED_JSON);
+
+        // when
+        listener.record(event);
+
+        // then
+        verify(outboxRepository).save(outboxCaptor.capture());
+
+        PayoutOutbox saved = outboxCaptor.getValue();
+        assertThat(saved.getTopic()).isEqualTo(TOPIC);
+        assertThat(saved.getPayload()).isEqualTo(MOCKED_JSON);
+        assertThat(saved.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(saved.getEventId()).isNotBlank();
+        assertThat(saved.getRetryCount()).isZero();
+        assertThat(saved.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("record - Envelope 직렬화 요청됨")
+    void record_serializesEnvelope() {
+        // given
+        PayoutFailedEvent event = new PayoutFailedEvent(123L, "금액 검증 실패");
+        given(jsonMapper.writeValueAsString(any())).willReturn(MOCKED_JSON);
+
+        // when
+        listener.record(event);
+
+        // then
+        verify(jsonMapper).writeValueAsString(any());
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/cash/src/test/java/com/back/cash/app/CashPayoutFacadeTest.java
+++ b/cash/src/test/java/com/back/cash/app/CashPayoutFacadeTest.java
@@ -5,6 +5,7 @@ import com.back.cash.app.usecase.CashPayoutUseCase;
 import com.back.cash.domain.event.CashPayoutRequestedCommand;
 import com.back.common.code.FailureCode;
 import com.back.common.exception.BadRequestException;
+import com.back.common.exception.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +63,18 @@ class CashPayoutFacadeTest {
     void badRequest_saveFailedAndReturn() {
         CashPayoutRequestedCommand event = event(102L);
         doThrow(new BadRequestException(FailureCode.INVALID_AMOUNT))
+                .when(cashPayoutUseCase).execute(event);
+
+        cashPayoutFacade.requestPayout(event);
+
+        verify(cashPayoutUseCase, times(1)).saveFailedPayout(eq(event), anyString());
+    }
+
+    @Test
+    @DisplayName("EntityNotFoundException이면 실패 마킹 후 종료한다")
+    void entityNotFound_saveFailedAndReturn() {
+        CashPayoutRequestedCommand event = event(104L);
+        doThrow(new EntityNotFoundException(FailureCode.WALLET_NOT_FOUND))
                 .when(cashPayoutUseCase).execute(event);
 
         cashPayoutFacade.requestPayout(event);

--- a/cash/src/test/java/com/back/cash/app/usecase/CashPayoutUseCaseTest.java
+++ b/cash/src/test/java/com/back/cash/app/usecase/CashPayoutUseCaseTest.java
@@ -1,9 +1,12 @@
 package com.back.cash.app.usecase;
 
 import com.back.cash.adapter.out.PayoutRepository;
+import com.back.cash.adapter.out.outbox.PayoutOutboxRepository;
 import com.back.cash.domain.Payout;
 import com.back.cash.domain.enums.PayoutStatus;
 import com.back.cash.domain.event.CashPayoutRequestedCommand;
+import com.back.cash.domain.outbox.PayoutOutbox;
+import com.back.cash.domain.outbox.enums.OutboxStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +18,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -32,11 +36,15 @@ class CashPayoutUseCaseTest {
     @MockitoSpyBean
     PayoutRepository payoutRepository;
 
+    @Autowired
+    PayoutOutboxRepository payoutOutboxRepository;
+
     private static final Long TEST_SETTLEMENT_ID = 99999L;
     private static final Long DONE_SETTLEMENT_ID = 99991L;
     private static final Long PROCESSING_SETTLEMENT_ID = 99992L;
     private static final Long NEW_SETTLEMENT_ID = 99993L;
     private static final Long DUPLICATE_CHECK_ID = 99994L;
+    private static final Long OUTBOX_TEST_SETTLEMENT_ID = 99995L;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +53,7 @@ class CashPayoutUseCaseTest {
         deleteBySettlementId(PROCESSING_SETTLEMENT_ID);
         deleteBySettlementId(NEW_SETTLEMENT_ID);
         deleteBySettlementId(DUPLICATE_CHECK_ID);
+        deleteBySettlementId(OUTBOX_TEST_SETTLEMENT_ID);
     }
 
     @Test
@@ -190,6 +199,28 @@ class CashPayoutUseCaseTest {
 
         assertThatThrownBy(() -> cashPayoutUseCase.execute(event))
                 .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @DisplayName("saveFailedPayout: 실패 처리 시 PayoutOutbox가 PENDING 상태로 저장된다")
+    void saveFailedPayout_savesOutboxAsPending() {
+        // given
+        long settlementId = 99995L;
+        payoutOutboxRepository.findAll().stream()
+                .filter(o -> o.getTopic().equals("cash.payout.failed"))
+                .forEach(o -> payoutOutboxRepository.deleteById(o.getId()));
+
+        // when
+        cashPayoutUseCase.saveFailedPayout(event(settlementId), "지갑 없음");
+
+        // then
+        List<PayoutOutbox> outboxes = payoutOutboxRepository.findByStatusOrderByCreatedAtAsc(
+                OutboxStatus.PENDING, org.springframework.data.domain.Limit.of(100));
+
+        assertThat(outboxes).anyMatch(o ->
+                o.getTopic().equals("cash.payout.failed") &&
+                o.getPayload().contains(String.valueOf(settlementId))
+        );
     }
 
     private CashPayoutRequestedCommand event(Long settlementId) {


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #382 

## 🔎 작업 내용

- 정산 이벤트가 (BadRequestException, EntityNotFoundException)으로 실패한 경우에 정산 실패 이벤트를 발송합니다. 

<br>


---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
