### PR TITLE
[FEAT] 캐시 지급 실패에 대한 최종적 일관성 보장을 위한 실패 처리 (#385)

### DIFF
--- a/settlement/src/main/java/com/back/settlement/adapter/in/listener/PayoutFailedListener.java
+++ b/settlement/src/main/java/com/back/settlement/adapter/in/listener/PayoutFailedListener.java
@@ -1,0 +1,40 @@
+package com.back.settlement.adapter.in.listener;
+
+import com.back.common.event.Envelope;
+import com.back.settlement.app.event.payload.PayoutFailedPayload;
+import com.back.settlement.app.usecase.SettlementPayoutFailUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PayoutFailedListener {
+
+    private final SettlementPayoutFailUseCase settlementPayoutFailUseCase;
+    private final JsonMapper jsonMapper;
+
+    @KafkaListener(
+            topics = "${custom.kafka.topic.cash-payout-failed}",
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "payoutFailedKafkaListenerContainerFactory"
+    )
+    public void on(String message) {
+        Envelope<PayoutFailedPayload> event;
+        try {
+            event = jsonMapper.readValue(message, new TypeReference<Envelope<PayoutFailedPayload>>() {});
+        } catch (Exception e) {
+            log.error("[ERROR_PAYOUT_FAILED_CONSUME] 역직렬화 실패. message={}", message, e);
+            throw new MessageConversionException("payout failed message parse failed", e);
+        }
+
+        PayoutFailedPayload data = event.payload();
+        settlementPayoutFailUseCase.markAsFailed(data.settlementId(), data.reason());
+        log.info("[PAYOUT_FAILED_CONSUME] 정산 실패 처리 완료 - settlementId: {}", data.settlementId());
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/app/event/payload/PayoutFailedPayload.java
+++ b/settlement/src/main/java/com/back/settlement/app/event/payload/PayoutFailedPayload.java
@@ -1,0 +1,8 @@
+package com.back.settlement.app.event.payload;
+
+import com.back.common.event.KafkaPayload;
+
+public record PayoutFailedPayload(
+        Long settlementId,
+        String reason
+) implements KafkaPayload {}

--- a/settlement/src/main/java/com/back/settlement/app/usecase/SettlementPayoutFailUseCase.java
+++ b/settlement/src/main/java/com/back/settlement/app/usecase/SettlementPayoutFailUseCase.java
@@ -1,0 +1,36 @@
+package com.back.settlement.app.usecase;
+
+import com.back.settlement.adapter.out.SettlementRepository;
+import com.back.settlement.domain.Settlement;
+import com.back.settlement.domain.SettlementStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SettlementPayoutFailUseCase {
+    private final SettlementRepository settlementRepository;
+
+    @Transactional
+    public void markAsFailed(Long settlementId, String reason) {
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElse(null);
+
+        if (settlement == null) {
+            log.warn("정산을 찾을 수 없습니다. 실패 처리 생략. settlementId={}", settlementId);
+            return;
+        }
+
+        if (settlement.getStatus() == SettlementStatus.FAILED) {
+            log.info("이미 실패 처리된 정산입니다. settlementId={}", settlementId);
+            return;
+        }
+
+        settlement.fail(reason);
+        settlementRepository.save(settlement);
+        log.info("정산 지급 실패 처리 완료. settlementId={}, reason={}", settlementId, reason);
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/config/KafkaConsumerConfig.java
+++ b/settlement/src/main/java/com/back/settlement/config/KafkaConsumerConfig.java
@@ -1,0 +1,72 @@
+package com.back.settlement.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
+
+import java.util.Map;
+
+@Slf4j
+@Configuration
+public class KafkaConsumerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${custom.kafka.topic.cash-payout-failed-dlt}")
+    private String payoutFailedDltTopic;
+
+    @Bean
+    public KafkaTemplate<String, String> dltKafkaTemplate() {
+        return new KafkaTemplate<>(
+                new DefaultKafkaProducerFactory<>(Map.of(
+                        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class
+                ))
+        );
+    }
+
+    @Bean
+    public DefaultErrorHandler payoutFailedErrorHandler(KafkaTemplate<String, String> dltKafkaTemplate) {
+        ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(3);
+        backOff.setInitialInterval(1_000L);
+        backOff.setMultiplier(2.0);
+        backOff.setMaxInterval(10_000L);
+
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(dltKafkaTemplate,
+                (record, ex) -> new TopicPartition(payoutFailedDltTopic, -1)) {
+                    @Override
+                    public void accept(ConsumerRecord<?, ?> record, org.apache.kafka.clients.consumer.Consumer<?, ?> consumer, Exception exception) {
+                        log.error("[DLT] 재시도 소진, DLT로 전송. topic={}, offset={}, value={}", record.topic(), record.offset(), record.value(), exception);
+                        super.accept(record, consumer, exception);
+                    }
+                };
+
+        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
+        handler.setRetryListeners((record, ex, deliveryAttempt) ->
+                log.warn("[RETRY] 재시도 {}/3. topic={}, offset={}, cause={}",
+                        deliveryAttempt, record.topic(), record.offset(), ex.getMessage())
+        );
+        return handler;
+    }
+
+    @Bean(name = "payoutFailedKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, String> payoutFailedKafkaListenerContainerFactory(ConsumerFactory<String, String> consumerFactory, DefaultErrorHandler payoutFailedErrorHandler) {
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(payoutFailedErrorHandler);
+        return factory;
+    }
+}

--- a/settlement/src/main/java/com/back/settlement/domain/SettlementStatus.java
+++ b/settlement/src/main/java/com/back/settlement/domain/SettlementStatus.java
@@ -19,7 +19,8 @@ public enum SettlementStatus {
         return switch (this) {
             case PENDING -> Set.of(COMPLETED, HOLD, FAILED);
             case HOLD -> Set.of(COMPLETED, FAILED);
-            case COMPLETED, FAILED -> Set.of();  // 최종 상태, 전이 불가
+            case COMPLETED -> Set.of(FAILED);  // 보상 트랜잭션: 지급 실패 시 FAILED 전이 허용
+            case FAILED -> Set.of();  // 최종 상태, 전이 불가
         };
     }
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #385 

## 🔎 작업 내용

-


---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수
